### PR TITLE
[YTDB-1064, YTDB-1267, YTDB-1305] Background index build for a class that already holds records

### DIFF
--- a/.claude/docs/mcp-steroid/maven.md
+++ b/.claude/docs/mcp-steroid/maven.md
@@ -10,7 +10,7 @@ Full rules for routing Maven invocations through mcp-steroid vs Bash `./mvnw`. T
 |---|---|
 | Running a single test class or method (`-Dtest=Foo#bar`) — IDE returns a parsed test tree with per-method status and split stack traces | Full-suite runs (`./mvnw clean package`, `verify`) — same Maven, same noise, but Bash survives IDE crashes |
 | Compile-fix loops where you want just the compiler errors, not the surrounding Maven INFO/download chatter | Coverage runs (`-P coverage`) — must pair with `coverage-gate.py` driven by Bash |
-| Quick post-edit "did this still compile?" check on a single module | Integration tests (`-P ci-integration-tests`), Docker tests, JMH benchmarks |
+| Quick post-edit "did this still compile?" check on a single module | Pipeline-owned integration tests stay in the pull request pipeline. Docker tests and JMH benchmarks stay on Bash `./mvnw` |
 | Re-running the failing test after a fix, where seeing structured pass/fail matters | Anything that runs >5 min — IDE liveness becomes a risk, and Bash + `run_in_background` is more robust |
 
 ## Preflight before routing Maven through mcp-steroid

--- a/.claude/docs/testing-details.md
+++ b/.claude/docs/testing-details.md
@@ -10,8 +10,9 @@ Reference material for testing infrastructure beyond the core rules in `CLAUDE.m
 
 ## Integration Tests
 
-- Activated via Maven profile: `./mvnw clean verify -P ci-integration-tests`
-- Uses failsafe plugin in `core` and `server` modules
+- The pull request pipeline activates the Maven profile for integration tests.
+- A developer machine never runs integration tests. Follow `docs-internal/dev-workflow/track-development.md`.
+- The profile uses the Failsafe plugin in `core` and `server` modules.
 
 ## TinkerPop Cucumber Feature Tests
 

--- a/.claude/skills/fix-ci-failure/SKILL.md
+++ b/.claude/skills/fix-ci-failure/SKILL.md
@@ -313,6 +313,7 @@ gh api repos/JetBrains/youtrackdb/issues/{pr}/comments --jq '.[] | select(.body 
 # Run single module tests
 ./mvnw -pl {module} clean test -Dtest={TestClass}
 
-# Run with disk storage (as CI does)
-./mvnw -pl {module} clean test -Dyoutrackdb.test.env=ci
+# Run a targeted test class with disk storage
+./mvnw -pl {module} clean test -Dtest={TestClass} \
+  -Dyoutrackdb.test.env=ci
 ```

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -547,8 +547,9 @@ IDE. Three project-relevant defaults:
   after a focused fix) and **compile-fix loops** benefit from
   `steroid_execute_code` — the IDE returns parsed test results and
   filtered compiler output. Full-suite runs, coverage profiles, JMH
-  benchmarks, and integration-test suites stay on Bash `./mvnw` per the
-  Maven-routing rule in the project's `CLAUDE.md` § MCP Steroid.
+  benchmarks stay on Bash `./mvnw` per the Maven-routing rule in the project's `CLAUDE.md` § MCP
+  Steroid. Pipeline-owned integration tests stay in the pull request pipeline, not on a developer
+  machine.
 - **Renames, moves, signature changes, extract-method, pull-up/push-down,
   and any refactor that touches more than one reference site** route
   through the IDE refactoring engine via mcp-steroid, not raw `Edit`.

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -515,8 +515,8 @@ Pacing is the orchestrator's job, not the implementer's. The
 implementer runs straight through sub-steps 1–3 and emits exactly
 one return block.
 
-**For long-running Maven runs** — full `core` test suite, coverage
-profile build, integration tests:
+**For long-running Maven runs** — full `core` test suite and coverage
+profile build. Integration tests run only in the pull request pipeline.
 
 - Use **foreground** Bash with the Bash tool's `timeout` parameter
   set to the realistic upper bound (the parameter is in
@@ -571,12 +571,12 @@ profile build, integration tests:
   surefire stdout into the conversation — typically a 10–25× context
   saving on a failing run, which is the lever that prevents the
   message-budget exhaustion mode the targeted-rerun rule above is
-  also targeting. Full-module verification, coverage-profile builds,
-  and integration tests stay on Bash per the project rule, even
-  when the IDE is reachable.
+  also targeting. Full-module verification and coverage-profile builds stay on Bash per the project
+  rule, even when the IDE is reachable. Integration tests run only in the pull request
+  pipeline.
 
 If even a staged sequence cannot fit the foreground budget (rare —
-only large `-P ci-integration-tests` runs or full multi-module
+only full pipeline-owned integration runs or full multi-module
 coverage on a slow host), return `RESULT: FAILED` with
 `recommended_action: split` (at `level=step`) or
 `recommended_action: escalate` (at `level=track`, where step-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,7 @@ YouTrackDB is a general-purpose object-oriented graph database developed by JetB
 # Full build with unit tests (in-memory storage, default)
 ./mvnw clean package
 
-# Full build with unit tests on disk storage (as CI does)
-./mvnw clean package -Dyoutrackdb.test.env=ci
-
-# Run integration tests (separate from PR pipeline, used by nightly CI)
-./mvnw clean verify -P ci-integration-tests
+# Verification scope follows docs-internal/dev-workflow/track-development.md.
 
 # Build with Docker images (requires Docker)
 ./mvnw clean package -P docker-images
@@ -115,7 +111,7 @@ Two layers, two files. The chat/terminal register is set by default through the 
 
 ### Test Modules at a Glance
 - **Unit tests**: `./mvnw -pl <module> clean test`. Core/server use JUnit 4 (`surefire-junit47` runner); the `tests` module uses JUnit 5 with `EmbeddedTestSuite` (shared DB, fixed class/method order via `@SelectClasses` / `@Order`).
-- **Integration tests**: `./mvnw clean verify -P ci-integration-tests` (uses failsafe in `core` and `server`).
+- **Integration tests**: Follow `docs-internal/dev-workflow/track-development.md`.
 - **Test utilities**: `test-commons` provides `TestBuilder`, `TestFactory`, `ConcurrentTestHelper`.
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.
@@ -173,14 +169,7 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
    ./mvnw clean package
    ```
 
-2. **Run related integration tests** if the change touches areas covered by integration tests:
-   ```bash
-   # Run integration tests for the affected module(s)
-   ./mvnw -pl core clean verify -P ci-integration-tests
-
-   # Or run the full integration test suite
-   ./mvnw clean verify -P ci-integration-tests
-   ```
+2. **Integration-test verification**: Follow `docs-internal/dev-workflow/track-development.md`.
 
 3. **Check coverage of changed code** by running tests with the `coverage` profile and verifying coverage locally:
    ```bash
@@ -201,8 +190,8 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
 5. **Determining which tests to run:**
    - Changes to `core` module: always run `./mvnw -pl core clean test`
    - Changes to `server` module: run `./mvnw -pl server clean test`
-   - Changes to storage, WAL, or index code: also run integration tests (`-P ci-integration-tests`)
-   - Changes to Gremlin integration or transaction handling: also run integration tests
+   - Changes to storage, WAL, or index code: rely on the pull request pipeline for integration tests
+   - Changes to Gremlin integration or transaction handling: rely on the pull request pipeline
    - Changes to `embedded` module: run `./mvnw -pl embedded clean test` (includes Cucumber feature tests)
    - Changes to `tests` module: run `./mvnw -pl tests clean test`
    - If in doubt, run the full test suite: `./mvnw clean package`

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <name>YouTrackDB Core</name>
 
   <properties>
-    <jna.version>4.0.0</jna.version>
+    <jna.version>5.18.1</jna.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.clean.plugin.version>3.5.0</maven.clean.plugin.version>
     <generated.antlr.dir>${project.build.directory}/generated-sources/antlr</generated.antlr.dir>
@@ -649,6 +649,11 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.concurrentlinkedhashmap</groupId>

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/YouTrackDB.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/YouTrackDB.java
@@ -1,8 +1,8 @@
 package com.jetbrains.youtrackdb.api;
 
 import com.jetbrains.youtrackdb.api.gremlin.YTDBGraphTraversalSource;
-import java.util.Locale;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.Configuration;
@@ -394,4 +394,31 @@ public interface YouTrackDB extends AutoCloseable {
   /// @param config       database configuration
   void restore(@Nonnull String databaseName, @Nonnull String path, @Nullable String expectedUUID,
       @Nonnull Configuration config);
+
+  /// Restarts an interrupted restore of one database, and destroys the target of that restore.
+  ///
+  /// An interrupted restore leaves a target that no open accepts. This method deletes that whole
+  /// target and restores the backup again. This method never continues a partial restore.
+  ///
+  /// This method accepts a target of an interrupted restore only. This method refuses a healthy
+  /// database and refuses the residue of an interrupted creation, and such a refusal changes no
+  /// file.
+  ///
+  /// This method works for an embedded connection only. Every other connection refuses this
+  /// method, because the restart deletes a whole database directory of the host that stores the
+  /// database.
+  ///
+  /// @param databaseName Name of the database whose restore was interrupted.
+  /// @param path         Path to the backup directory.
+  /// @param expectedUUID UUID of the database to be restored. If null, the database will be
+  ///                     restored only if the directory contains backup only from one database.
+  /// @param config       database configuration
+  default void restartInterruptedRestore(@Nonnull String databaseName, @Nonnull String path,
+      @Nullable String expectedUUID, @Nullable Configuration config) {
+    throw new UnsupportedOperationException(
+        "The destructive restart of an interrupted restore is available for an embedded connection"
+            + " only. Run the restart of database '"
+            + databaseName
+            + "' on the host that stores the database.");
+  }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/MultiValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/MultiValue.java
@@ -173,11 +173,7 @@ public class MultiValue {
       }
     } catch (RuntimeException e) {
       // IGNORE IT
-      LogManager.instance()
-          .debug(
-              value, "Error on reading the first item of the Multi-value field '%s'", logger,
-              value,
-              e);
+      logReadError("first", value, e);
     }
 
     return null;
@@ -224,11 +220,7 @@ public class MultiValue {
       }
     } catch (RuntimeException e) {
       // IGNORE IT
-      LogManager.instance()
-          .debug(
-              valu, "Error on reading the last item of the Multi-value field '%s'", logger,
-              valu,
-              e);
+      logReadError("last", valu, e);
     }
 
     return null;
@@ -294,13 +286,29 @@ public class MultiValue {
       }
     } catch (RuntimeException e) {
       // IGNORE IT
-      LogManager.instance()
-          .debug(
-              iObject, "Error on reading the first item of the Multi-value field '%s'", logger,
-              iObject,
-              e);
+      logReadError("indexed", iObject, e);
     }
     return null;
+  }
+
+  static String containerSummary(Object value) {
+    try {
+      return value.getClass().getName();
+    } catch (RuntimeException exception) {
+      return "<unavailable>";
+    }
+  }
+
+  static String readErrorMessage(String position, Object value) {
+    return "Error on reading the %s item of the Multi-value container %s"
+        .formatted(position, containerSummary(value));
+  }
+
+  private static void logReadError(String position, Object value, RuntimeException exception) {
+    if (logger.isDebugEnabled()) {
+      LogManager.instance()
+          .debug(MultiValue.class, readErrorMessage(position, value), logger, exception);
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLock.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLock.java
@@ -289,6 +289,12 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
     return stampedLock.isWriteLocked();
   }
 
+  /** Returns whether the current thread holds this lock in read mode. */
+  public boolean isReadLockedByCurrentThread() {
+    final var localEntry = entry.get();
+    return localEntry != null && localEntry.state.get() == SRWL_STATE_READING;
+  }
+
   /**
    * Creates a new ReadersEntry instance for the current thread and its associated AtomicInteger to
    * store the state of the Reader

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLock.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLock.java
@@ -95,17 +95,13 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
    */
   private final transient ConcurrentLinkedQueue<AtomicInteger> readersStateList;
 
-  /**
-   * The thread-id of the Writer currently holding the lock in write-mode, or SRWL_INVALID_TID if
-   * there is no Writer holding or attempting to acquire the lock in write mode.
-   */
+  /** Coordinates exclusive admission. Reader state is tracked separately. */
   private final transient StampedLock stampedLock;
 
-  /**
-   * Thread-local reference to the current thread's ReadersEntry instance. It's from this instance
-   * that the current Reader thread is able to determine where to store its own state, and the
-   * number of reentrant read lock loops for that particular thread.
-   */
+  /** The thread that currently holds write mode, or {@code null} when write mode is free. */
+  private transient volatile Thread writeOwner;
+
+  /** Holds the current thread's single non-reentrant reader state. */
   private final transient ThreadLocal<ReadersEntry> entry;
 
   private final transient AtomicReference<AtomicInteger[]> readersStateArrayRef;
@@ -279,11 +275,8 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Whether the exclusive (write) lock is currently held by some thread. The underlying
-   * {@link StampedLock} tracks no owner, so this cannot distinguish the current thread from
-   * another holder; it exists for assertions that a code path runs inside an exclusive-lock
-   * window (a caller that must itself hold the lock cannot be foiled by another holder anyway,
-   * because that holder would have blocked it).
+   * Whether some thread currently holds write mode. Use {@link
+   * #isWriteLockedByCurrentThread()} when ownership by the caller matters.
    */
   public boolean isWriteLocked() {
     return stampedLock.isWriteLocked();
@@ -293,6 +286,11 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   public boolean isReadLockedByCurrentThread() {
     final var localEntry = entry.get();
     return localEntry != null && localEntry.state.get() == SRWL_STATE_READING;
+  }
+
+  /** Returns whether the current thread holds this lock in write mode. */
+  public boolean isWriteLockedByCurrentThread() {
+    return writeOwner == Thread.currentThread();
   }
 
   /**
@@ -359,14 +357,11 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Attempts to release the read lock.
+   * Releases the current thread's read mode.
    *
-   * <p>If the current thread is the holder of this lock then the {@code reentrantReaderCount} is
-   * decremented. If the {@code reentrantReaderCount} is now zero then the lock is released. If the
-   * current thread is not the holder of this lock then {@link IllegalMonitorStateException} is
-   * thrown.
+   * <p>Read mode is not reentrant. One release clears the current thread's reader state.
    *
-   * @throws IllegalMonitorStateException if the current thread does not hold this lock.
+   * @throws IllegalMonitorStateException if the current thread has no reader state.
    */
   public void sharedUnlock() {
     final var localEntry = entry.get();
@@ -383,23 +378,16 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Acquires the write lock.
+   * Acquires write mode after prior readers and writers leave.
    *
-   * <p>Acquires the write lock if neither the read nor write lock are held by another thread and
-   * returns immediately, setting the write lock {@code reentrantWriterCount} to one.
-   *
-   * <p>If the current thread already holds the write lock then the {@code reentrantWriterCount} is
-   * incremented by one and the method returns immediately.
-   *
-   * <p>If the lock is held by another thread, then the current thread yields and lies dormant
-   * until the write lock has been acquired, at which time the {@code reentrantWriterCount} is set
-   * to one.
+   * <p>Write mode is not reentrant. A current-thread reacquisition blocks indefinitely.
    */
   public void exclusiveLock() {
     // Try to acquire the lock in write-mode
     stampedLock.writeLock();
+    writeOwner = Thread.currentThread();
 
-    // We can only do this after writerOwner has been set to the current thread
+    // We can only do this after writeOwner has been set to the current thread
     var localReadersStateArray = readersStateArrayRef.get();
     if (localReadersStateArray == null) {
       // Set to dummyArray before scanning the readersStateList to impose
@@ -419,21 +407,18 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Attempts to release the write lock.
+   * Releases the current thread's write mode.
    *
-   * <p>If the current thread is the holder of this lock then the {@code reentrantWriterCount} is
-   * decremented. If {@code reentrantWriterCount} is now zero then the lock is released. If the
-   * current thread is not the holder of this lock then {@link IllegalMonitorStateException} is
-   * thrown.
+   * <p>Write mode is not reentrant. One release frees the lock.
    *
-   * @throws IllegalMonitorStateException if the current thread does not hold this lock.
+   * @throws IllegalMonitorStateException if the current thread does not hold write mode.
    */
   public void exclusiveUnlock() {
-    if (!stampedLock.isWriteLocked()) {
-      // ERROR: tried to unlock a non write-locked instance
+    if (!isWriteLockedByCurrentThread()) {
       throw new IllegalMonitorStateException();
     }
 
+    writeOwner = null;
     stampedLock.asWriteLock().unlock();
   }
 
@@ -521,28 +506,20 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Acquires the write lock only if it is not held by another thread at the time of invocation.
+   * Attempts to acquire write mode without waiting.
    *
-   * <p>Acquires the write lock if the write lock is not held by another thread and returns
-   * immediately with the value {@code true} if and only if no other thread is attempting a read
-   * lock, setting the write lock {@code writerLoop} count to one.
+   * <p>Write mode is not reentrant. A current-thread reacquisition returns {@code false}.
    *
-   * <p>If the current thread already holds this lock then the {@code reentrantWriterCount} count
-   * is incremented by one and the method returns {@code true}.
-   *
-   * <p>If the write lock is held by another thread then this method will return immediately with
-   * the value {@code false}.
-   *
-   * @return {@code true} if the write lock was free and was acquired by the current thread, or the
-   * write lock was already held by the current thread; and {@code false} otherwise.
+   * @return {@code true} if write mode was acquired
    */
   public boolean exclusiveTryLock() {
     // Try to acquire the lock in write-mode
     if (stampedLock.tryWriteLock() == 0) {
       return false;
     }
+    writeOwner = Thread.currentThread();
 
-    // We can only do this after writerOwner has been set to the current thread
+    // We can only do this after writeOwner has been set to the current thread
     var localReadersStateArray = readersStateArrayRef.get();
     if (localReadersStateArray == null) {
       // Set to dummyArray before scanning the readersStateList to impose
@@ -557,6 +534,7 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
     for (var readerState : localReadersStateArray) {
       if (readerState != null && readerState.get() == SRWL_STATE_READING) {
         // There is at least one ongoing Reader so give up
+        writeOwner = null;
         stampedLock.asWriteLock().unlock();
         return false;
       }
@@ -566,31 +544,13 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
   }
 
   /**
-   * Acquires the write lock if it is not held by another thread within the given waiting time.
+   * Attempts to acquire write mode within the given waiting time.
    *
-   * <p>Acquires the write lock if the write lock is not held by another thread and returns
-   * immediately with the value {@code true} if and only if no other thread is attempting a read
-   * lock, setting the write lock {@code reentrantWriterCount} to one. If another thread is
-   * attempting a read lock, this function <b>may yield until the read lock is released</b>.
+   * <p>The method may yield while prior readers leave. Write mode is not reentrant. A
+   * current-thread reacquisition expires unless the timeout is effectively unbounded.
    *
-   * <p>If the current thread already holds this lock then the {@code reentrantWriterCount} is
-   * incremented by one and the method returns {@code true}.
-   *
-   * <p>If the write lock is held by another thread then the current thread yields and lies dormant
-   * until one of two things happens:
-   *
-   * <ul>
-   *   <li>The write lock is acquired by the current thread; or
-   *   <li>The specified waiting time elapses
-   * </ul>
-   *
-   * <p>If the write lock is acquired then the value {@code true} is returned and the write lock
-   * {@code reentrantWriterCount} is set to one.
-   *
-   * @param nanosTimeout the time to wait for the write lock in nanoseconds
-   * @return {@code true} if the lock was free and was acquired by the current thread, or the write
-   * lock was already held by the current thread; and {@code false} if the waiting time elapsed
-   * before the lock could be acquired.
+   * @param nanosTimeout the time to wait for write mode in nanoseconds
+   * @return {@code true} if write mode was acquired, or {@code false} if the time elapsed first
    */
   public boolean exclusiveTryLockNanos(long nanosTimeout) throws java.lang.InterruptedException {
     final var lastTime = System.nanoTime();
@@ -598,8 +558,9 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
     if (stampedLock.tryWriteLock(nanosTimeout, TimeUnit.NANOSECONDS) == 0) {
       return false;
     }
+    writeOwner = Thread.currentThread();
 
-    // We can only do this after writerOwner has been set to the current thread
+    // We can only do this after writeOwner has been set to the current thread
     var localReadersStateArray = readersStateArrayRef.get();
     if (localReadersStateArray == null) {
       // Set to dummyArray before scanning the readersStateList to impose
@@ -617,6 +578,7 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
           Thread.yield();
         } else {
           // Time has expired and there is at least one ongoing Reader so give up
+          writeOwner = null;
           stampedLock.asWriteLock().unlock();
           return false;
         }
@@ -723,6 +685,8 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
       }
     }
 
+    writeOwner = Thread.currentThread();
+
     // Phase 2: the write bit is HELD from here on — writer preference engaged exactly like
     // exclusiveLock (new readers observe isWriteLocked() and back off). Drain the residual
     // readers, polling the abort predicate on every yield iteration. The whole phase is guarded:
@@ -749,6 +713,7 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
             // Full release: the bit drops, backed-off readers spinning on isWriteLocked() proceed
             // (no lost wakeup possible — there is no parking channel, only the polled bit), and
             // the primitive is immediately reusable.
+            writeOwner = null;
             stampedLock.asWriteLock().unlock();
             return false;
           }
@@ -760,11 +725,13 @@ public class ScalableRWLock implements ReadWriteLock, java.io.Serializable {
       // the window where the condition arrives exactly as the drain completes — including the
       // zero-residual-readers case, where the drain loop body never ran and so never polled.
       if (abort.getAsBoolean()) {
+        writeOwner = null;
         stampedLock.asWriteLock().unlock();
         return false;
       }
       return true;
     } catch (final Throwable phaseTwoFailure) {
+      writeOwner = null;
       stampedLock.asWriteLock().unlock();
       throw phaseTwoFailure;
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/resource/SharedResourceAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/resource/SharedResourceAbstract.java
@@ -54,6 +54,11 @@ public abstract class SharedResourceAbstract {
     rwLock.readLock().unlock();
   }
 
+  /** Returns {@code true} if the current thread holds the shared lock on this resource. */
+  public boolean isSharedOwner() {
+    return rwLock.getReadHoldCount() > 0;
+  }
+
   /**
    * Returns {@code true} if the current thread holds the exclusive lock on this resource.
    */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/io/FileUtils.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/io/FileUtils.java
@@ -20,6 +20,10 @@
 package com.jetbrains.youtrackdb.internal.common.io;
 
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import com.sun.jna.Native;
+import com.sun.jna.WString;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -30,13 +34,16 @@ import java.nio.file.CopyOption;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayDeque;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 public class FileUtils {
@@ -47,6 +54,9 @@ public class FileUtils {
   public static final long TERABYTE = 1099511627776L;
 
   private static final boolean useOldFileAPI;
+  static final String MISSING_NATIVE_HELPER_WARNING =
+      "The Java Native Access native helper is unavailable. The crash-atomic guarantee is not"
+          + " available on this host. Using the portable move";
 
   static {
     var oldAPI = false;
@@ -321,56 +331,289 @@ public class FileUtils {
   }
 
   /**
-   * Durably promotes {@code source} to {@code target} (the CS40 promote recipe of Track 8's
-   * export hardening): (1) the source file's content is fsynced through a freshly opened
-   * channel — the writing stream is already closed, so the sync needs its own channel; (2) the
-   * file is renamed with {@code ATOMIC_MOVE} + {@code REPLACE_EXISTING}, so a pre-existing
-   * target is replaced only by this whole, durable file and a crash can never leave a torn
-   * target; (3) the target's parent directory is fsynced (POSIX rename durability — without it
-   * a crash after the rename can lose the directory entry itself).
+   * Durably promotes {@code source} to {@code target}. The source content is forced before an
+   * atomic replacement. Unix systems then force the target directory. Windows uses a write-through
+   * native replacement because the standard Java move does not provide that durability barrier.
+   * If its native helper cannot load, Windows records one warning and uses the portable atomic move
+   * with the pre-existing parent-directory barrier.
    *
-   * <p>Deliberately FAIL-CLOSED: unlike {@link #atomicMoveWithFallback} there is NO regular-move
-   * fallback — a filesystem that cannot perform the atomic replace fails the promote rather
-   * than silently degrading to a copy that can tear the target. The parent-directory fsync
-   * carve-out is NARROW: only the directory-channel OPEN failure is tolerated (platforms like
-   * Windows cannot open directory channels, and the POSIX directory-entry hazard does not
-   * apply there in the same form); an I/O failure from {@code force(true)} on a successfully
-   * opened directory channel is a GENUINE fsync failure and propagates — reporting success
-   * over it would let a crash revert the rename after the caller already reported the promote
-   * durable.
-   *
-   * <p>Contract note: only the TARGET's parent directory is fsynced. The current callers move
-   * within a single directory (the export temp file sits next to its final name); a future
-   * CROSS-directory caller would additionally need the SOURCE's parent fsynced, or the
-   * source-entry removal may not be durable.
+   * <p>The operation fails closed when an atomic replacement or required durability barrier fails.
+   * The Windows native-load fallback cannot promise crash atomicity. Current callers move within
+   * one directory. A cross-directory caller must also force the source directory.
    */
   public static void durableAtomicMove(Path source, Path target, Object requester)
       throws IOException {
-    try (var channel = FileChannel.open(source, StandardOpenOption.WRITE)) {
+    durableAtomicMove(source, target, requester, IOUtils.isOsWindows(), FileUtils::forceDirectory);
+  }
+
+  static void durableAtomicMove(
+      final Path source,
+      final Path target,
+      final boolean windows,
+      final DirectoryForce directoryForce)
+      throws IOException {
+    durableAtomicMove(source, target, FileUtils.class, windows, directoryForce);
+  }
+
+  private static void durableAtomicMove(
+      final Path source,
+      final Path target,
+      final Object requester,
+      final boolean windows,
+      final DirectoryForce directoryForce)
+      throws IOException {
+    if (windows) {
+      durableAtomicMove(
+          source,
+          target,
+          requester,
+          true,
+          directoryForce,
+          WindowsDurableMove.BINDING,
+          FileUtils::portableWindowsMove,
+          FileUtils::warnAboutMissingNativeHelper,
+          WindowsDurableMove.FALLBACK_WARNING_RECORDED);
+    } else {
+      durableAtomicMove(
+          source, target, requester, false, directoryForce, null, null, null, null);
+    }
+  }
+
+  static void durableAtomicMove(
+      final Path source,
+      final Path target,
+      final Object requester,
+      final boolean windows,
+      final DirectoryForce directoryForce,
+      final WindowsMoveBinding windowsBinding,
+      final PortableMove portableMove,
+      final NativeHelperWarning warning,
+      final AtomicBoolean warningRecorded)
+      throws IOException {
+    final var sourceAttributes =
+        Files.readAttributes(source, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+    if (!sourceAttributes.isRegularFile()) {
+      throw new IOException("Durable atomic move source is not a regular file: " + source);
+    }
+    try (var channel =
+        FileChannel.open(source, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS)) {
       channel.force(true);
     }
+
+    if (windows) {
+      final var nativeMove = windowsBinding.nativeMove();
+      if (nativeMove != null) {
+        nativeMove.move(source, target);
+        return;
+      }
+
+      final var loadFailure = windowsBinding.loadFailure();
+      if (warningRecorded.compareAndSet(false, true)) {
+        warning.warn(requester, MISSING_NATIVE_HELPER_WARNING, loadFailure);
+      }
+      try {
+        portableMove.move(source, target, requester);
+      } catch (IOException portableFailure) {
+        final var failure =
+            new IOException(
+                "Portable move failed after the Windows native helper failed to load: native"
+                    + " helper cause: "
+                    + loadFailure
+                    + "; portable move cause: "
+                    + portableFailure,
+                portableFailure);
+        failure.addSuppressed(loadFailure);
+        throw failure;
+      }
+      return;
+    }
+
     Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
     final var parent = target.toAbsolutePath().getParent();
     if (parent != null) {
-      FileChannel directoryChannel = null;
-      try {
-        directoryChannel = FileChannel.open(parent, StandardOpenOption.READ);
-      } catch (IOException e) {
-        // The documented platform carve-out: the directory cannot be opened as a channel
-        // (e.g. Windows). Only the OPEN failure is tolerated — see the javadoc.
-        LogManager.instance()
-            .warn(requester,
-                "Cannot open the parent directory of '%s' for fsync after the atomic move;"
-                    + " continuing (the platform does not support directory channels)",
-                e, target);
-      }
-      if (directoryChannel != null) {
-        // A failure from force(true) here is a genuine fsync failure and MUST propagate
-        // (fail-closed): the rename's durability cannot be vouched for.
-        try (var openedDirectoryChannel = directoryChannel) {
-          openedDirectoryChannel.force(true);
-        }
+      directoryForce.force(parent);
+    }
+  }
+
+  private static void forceDirectory(final Path directory) throws IOException {
+    try (var channel = FileChannel.open(directory, StandardOpenOption.READ)) {
+      channel.force(true);
+    }
+  }
+
+  static void portableWindowsMove(
+      final Path source, final Path target, final Object requester) throws IOException {
+    Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    final var parent = target.toAbsolutePath().getParent();
+    if (parent == null) {
+      return;
+    }
+
+    FileChannel directoryChannel = null;
+    try {
+      directoryChannel = FileChannel.open(parent, StandardOpenOption.READ);
+    } catch (IOException e) {
+      LogManager.instance()
+          .warn(
+              requester,
+              "Cannot open the parent directory of '%s' for fsync after the atomic move;"
+                  + " continuing (the platform does not support directory channels)",
+              e,
+              target);
+    }
+    if (directoryChannel != null) {
+      try (var openedDirectoryChannel = directoryChannel) {
+        openedDirectoryChannel.force(true);
       }
     }
+  }
+
+  private static void warnAboutMissingNativeHelper(
+      final Object requester, final String message, final Throwable loadFailure) {
+    LogManager.instance().warn(requester, message, loadFailure);
+  }
+
+  @FunctionalInterface
+  interface DirectoryForce {
+
+    void force(Path directory) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface NativeMove {
+
+    void move(Path source, Path target) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface WindowsBindingLoader {
+
+    WindowsMoveBinding load();
+  }
+
+  @FunctionalInterface
+  interface PortableMove {
+
+    void move(Path source, Path target, Object requester) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface NativeHelperWarning {
+
+    void warn(Object requester, String message, Throwable loadFailure);
+  }
+
+  record WindowsMoveBinding(NativeMove nativeMove, Throwable loadFailure) {
+
+    static WindowsMoveBinding unavailable(final Throwable loadFailure) {
+      return new WindowsMoveBinding(null, loadFailure);
+    }
+  }
+
+  private static final class WindowsDurableMove {
+
+    private static final int MOVE_FILE_REPLACE_EXISTING = 0x1;
+    private static final int MOVE_FILE_WRITE_THROUGH = 0x8;
+    private static final AtomicBoolean FALLBACK_WARNING_RECORDED = new AtomicBoolean();
+    private static final WindowsMoveBinding BINDING = loadBinding();
+
+    private WindowsDurableMove() {
+    }
+
+    private static WindowsMoveBinding loadBinding() {
+      return loadWindowsMoveBinding(() -> {
+        final var kernel32 =
+            (Kernel32) Native.loadLibrary(
+                "kernel32", Kernel32.class, W32APIOptions.UNICODE_OPTIONS);
+        return new WindowsMoveBinding(
+            (source, target) -> move(kernel32, source, target), null);
+      });
+    }
+
+    private static void move(
+        final Kernel32 kernel32, final Path source, final Path target) throws IOException {
+      final var moved =
+          kernel32.MoveFileEx(
+              new WString(toWindowsNativePath(source.toAbsolutePath().toString())),
+              new WString(toWindowsNativePath(target.toAbsolutePath().toString())),
+              MOVE_FILE_REPLACE_EXISTING | MOVE_FILE_WRITE_THROUGH);
+      if (!moved) {
+        throw new IOException(
+            "Windows durable atomic move failed with error " + Native.getLastError());
+      }
+    }
+  }
+
+  static WindowsMoveBinding loadWindowsMoveBinding(final WindowsBindingLoader loader) {
+    try {
+      return loader.load();
+    } catch (Throwable loadFailure) {
+      // D192 requires every native-helper load failure to become a memorized fallback result.
+      return WindowsMoveBinding.unavailable(loadFailure);
+    }
+  }
+
+  /**
+   * Adds the extended Windows namespace prefix to absolute drive and UNC paths. Ordinary absolute
+   * paths are normalized first because the extended namespace does not interpret dot segments.
+   * Relative paths and paths that already select a Windows device namespace remain unchanged.
+   */
+  static String toWindowsNativePath(final String path) {
+    if (path.startsWith("\\\\?\\") || path.startsWith("\\\\.\\")) {
+      return path;
+    }
+    if (path.startsWith("\\\\")) {
+      final var serverEnd = path.indexOf('\\', 2);
+      final var shareEnd = serverEnd < 0 ? -1 : path.indexOf('\\', serverEnd + 1);
+      final var normalized =
+          shareEnd < 0 ? path : normalizeWindowsAbsolutePath(path, shareEnd + 1);
+      return "\\\\?\\UNC\\" + normalized.substring(2);
+    }
+    if (path.length() >= 3
+        && Character.isLetter(path.charAt(0))
+        && path.charAt(1) == ':'
+        && path.charAt(2) == '\\') {
+      return "\\\\?\\" + normalizeWindowsAbsolutePath(path, 3);
+    }
+    return path;
+  }
+
+  /**
+   * Removes dot segments without accessing the file system. Windows applies the same lexical rule
+   * before an ordinary path enters the extended namespace, including when a segment is a link.
+   */
+  private static String normalizeWindowsAbsolutePath(
+      final String path, final int componentStart) {
+    final var components = new ArrayDeque<String>();
+    var start = componentStart;
+    while (start <= path.length()) {
+      var end = path.indexOf('\\', start);
+      if (end < 0) {
+        end = path.length();
+      }
+      final var component = path.substring(start, end);
+      if (component.equals("..")) {
+        if (!components.isEmpty()) {
+          components.removeLast();
+        }
+      } else if (!component.isEmpty() && !component.equals(".")) {
+        components.addLast(component);
+      }
+      start = end + 1;
+    }
+
+    final var normalized = new StringBuilder(path.substring(0, componentStart));
+    for (var component : components) {
+      if (normalized.charAt(normalized.length() - 1) != '\\') {
+        normalized.append('\\');
+      }
+      normalized.append(component);
+    }
+    return normalized.toString();
+  }
+
+  private interface Kernel32 extends StdCallLibrary {
+
+    boolean MoveFileEx(WString source, WString target, int flags);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -3183,6 +3183,11 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
     checkOpenness();
 
     final var collectionId = getCollectionIdByName(iCollectionName);
+    var collectionName = getCollectionNameById(collectionId);
+    if (MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME.equals(collectionName)) {
+      checkSecurity(ResourceGeneric.COLLECTION, Role.PERMISSION_DELETE, collectionName);
+    }
+
     var schema = metadata.getSchema();
 
     var clazz = schema.getClassByCollectionId(collectionId);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/SharedContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/SharedContext.java
@@ -5,7 +5,7 @@ import com.jetbrains.youtrackdb.internal.common.listener.ListenerManger;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
-import com.jetbrains.youtrackdb.internal.core.exception.GenesisIncompleteException;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
 import com.jetbrains.youtrackdb.internal.core.gql.executor.GqlExecutionPlanCache;
 import com.jetbrains.youtrackdb.internal.core.gql.parser.GqlStatementCache;
 import com.jetbrains.youtrackdb.internal.core.index.IndexException;
@@ -159,24 +159,30 @@ public class SharedContext extends ListenerManger<MetadataUpdateListener> {
     try {
       database.executeInTx(transaction -> {
         schema.load(database);
-        // Genesis-completion belt (design §A1): a database whose creation never ran to
-        // completion is refused before anything else loads — a half-genesis corpse (W6/W7 of
-        // the design's crash-state enumeration) would otherwise reopen silently with a partial
-        // or empty schema; the accepted W9a window (complete database, marker write not yet
-        // durable) is refused fail-closed the same way. The check runs AFTER the schema load
-        // ON PURPOSE (review CS52): Track 2's schema-version gate inside fromStream must own
-        // old-format databases first, with its export/reimport redirect — never the
-        // discard-and-recreate refusal below. It runs on the FIRST session of every context
-        // (the loaded flag is set only at the end, so a refused load re-runs and re-refuses),
-        // which is every reopen a real crash corpse can experience; drop() tolerates the
-        // refusal (CN54) so the prescribed discard always works.
+        // Track 24 turned this later check into a consistency check. Storage admission already
+        // accepted the storage image before recovery, and this check never reverses that
+        // decision. The check compares two durable sources. The first source is the accepted
+        // lifecycle state of the image, which says active. The second source is the genesis
+        // marker of the storage configuration, which says unfinished. A disagreement reports the
+        // named inconsistent-metadata result and keeps the storage closed for the caller.
+        // The check still runs AFTER the schema load ON PURPOSE (review CS52). The schema
+        // version gate of Track 2 inside fromStream must own an old-format database first, with
+        // the export and reimport redirect of that gate.
+        // The check runs on the FIRST session of every context, because the loaded flag is set
+        // only at the end, so a refused load runs again and refuses again. The drop path
+        // tolerates the genesis marker result (CN54), so the prescribed discard always works.
         if (!Boolean.parseBoolean(storage.getProperty(GENESIS_COMPLETED_PROPERTY))) {
-          throw new GenesisIncompleteException(storage.getName(),
-              "Database '"
+          throw new InconsistentStorageMetadataException(storage.getName(),
+              InconsistentStorageMetadataException.Inconsistency.GENESIS_MARKER,
+              "Inconsistent storage metadata of database '"
                   + storage.getName()
-                  + "' cannot be opened: its creation did not run to completion (the"
-                  + " genesis-completion marker is absent). Discard and re-create the"
-                  + " database.");
+                  + "'. The bootstrap authority record reports the active lifecycle state. The"
+                  + " genesis-completion marker of the storage configuration is absent. The"
+                  + " creation of database '"
+                  + storage.getName()
+                  + "' therefore never ran to completion. Drop database '"
+                  + storage.getName()
+                  + "', and create the database again.");
         }
         schema.forceSnapshot();
         indexManager.load(database);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBImpl.java
@@ -103,7 +103,6 @@ public class YouTrackDBImpl implements YouTrackDB, AutoCloseable {
       String... userCredentials) {
     create(databaseName, type, YouTrackDBConfig.defaultConfig(), userCredentials);
 
-
   }
 
   public void create(@Nonnull String databaseName, @Nonnull DatabaseType type,
@@ -207,7 +206,6 @@ public class YouTrackDBImpl implements YouTrackDB, AutoCloseable {
     return sessionPool.asGraph();
   }
 
-
   @Override
   public @NonNull YTDBGraphTraversalSource openTraversal(@NonNull String databaseName,
       @NonNull String userName, @NonNull String userPassword) {
@@ -310,6 +308,19 @@ public class YouTrackDBImpl implements YouTrackDB, AutoCloseable {
       @Nullable String expectedUUID, @Nonnull Configuration config) {
     internal.restore(databaseName, path, expectedUUID,
         YouTrackDBConfig.builder().fromApacheConfiguration(config).build());
+  }
+
+  /// Restarts an interrupted restore of one database, and destroys the target of that restore.
+  ///
+  /// The embedded implementation deletes the whole target and restores the backup again.
+  @Override
+  public void restartInterruptedRestore(@Nonnull String databaseName, @Nonnull String path,
+      @Nullable String expectedUUID, @Nullable Configuration config) {
+    var restoreConfig =
+        config == null
+            ? YouTrackDBConfig.defaultConfig()
+            : YouTrackDBConfig.builder().fromApacheConfiguration(config).build();
+    internal.restartInterruptedRestore(databaseName, path, expectedUUID, restoreConfig);
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBInternal.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBInternal.java
@@ -32,11 +32,9 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
-
 public interface YouTrackDBInternal extends AutoCloseable, SchedulerInternal {
 
   YouTrackDBImpl newYouTrackDb();
-
 
   /**
    * Create a new Embedded factory
@@ -54,7 +52,6 @@ public interface YouTrackDBInternal extends AutoCloseable, SchedulerInternal {
     return new YouTrackDBInternalEmbedded(directoryPath, config,
         YouTrackDBEnginesManager.instance(), serverMode);
   }
-
 
   /**
    * Open a database specified by name using the username and password if needed
@@ -194,6 +191,26 @@ public interface YouTrackDBInternal extends AutoCloseable, SchedulerInternal {
 
   void restore(String name, Supplier<Iterator<String>> ibuFilesSupplier,
       Function<String, InputStream> ibuInputStreamSupplier, @Nullable String expectedUUID,
+      YouTrackDBConfig config);
+
+  /**
+   * Restarts an interrupted restore of one database, and destroys the target of that restore.
+   *
+   * <p>An interrupted restore leaves a target in the restore-in-progress lifecycle state. The
+   * restart deletes that whole target and restores the backup again. The restart never continues a
+   * partial restore.
+   *
+   * <p>The restart accepts a target in the restore-in-progress lifecycle state. The restart also
+   * accepts one directory whose only entry is the authority lock file, because that directory is
+   * the residue of a crash inside an earlier restart deletion. The restart refuses every other
+   * target with one named admission reason, and the refusal changes no file.
+   *
+   * @param name         the database name of the restore target
+   * @param path         the directory of the backup
+   * @param expectedUUID the expected database identifier inside the backup, or null
+   * @param config       the configuration of the restored database
+   */
+  void restartInterruptedRestore(String name, String path, @Nullable String expectedUUID,
       YouTrackDBConfig config);
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBInternalEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/YouTrackDBInternalEmbedded.java
@@ -34,6 +34,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.CoreException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.GenesisIncompleteException;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBGraphFactory;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.auth.AuthenticationInfo;
@@ -42,13 +43,18 @@ import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.config.CollectionBasedStorageConfiguration;
 import com.jetbrains.youtrackdb.internal.core.storage.disk.DiskStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,6 +74,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -435,6 +442,7 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
   }
 
   private AbstractStorage getAndOpenStorage(String name, YouTrackDBConfigImpl config) {
+    var registeredStorage = storages.get(name);
     var storage = getOrInitStorage(name);
     // THIS OPEN THE STORAGE ONLY THE FIRST TIME
     try {
@@ -442,6 +450,12 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
       storage.open(config.getConfiguration());
     } catch (RuntimeException e) {
       storages.remove(storage.getName());
+      if (registeredStorage != storage) {
+        // This call created the storage, and the failed open leaves no usable storage behind.
+        // The storage identifier therefore returns to the pool of free identifiers. A retained
+        // identifier would leak one entry of the static identifier set on every failed open.
+        currentStorageIds.remove(storage.getId());
+      }
 
       throw e;
     }
@@ -467,7 +481,10 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
    */
   private synchronized void unregisterGenesisIncompleteCorpse(AbstractStorage storage,
       RuntimeException failure) {
-    if (!isCausedByGenesisIncomplete(failure)) {
+    // Track 24 moved the genesis check of the shared context to the named inconsistent-metadata
+    // result. Both shapes describe an image whose creation never ran to completion, so both
+    // shapes unregister the storage and keep the storage closed for the caller.
+    if (!isCausedByGenesisIncomplete(failure) && !isCausedByGenesisMarkerInconsistency(failure)) {
       return;
     }
     storages.remove(storage.getName());
@@ -495,6 +512,60 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
   private static boolean isCausedByGenesisIncomplete(Throwable failure) {
     for (var cause = failure; cause != null; cause = cause.getCause()) {
       if (cause instanceof GenesisIncompleteException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reports whether the cause chain of one failure carries the genesis marker inconsistency.
+   *
+   * <p>A consistency check is a later check that compares two durable sources without deciding
+   * admission. The genesis check of the shared context reports the named inconsistent-metadata
+   * result when the accepted lifecycle state says active and the genesis marker says unfinished.
+   * The drop path tolerates that result, so the prescribed discard always works.
+   */
+  private static boolean isCausedByGenesisMarkerInconsistency(Throwable failure) {
+    for (var cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof InconsistentStorageMetadataException inconsistency
+          && inconsistency.inconsistency()
+              == InconsistentStorageMetadataException.Inconsistency.GENESIS_MARKER) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the given failure is, or wraps, the interrupted-birth admission rejection.
+   *
+   * <p>Storage admission is the decision that accepts an existing storage image for use. Admission
+   * reports the interrupted-birth reason for an image whose genesis never finished. Delayed
+   * activation makes that image shape the ordinary residue of a crashed creation.
+   */
+  private static boolean isCausedByInterruptedBirth(Throwable failure) {
+    return isCausedByAdmissionReason(
+        failure, StorageAdmissionException.Reason.INTERRUPTED_BIRTH);
+  }
+
+  /**
+   * Reports whether the cause chain of one failure carries the interrupted-restore reason.
+   *
+   * <p>An interrupted restore leaves the restore-in-progress lifecycle state. The drop tolerates
+   * that reason, so an operator can always discard a restore target that no restore can finish.
+   */
+  private static boolean isCausedByInterruptedRestore(Throwable failure) {
+    return isCausedByAdmissionReason(
+        failure, StorageAdmissionException.Reason.INTERRUPTED_RESTORE);
+  }
+
+  /** Walks the cause chain of one failure and looks for one named admission reason. */
+  private static boolean isCausedByAdmissionReason(
+      Throwable failure, StorageAdmissionException.Reason reason) {
+    for (var cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof StorageAdmissionException admission
+          && admission.reason() == reason) {
         return true;
       }
     }
@@ -750,24 +821,291 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
   @Override
   public void restore(String name, String path,
       @Nullable String expectedUUID, YouTrackDBConfig config) {
-    createStorage(name, DatabaseType.DISK, (YouTrackDBConfigImpl) config, true,
-        (storage, embedded) -> {
-          storage.restoreFromBackup(Path.of(path), expectedUUID);
-          embedded.getSharedContext().getSchema().reload(embedded);
-          embedded.getSharedContext().getIndexManager().reload(embedded);
-        });
+    restoreStorage(name, (YouTrackDBConfigImpl) config,
+        storage -> storage.restoreFromBackup(Path.of(path), expectedUUID));
   }
 
   @Override
   public void restore(String name, Supplier<Iterator<String>> ibuFilesSupplier,
       Function<String, InputStream> ibuInputStreamSupplier, @Nullable String expectedUUID,
       YouTrackDBConfig config) {
-    createStorage(name, DatabaseType.DISK, (YouTrackDBConfigImpl) config, true,
-        (storage, embedded) -> {
-          storage.restoreFromBackup(ibuFilesSupplier, ibuInputStreamSupplier, expectedUUID);
-          embedded.getSharedContext().getSchema().reload(embedded);
-          embedded.getSharedContext().getIndexManager().reload(embedded);
-        });
+    restoreStorage(name, (YouTrackDBConfigImpl) config,
+        storage -> storage.restoreFromBackup(ibuFilesSupplier, ibuInputStreamSupplier,
+            expectedUUID));
+  }
+
+  @Override
+  public void restartInterruptedRestore(String name, String path,
+      @Nullable String expectedUUID, YouTrackDBConfig config) {
+    // Both name checks run before the restart changes anything, and both use the same
+    // lower-case rule. A refused name therefore never reaches the deletion of the restart.
+    checkDatabaseName(name);
+    checkReservedDatabaseNamePrefixes(name);
+    var targetPath = resolveDatabaseDirectory(name);
+    var solvedConfig = solveConfig((YouTrackDBConfigImpl) config);
+    // One instance monitor covers the acceptance check, the deletion, and the new restore. No
+    // concurrent creation, open, or restart can occupy the name between the deletion and the
+    // new restore, so the name never holds an empty active database.
+    synchronized (this) {
+      checkOpen();
+      // The acceptance check runs before the restart touches any in-memory state. A refused
+      // restart therefore keeps every file and every live session of a healthy database.
+      requireInterruptedRestoreTarget(name, targetPath);
+      // The registration of an earlier failed restore attempt of this process leaves now. The
+      // registration would otherwise pin an open storage over the deleted files.
+      discardRestoreTargetRegistration(name, targetPath);
+      try {
+        DiskStorage.deleteInterruptedRestoreTarget(targetPath);
+      } catch (StorageAdmissionException rejection) {
+        throw refusedRestart(name, rejection);
+      } catch (IOException deletionFailure) {
+        throw BaseException.wrapException(
+            new DatabaseException(basePath.toString(),
+                "Cannot delete the interrupted restore target of database '"
+                    + name
+                    + "'"),
+            deletionFailure,
+            basePath.toString());
+      }
+      restoreStorage(name, solvedConfig,
+          storage -> storage.restoreFromBackup(Path.of(path), expectedUUID), true);
+    }
+  }
+
+  /**
+   * Checks that one named database is a valid destructive restart target.
+   *
+   * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+   * restore. This check changes no file and no in-memory state. The deletion repeats the same
+   * check inside its own exclusive unit, so the acceptance and the deletion stay one exclusive
+   * unit.
+   */
+  private void requireInterruptedRestoreTarget(String name, Path targetPath) {
+    try {
+      DiskStorage.requireInterruptedRestoreTarget(targetPath);
+    } catch (StorageAdmissionException rejection) {
+      throw refusedRestart(name, rejection);
+    } catch (IOException probeFailure) {
+      throw BaseException.wrapException(
+          new DatabaseException(basePath.toString(),
+              "Cannot check the restore target of database '" + name + "'"),
+          probeFailure,
+          basePath.toString());
+    }
+  }
+
+  /** Builds the failure of one refused destructive restart. The refusal changes no file. */
+  private BaseException refusedRestart(String name, StorageAdmissionException rejection) {
+    return BaseException.wrapException(
+        new DatabaseException(basePath.toString(),
+            "Cannot restart the interrupted restore of database '"
+                + name
+                + "' because the destructive restart refuses this target"),
+        rejection,
+        basePath.toString());
+  }
+
+  /**
+   * Resolves the directory of one database inside the configured databases directory.
+   *
+   * <p>The resolved path must be one direct child of the databases directory. A name that escapes
+   * the databases directory is refused. A path that exists and is no real directory is refused as
+   * well, because a symbolic link would redirect a later deletion to another location.
+   *
+   * @return the resolved directory of the named database
+   */
+  private Path resolveDatabaseDirectory(String name) {
+    if (basePath == null) {
+      throw new DatabaseException("",
+          "This manager holds no databases directory, so this manager allows a memory database"
+              + " only");
+    }
+    var databasesDirectory = basePath.toAbsolutePath().normalize();
+    var target = databasesDirectory.resolve(name).normalize();
+    if (!databasesDirectory.equals(target.getParent())) {
+      throw new DatabaseException(basePath.toString(),
+          "Invalid database name '"
+              + name
+              + "'. A database name must resolve to one direct child of the databases directory");
+    }
+    try {
+      var attributes =
+          Files.readAttributes(target, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isDirectory()) {
+        throw new DatabaseException(basePath.toString(),
+            "The path of database '" + name + "' is no real directory");
+      }
+    } catch (NoSuchFileException absentTarget) {
+      // An absent directory needs no further check, because a later restore creates it.
+    } catch (IOException readFailure) {
+      throw BaseException.wrapException(
+          new DatabaseException(basePath.toString(),
+              "Cannot read the attributes of the directory of database '" + name + "'"),
+          readFailure,
+          basePath.toString());
+    }
+    return target;
+  }
+
+  /**
+   * Creates one restore target without genesis and without activation, and then restores content.
+   *
+   * <p>Genesis is the creation of the initial database metadata. Genesis creates the schema, the
+   * index manager, the index statistics, and the default users. The backup content replaces every
+   * genesis artifact, so a restore target runs no genesis at all.
+   *
+   * <p>The order of this method has four steps. The first step creates the storage files, which
+   * publishes the birth-in-progress lifecycle state. The second step publishes the
+   * restore-in-progress lifecycle state directly from that birth-in-progress state. The third step
+   * copies the backup content. The fourth step validates the restored content, passes a durability
+   * barrier, and publishes the active lifecycle state inside the storage.
+   *
+   * <p>A failed restore keeps every file of the target, because the destructive restart entry and
+   * the drop both need that evidence. A failed restore removes the in-memory registration only.
+   */
+  private void restoreStorage(String name, YouTrackDBConfigImpl config,
+      Consumer<AbstractStorage> restoreContent) {
+    restoreStorage(name, config, restoreContent, false);
+  }
+
+  /**
+   * Restores one target, and skips the existence refusal after a destructive restart.
+   *
+   * @param afterDestructiveRestart true when the deletion of a destructive restart ran before
+   */
+  private void restoreStorage(String name, YouTrackDBConfigImpl config,
+      Consumer<AbstractStorage> restoreContent, boolean afterDestructiveRestart) {
+    checkDatabaseName(name);
+    // Every restore entry resolves the target directory of the name. A name that escapes the
+    // databases directory therefore never reaches the creation of a storage. The restart entry
+    // resolved the same directory before the deletion, and one repeated resolution changes no file.
+    resolveDatabaseDirectory(name);
+    synchronized (this) {
+      checkOpen();
+      // The deletion of a destructive restart keeps the authority lock file of the target, so
+      // the existence probe still reports one database. That single file is the expected state
+      // after the deletion, and only the restart caller therefore skips the refusal below.
+      if (!afterDestructiveRestart && exists(name)) {
+        throw new DatabaseException(basePath.toString(),
+            "Cannot restore database '" + name + "' because it already exists");
+      }
+      checkReservedDatabaseNamePrefixes(name);
+
+      var solvedConfig = solveConfig(config);
+      var storage =
+          (AbstractStorage) disk.createStorage(
+              buildName(name),
+              getMaxWalSegSize(),
+              getDoubleWriteLogMaxSegSize(),
+              generateStorageId(),
+              this);
+      storages.put(name, storage);
+      try {
+        storage.create(solvedConfig.getConfiguration());
+        storage.beginRestoreLifecycle();
+        restoreContent.accept(storage);
+      } catch (RuntimeException | Error restoreFailure) {
+        // The on-disk target survives on purpose. The target carries the restore-in-progress
+        // lifecycle state, so the destructive restart entry accepts the target, and a drop
+        // discards the target. Only the in-memory registration leaves here.
+        closeFailedRestoreTarget(name, storage, restoreFailure);
+        throw restoreFailure;
+      }
+    }
+  }
+
+  /** Closes and unregisters the storage of a failed restore without any file deletion. */
+  private void closeFailedRestoreTarget(
+      String name, AbstractStorage storage, Throwable restoreFailure) {
+    storages.remove(name);
+    currentStorageIds.remove(storage.getId());
+    var sharedContext = sharedContexts.remove(name);
+    if (sharedContext != null) {
+      try {
+        sharedContext.close();
+      } catch (RuntimeException cleanupFailure) {
+        restoreFailure.addSuppressed(cleanupFailure);
+      }
+    }
+    try {
+      storage.shutdown();
+    } catch (RuntimeException | Error cleanupFailure) {
+      // A half-restored storage can refuse a clean shutdown. The restore failure stays primary.
+      restoreFailure.addSuppressed(cleanupFailure);
+    }
+  }
+
+  /**
+   * Removes every in-memory registration of one restore target before a destructive restart.
+   *
+   * <p>The registration map holds one storage per database name. A memory database and a database
+   * of a custom directory both use that same map. The restart therefore checks that the resolved
+   * target directory backs the registered storage. A registered storage of another directory keeps
+   * every registration, and the restart reports the mismatch to the caller.
+   *
+   * @param name the database name of the restore target
+   * @param targetPath the resolved directory of the restore target
+   */
+  private void discardRestoreTargetRegistration(String name, Path targetPath) {
+    requireRegisteredStorageOfTarget(name, targetPath);
+    var sharedContext = sharedContexts.remove(name);
+    if (sharedContext != null) {
+      sharedContext.close();
+    }
+    var storage = storages.remove(name);
+    if (storage != null) {
+      currentStorageIds.remove(storage.getId());
+      try {
+        storage.shutdown();
+      } catch (RuntimeException | Error cleanupFailure) {
+        LogManager.instance()
+            .warn(this,
+                "Could not shut down the registered storage of restore target '%s'",
+                cleanupFailure, name);
+      }
+    }
+  }
+
+  /**
+   * Refuses a destructive restart whose registered storage sits in another directory.
+   *
+   * <p>A memory database keeps no directory at all, so a memory database never passes this check.
+   * A database of a custom directory passes this check only when the custom directory equals the
+   * resolved target directory. The check therefore stops the restart before the restart shuts down
+   * a storage that the resolved target directory does not back.
+   *
+   * @param name the database name of the restore target
+   * @param targetPath the resolved directory of the restore target
+   */
+  private void requireRegisteredStorageOfTarget(String name, Path targetPath) {
+    var storage = storages.get(name);
+    if (storage == null) {
+      return;
+    }
+    if (storage instanceof DiskStorage diskStorage
+        && diskStorage.getStoragePath().equals(targetPath)) {
+      return;
+    }
+    throw new DatabaseException(basePath.toString(),
+        "Cannot restart the interrupted restore of database '"
+            + name
+            + "' because the registered storage of that name does not sit in the directory "
+            + targetPath);
+  }
+
+  /** Refuses a database name that carries one of the two reserved prefixes. */
+  private static void checkReservedDatabaseNamePrefixes(String name) {
+    var lowerCaseName = name.toLowerCase(Locale.ROOT);
+    if (lowerCaseName.startsWith("ytdb")) {
+      throw new IllegalArgumentException("Usage of database names started with 'ytdb'"
+          + " is prohibited as it is used as prefix of the names of GraphTraversal instances,"
+          + " provided name : "
+          + name);
+    }
+    if (lowerCaseName.startsWith("server")) {
+      throw new IllegalArgumentException(
+          "Database name can not start with 'server' prefix, provided name is : " + name);
+    }
   }
 
   private void createStorage(String name,
@@ -779,16 +1117,7 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
     synchronized (this) {
       if (!exists(name)) {
         try {
-          var lowerCaseName = name.toLowerCase(Locale.ROOT);
-          if (lowerCaseName.startsWith("ytdb")) {
-            throw new IllegalArgumentException("Usage of database names started with 'ytdb'"
-                + " is prohibited as it is used as prefix of the names of GraphTraversal instances, provided name : "
-                + name);
-          }
-          if (lowerCaseName.startsWith("server")) {
-            throw new IllegalArgumentException(
-                "Database name can not start with 'server' prefix, provided name is : " + name);
-          }
+          checkReservedDatabaseNamePrefixes(name);
 
           config = solveConfig(config);
           AbstractStorage storage;
@@ -848,7 +1177,33 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
           // adopted either); it is refused loudly instead of being reported as "nothing to
           // do". The message avoids unconditional discard advice: an old-format database's
           // migration guidance lives in the open path's schema-version gate.
-          var existing = getAndOpenStorage(name, solveConfig(config));
+          AbstractStorage existing;
+          try {
+            existing = getAndOpenStorage(name, solveConfig(config));
+          } catch (RuntimeException openFailure) {
+            // Track 24 delayed activation: a crashed creation now leaves an image in the
+            // birth-in-progress lifecycle state, and admission rejects that image before the
+            // marker branch below can read any property. The interrupted-birth reason therefore
+            // gets the same tailored explanation as a marker-less image. The failed open of
+            // getAndOpenStorage already removed the registration and freed the storage
+            // identifier. Every other open failure keeps its present behavior and propagates.
+            if (!isCausedByInterruptedBirth(openFailure)) {
+              throw openFailure;
+            }
+            // The interrupted-birth reason covers two causes. The first cause is a creation that
+            // never finished. The second cause is damage to every authority record of a complete
+            // database. The message therefore states the observed condition and names both
+            // causes. The wording lives in the reason description alone, so the create path and
+            // the open path always tell the operator the same story.
+            var interruptedBirthRefusal = new GenesisIncompleteException(name,
+                "Cannot create database '"
+                    + name
+                    + "': a database with this name already exists, and storage admission"
+                    + " rejected the image of that database with the interrupted-birth reason. "
+                    + StorageAdmissionException.Reason.INTERRUPTED_BIRTH.description());
+            interruptedBirthRefusal.addSuppressed(openFailure);
+            throw interruptedBirthRefusal;
+          }
           if (!Boolean.parseBoolean(
               existing.getProperty(SharedContext.GENESIS_COMPLETED_PROPERTY))) {
             var refusal = new GenesisIncompleteException(name,
@@ -906,10 +1261,26 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
     }
   }
 
+  /**
+   * Creates one storage image and runs genesis on that image.
+   *
+   * <p>Genesis is the creation of the initial database metadata. Genesis creates the schema, the
+   * index manager, the index statistics, and the default users. Genesis completes inside
+   * {@code newCreateSessionInstance}, which is the database session creation path.
+   *
+   * <p>This method is the single funnel of every production creation path. The ordinary create
+   * path, the restore create path, and the server registration path all reach this method. The
+   * publication of the active lifecycle state therefore happens here, after genesis finished and
+   * after the durability barrier completed (Track 24 delayed activation).
+   */
   private DatabaseSessionEmbedded internalCreate(
       YouTrackDBConfigImpl config, AbstractStorage storage) {
     storage.create(config.getConfiguration());
-    return newCreateSessionInstance(storage, config, getOrCreateSharedContext(storage));
+    var session = newCreateSessionInstance(storage, config, getOrCreateSharedContext(storage));
+    // Genesis finished above. The barrier and the activation run only now, so a crash inside
+    // genesis leaves an image that storage admission rejects with the interrupted-birth reason.
+    storage.completeStorageBirth();
+    return session;
   }
 
   private synchronized SharedContext getOrCreateSharedContext(
@@ -956,7 +1327,23 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
         // onDrop listeners — no usable session can be minted for it. Any other open failure
         // keeps today's behavior: the deletion in the finally still runs, and the failure
         // surfaces to the caller.
-        if (!isCausedByGenesisIncomplete(openFailure)) {
+        // Track 24 adds the second tolerated cause. Delayed activation leaves the birth-in-progress
+        // lifecycle state after a crashed creation, and admission then reports the
+        // interrupted-birth reason. Drop deletes that incomplete image and reports success. Drop
+        // stays loud for every other cause, so unrelated damage still reaches the operator.
+        // Track 24 adds the third tolerated cause. An interrupted restore leaves the
+        // restore-in-progress lifecycle state, and admission then reports the interrupted-restore
+        // reason. A backup whose content fails the restore validation would otherwise leave a
+        // target that no entry point can clear, so the drop deletes that target and reports
+        // success.
+        // Track 24 adds the fourth tolerated cause. The genesis check of the shared context now
+        // reports the named inconsistent-metadata result with the genesis marker value. The drop
+        // path tolerates that value and stays loud for the storage layout version value, because
+        // an operator must see a layout version mismatch.
+        if (!isCausedByGenesisIncomplete(openFailure)
+            && !isCausedByGenesisMarkerInconsistency(openFailure)
+            && !isCausedByInterruptedBirth(openFailure)
+            && !isCausedByInterruptedRestore(openFailure)) {
           throw openFailure;
         }
         LogManager.instance()
@@ -1151,10 +1538,14 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
           if (db.isDirectory()) {
             for (var cf : db.listFiles()) {
               var fileName = cf.getName();
+              // The scanner recognizes the same bootstrap authority artifact set as the existence
+              // probe of the disk storage. A listing and an existence check therefore agree after
+              // an interrupted storage birth.
               if (fileName.equals("database.ocf")
                   || (fileName.startsWith(CollectionBasedStorageConfiguration.COMPONENT_NAME)
                       && fileName.endsWith(
-                          CollectionBasedStorageConfiguration.DATA_FILE_EXTENSION))) {
+                          CollectionBasedStorageConfiguration.DATA_FILE_EXTENSION))
+                  || StorageBootstrapMetadata.isBootstrapArtifactName(fileName)) {
                 found.found(db.getName());
                 break;
               }
@@ -1333,18 +1724,26 @@ public class YouTrackDBInternalEmbedded implements YouTrackDBInternal {
     return basePath == null;
   }
 
+  /**
+   * Refuses an invalid database name.
+   *
+   * <p>The two reserved prefixes use the same lower-case rule as
+   * {@link #checkReservedDatabaseNamePrefixes}. One single letter-case rule keeps every caller of
+   * the two checks consistent, so no caller passes the first check and fails the second check.
+   */
   private void checkDatabaseName(String name) {
     Objects.requireNonNull(name, "Database name is required");
     if (name.contains("/") || name.contains(":")) {
       throw new DatabaseException(basePath.toString(),
           String.format("Invalid database name:'%s'", name));
     }
-    if (name.startsWith("ytdb")) {
+    var lowerCaseName = name.toLowerCase(Locale.ROOT);
+    if (lowerCaseName.startsWith("ytdb")) {
       throw new DatabaseException(basePath.toString(),
           String.format("Invalid database name:'%s'. Database name cannot start with 'ytdb'",
               name));
     }
-    if (name.startsWith("server")) {
+    if (lowerCaseName.startsWith("server")) {
       throw new DatabaseException(basePath.toString(),
           String.format("Invalid database name:'%s'. Database name cannot start with 'server'",
               name));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExport.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExport.java
@@ -260,9 +260,12 @@ public class DatabaseExport extends DatabaseImpExpAbstract<DatabaseSessionEmbedd
   }
 
   /**
-   * Promotes the completed dump to the final name with the durable CS40 recipe (file fsync
-   * through a reopened channel, {@code ATOMIC_MOVE}+{@code REPLACE_EXISTING} rename, parent
-   * directory fsync; fail-closed — no copy fallback). A no-op for the streaming variant, whose
+   * Promotes the completed dump to the final name after forcing its content. Unix uses the
+   * standard Java atomic move and then forces the parent directory. Windows calls the operating
+   * system move through the JNA native helper with write-through enabled. If the native helper
+   * cannot load, Windows uses the standard Java atomic move and records one warning. Unlike Unix,
+   * that fallback also tolerates a parent-directory open failure. It does not provide a crash-atomic
+   * guarantee. This method is a no-op for the streaming variant. Its
    * completion marker is the manifest section itself.
    */
   private void promote() throws IOException {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExport.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExport.java
@@ -333,7 +333,8 @@ public class DatabaseExport extends DatabaseImpExpAbstract<DatabaseSessionEmbedd
     for (var i = 0; exportedCollections <= maxCollectionId; ++i) {
       var collectionName = session.getCollectionNameById(i);
 
-      if (MetadataDefault.COLLECTION_INTERNAL_NAME.equals(collectionName)) {
+      if (MetadataDefault.COLLECTION_INTERNAL_NAME.equals(collectionName)
+          || MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME.equals(collectionName)) {
         continue;
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImport.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImport.java
@@ -1591,6 +1591,14 @@ public class DatabaseImport extends DatabaseImpExpAbstract<DatabaseSessionEmbedd
       rid = record.getIdentity();
       originalRid = metadata.recordId();
 
+      if (originalRid != null
+          && MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME.equals(
+              session.getCollectionNameById(
+                  collectionToCollectionMapping.get(originalRid.getCollectionId())))) {
+        record.delete();
+        return null;
+      }
+
       if (exporterVersion <= 13 &&
           record instanceof Entity entity &&
           Role.CLASS_NAME.equals(entity.getSchemaClassName())) {
@@ -1794,8 +1802,9 @@ public class DatabaseImport extends DatabaseImpExpAbstract<DatabaseSessionEmbedd
 
       session.executeInTx(transaction -> {
         for (final var collectionName : session.getCollectionNames()) {
-          if (collectionName.equals(MetadataDefault.COLLECTION_INTERNAL_NAME)) {
-            // don't want to mess with the internal collection
+          if (collectionName.equals(MetadataDefault.COLLECTION_INTERNAL_NAME)
+              || collectionName.equals(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME)) {
+            // Do not delete records owned by internal database subsystems.
             continue;
           }
           var recordIterator = session.browseCollection(collectionName);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/GenesisIncompleteException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/GenesisIncompleteException.java
@@ -9,9 +9,10 @@ package com.jetbrains.youtrackdb.internal.core.exception;
  * creation and the end of the metadata-creation sequence) must be discarded and re-created, never
  * used — without this check it would reopen silently with a partial or empty schema.
  *
- * <p>The open-path refusal fires from the metadata load ({@code SharedContext.load}), AFTER the
- * schema-version gate parsed the schema root — so an old-format database gets the version gate's
- * export/reimport redirect, never this exception's discard advice (review CS52).
+ * <p>Track 24 moved the open-path refusal of the metadata load to
+ * {@link InconsistentStorageMetadataException}, which is the named inconsistent-metadata result of
+ * the two later consistency checks. This exception now reports the tolerant create path only. The
+ * tolerant create path is the create call that accepts an existing database.
  *
  * <p>The check is deliberately fail-closed: a crash after a fully completed genesis but before
  * the marker write became durable produces a FALSE refusal of a genuinely complete database

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/InconsistentStorageMetadataException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/InconsistentStorageMetadataException.java
@@ -1,0 +1,57 @@
+package com.jetbrains.youtrackdb.internal.core.exception;
+
+import com.jetbrains.youtrackdb.api.exception.HighLevelException;
+
+/**
+ * Reports one disagreement between two durable metadata sources of one storage image.
+ *
+ * <p>A storage is one physical database image on disk. Storage admission is the decision that
+ * accepts an existing storage image for use. Admission runs before write-ahead log setup and
+ * before recovery. A consistency check is a later check that compares two durable sources without
+ * deciding admission.
+ *
+ * <p>Track 24 turned the two later checks into consistency checks. The first later check runs
+ * during the load of the storage configuration and compares the storage layout version. The second
+ * later check runs during the load of the shared context and compares the genesis marker. Genesis
+ * is the creation of the initial database metadata. The genesis marker is the durable value that
+ * records a finished genesis.
+ *
+ * <p>Neither consistency check reverses the admission decision, because admission already happened
+ * before recovery. Each consistency check keeps the storage closed for the caller. Each message
+ * names the two disagreeing sources.
+ *
+ * <p>The value of {@link #inconsistency()} names the check that reported the disagreement. The drop
+ * path tolerates the genesis marker value, so an operator can always discard an image whose genesis
+ * never finished. The drop path stays loud for the storage layout version value, because an
+ * operator must see a version mismatch.
+ */
+public class InconsistentStorageMetadataException extends DatabaseException
+    implements HighLevelException {
+
+  /** Names the consistency check that found the disagreement. */
+  public enum Inconsistency {
+    /** The storage configuration and the bootstrap authority record name different layouts. */
+    STORAGE_LAYOUT_VERSION,
+    /** The accepted lifecycle state says active, and the genesis marker says unfinished. */
+    GENESIS_MARKER
+  }
+
+  private final Inconsistency inconsistency;
+
+  @SuppressWarnings("unused")
+  public InconsistentStorageMetadataException(InconsistentStorageMetadataException exception) {
+    super(exception);
+    this.inconsistency = exception.inconsistency;
+  }
+
+  public InconsistentStorageMetadataException(String dbName, Inconsistency inconsistency,
+      String message) {
+    super(dbName, message);
+    this.inconsistency = inconsistency;
+  }
+
+  /** The consistency check that reported this result. */
+  public Inconsistency inconsistency() {
+    return inconsistency;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/IndexEngineReplacedException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/IndexEngineReplacedException.java
@@ -1,0 +1,9 @@
+package com.jetbrains.youtrackdb.internal.core.exception;
+
+/** Reports that an index handle expects a different engine at a registered slot. */
+public final class IndexEngineReplacedException extends InvalidIndexEngineIdException {
+
+  public IndexEngineReplacedException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/StaleIndexEngineException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/StaleIndexEngineException.java
@@ -1,0 +1,24 @@
+package com.jetbrains.youtrackdb.internal.core.exception;
+
+import com.jetbrains.youtrackdb.api.exception.HighLevelException;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+
+/** Reports that an index engine cannot be recovered through its durable descriptor identity. */
+public final class StaleIndexEngineException extends CoreException implements HighLevelException {
+
+  public StaleIndexEngineException(StaleIndexEngineException exception) {
+    super(exception);
+  }
+
+  public StaleIndexEngineException(String message) {
+    super(message);
+  }
+
+  public StaleIndexEngineException(String dbName, String message) {
+    super(dbName, message);
+  }
+
+  public StaleIndexEngineException(DatabaseSessionEmbedded session, String message) {
+    super(session, message);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/DefaultIndexFactory.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/DefaultIndexFactory.java
@@ -19,7 +19,6 @@ import com.jetbrains.youtrackdb.internal.core.config.IndexEngineData;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
-import com.jetbrains.youtrackdb.internal.core.index.engine.V1IndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeMultiValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
@@ -132,19 +131,16 @@ public class DefaultIndexFactory implements IndexFactory {
       case "memory", "disk" -> {
         var realStorage = (AbstractStorage) storage;
         if (data.getAlgorithm().equals(BTREE_ALGORITHM)) {
-          var engineReference =
-              realStorage.allocateIndexEngineReference(data.getIndexId(),
-                  V1IndexEngine.API_VERSION);
           if (data.isMultivalue()) {
             indexEngine =
                 new BTreeMultiValueIndexEngine(
                     data.getIndexId(), data.getFileBaseId(), data.getName(), realStorage,
-                    version, engineReference);
+                    version);
           } else {
             indexEngine =
                 new BTreeSingleValueIndexEngine(
                     data.getIndexId(), data.getFileBaseId(), data.getName(), realStorage,
-                    version, engineReference);
+                    version);
           }
         } else {
           throw new IllegalStateException("Invalid name of algorithm :'" + "'");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/DefaultIndexFactory.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/DefaultIndexFactory.java
@@ -19,6 +19,7 @@ import com.jetbrains.youtrackdb.internal.core.config.IndexEngineData;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.engine.V1IndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeMultiValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
@@ -131,16 +132,19 @@ public class DefaultIndexFactory implements IndexFactory {
       case "memory", "disk" -> {
         var realStorage = (AbstractStorage) storage;
         if (data.getAlgorithm().equals(BTREE_ALGORITHM)) {
+          var engineReference =
+              realStorage.allocateIndexEngineReference(data.getIndexId(),
+                  V1IndexEngine.API_VERSION);
           if (data.isMultivalue()) {
             indexEngine =
                 new BTreeMultiValueIndexEngine(
                     data.getIndexId(), data.getFileBaseId(), data.getName(), realStorage,
-                    version);
+                    version, engineReference);
           } else {
             indexEngine =
                 new BTreeSingleValueIndexEngine(
                     data.getIndexId(), data.getFileBaseId(), data.getName(), realStorage,
-                    version);
+                    version, engineReference);
           }
         } else {
           throw new IllegalStateException("Invalid name of algorithm :'" + "'");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/Index.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/Index.java
@@ -190,6 +190,7 @@ public interface Index extends Comparable<Index> {
   String INDEX_DEFINITION = "indexDefinition";
   String INDEX_DEFINITION_CLASS = "indexDefinitionClass";
   String INDEX_VERSION = "indexVersion";
+  String LIFECYCLE_RECORD = "lifecycleRecord";
   String METADATA = "metadata";
   String MERGE_KEYS = "mergeKeys";
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -948,7 +948,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var mgr = btreeEngine.getHistogramManager();
           if (mgr != null) {
@@ -983,7 +983,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           if (btreeEngine.getHistogramManager() != null) {
             try {
@@ -1163,6 +1163,12 @@ public abstract class IndexAbstract implements Index {
   }
 
   protected void doDelete(FrontendTransaction transaction) {
+    final var initial = state();
+    if (!initial.hasEngine()) {
+      isNeverBuilt(initial);
+      return;
+    }
+
     boolean recovered = false;
     while (true) {
       try {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -564,6 +564,15 @@ public abstract class IndexAbstract implements Index {
 
   protected void doReloadIndexEngine() {
     indexId = storage.loadIndexEngine(im.getName());
+    checkReloadedIndexId();
+  }
+
+  private void doReloadIndexEngineWithStateLock() {
+    indexId = storage.loadIndexEngineWithStateLock(im.getName());
+    checkReloadedIndexId();
+  }
+
+  private void checkReloadedIndexId() {
     if (indexId < 0) {
       throw new IllegalStateException("Index " + im.getName() + " can not be loaded");
     }
@@ -1315,7 +1324,7 @@ public abstract class IndexAbstract implements Index {
         engine = storage.getIndexEngineWithStateLock(indexId);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        doReloadIndexEngineWithStateLock();
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -1312,7 +1312,7 @@ public abstract class IndexAbstract implements Index {
 
     while (true) {
       try {
-        engine = storage.getIndexEngine(indexId);
+        engine = storage.getIndexEngineWithStateLock(indexId);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
         doReloadIndexEngine();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -35,6 +35,9 @@ import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionExceptio
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
 import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
+import com.jetbrains.youtrackdb.internal.core.id.ChangeableIdentity;
+import com.jetbrains.youtrackdb.internal.core.id.IdentityChangeListener;
+import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysGreaterKey;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysLessKey;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
@@ -64,6 +67,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -87,8 +91,11 @@ public abstract class IndexAbstract implements Index {
   @Nonnull
   private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
 
-  protected volatile int indexId = -1;
-  @Nullable private volatile IdentityAttachment identityAttachment;
+  @Nonnull
+  private final AtomicReference<IndexHandleState> handleState =
+      new AtomicReference<>(IndexHandleState.EMPTY);
+  @Nonnull
+  private final IdentityChangeListener identityChangeListener = new DescriptorIdentityListener();
 
   @Nonnull
   protected Set<String> collectionsToIndex = new HashSet<>();
@@ -99,17 +106,15 @@ public abstract class IndexAbstract implements Index {
   // metadata) stale through a racing read of the new reference.
   @Nullable protected volatile IndexMetadata im;
 
-  @Nullable protected volatile RID identity;
-
   public IndexAbstract(@Nullable RID identity,
       @Nonnull FrontendTransactionImpl transaction, @Nonnull final Storage storage) {
     acquireExclusiveLock();
     try {
-      if (!identity.isPersistent()) {
+      if (identity == null || !identity.isPersistent()) {
         throw new IllegalStateException(
             "RID passed to index is not persistent and can not be used to load metadata");
       }
-      this.identity = identity;
+      handleState.set(new IndexHandleState(-1, null, immutableIdentity(identity), null));
       this.storage = (AbstractStorage) storage;
 
       load(transaction);
@@ -203,18 +208,18 @@ public abstract class IndexAbstract implements Index {
 
       Map<String, String> engineProperties = new HashMap<>();
       indexMetadata.setVersion(im.getVersion());
-      indexId = storage.addIndexEngine(indexMetadata, engineProperties);
+      final var engineIdentifier = storage.addIndexEngine(indexMetadata, engineProperties);
+      assert engineIdentifier >= 0;
+      publishEngine(engineIdentifier);
 
-      assert indexId >= 0;
-
-      onIndexEngineChange(transaction.getDatabaseSession(), indexId);
+      onIndexEngineChange(transaction.getDatabaseSession(), state());
 
       save(transaction);
       attachDescriptorIdentityLocked();
     } catch (Exception e) {
       LogManager.instance().error(this, "Exception during index '%s' creation", e, im.getName());
       // index is created inside of storage
-      if (indexId >= 0) {
+      if (state().hasEngine()) {
         doDelete(transaction);
       }
       throw BaseException.wrapException(
@@ -520,8 +525,9 @@ public abstract class IndexAbstract implements Index {
   void deleteRecordAtCommit(final FrontendTransaction transaction) {
     acquireExclusiveLock();
     try {
-      if (identity != null) {
-        transaction.loadEntity(identity).delete();
+      final var descriptorIdentity = state().descriptorIdentity();
+      if (descriptorIdentity != null) {
+        transaction.loadEntity(descriptorIdentity).delete();
       }
     } finally {
       releaseExclusiveLock();
@@ -553,95 +559,158 @@ public abstract class IndexAbstract implements Index {
     acquireExclusiveLock();
     try {
       final Map<String, String> engineProperties = new HashMap<>();
-      indexId = storage.createIndexEngineInCommitWindow(im, engineProperties, atomicOperation);
-      assert indexId >= 0;
+      final var engineIdentifier =
+          storage.createIndexEngineInCommitWindow(im, engineProperties, atomicOperation);
+      assert engineIdentifier >= 0;
+      publishEngine(engineIdentifier);
       // Record the published id before wiring the engine: the in-memory registries already carry
       // it, and onIndexEngineChange can fail with an exception the build loop's
       // InvalidIndexEngineIdException catch does not cover. The failure-path undo reverts exactly
       // the recorded ids, so recording only after a fully-successful build would leave such a
       // failure's engine behind as a phantom registration no revert arm ever removes.
-      createdEngineExternalIds.add(indexId);
+      createdEngineExternalIds.add(engineIdentifier);
       attachDescriptorIdentityLocked();
-      onIndexEngineChange(transaction.getDatabaseSession(), indexId);
+      onIndexEngineChange(transaction.getDatabaseSession(), state());
     } finally {
       releaseExclusiveLock();
     }
   }
 
-  /**
-   * Resolves this handle through its descriptor owner instead of its reusable index name.
-   *
-   * <p>Recovery fails closed while index creation has not saved the descriptor, while rebuild has
-   * cleared the descriptor identity, and while manager publication precedes descriptor attachment.
-   * An engine published before its owner binding also cannot be recovered. Track 20 closes these
-   * ownerless and unbound publication windows.
-   */
-  protected final int resolveOwnedEngineIdentifier() {
-    final var descriptorIdentity = identity;
-    if (descriptorIdentity == null) {
-      throw new StaleIndexEngineException(
-          storage.getName(),
-          "Cannot recover index '" + getName() + "' for descriptor null: the handle has no owner");
-    }
-
-    final int resolvedIdentifier;
-    try {
-      resolvedIdentifier =
-          storage.resolveIndexEngineByOwner(descriptorIdentity).engineIdentifier();
-    } catch (StaleIndexEngineException exception) {
-      throw new StaleIndexEngineException(
-          storage.getName(),
-          "Cannot recover index '" + getName() + "' for descriptor " + descriptorIdentity
-              + ": no registered engine has that owner");
-    }
-    indexId = resolvedIdentifier;
-    return resolvedIdentifier;
+  /** Resolves this handle through its durable descriptor owner. */
+  protected final IndexHandleState resolveOwnedEngine() {
+    return resolveOwnedEngine(false);
   }
 
-  private int resolveOwnedEngineIdentifierWithStateLock() {
-    final var descriptorIdentity = identity;
-    if (descriptorIdentity == null) {
+  private IndexHandleState resolveOwnedEngineWithStateLock() {
+    return resolveOwnedEngine(true);
+  }
+
+  private IndexHandleState resolveOwnedEngine(boolean stateLockHeld) {
+    final var expected = state();
+    final var descriptorIdentity = expected.descriptorIdentity();
+    if (descriptorIdentity == null || !descriptorIdentity.isPersistent()) {
       throw new StaleIndexEngineException(
           storage.getName(),
-          "Cannot recover index '" + getName() + "' for descriptor null: the handle has no owner");
+          "Cannot recover index '" + getName() + "': the handle has no durable owner");
     }
 
-    final int resolvedIdentifier;
+    final AbstractStorage.ResolvedIndexEngine resolved;
     try {
-      resolvedIdentifier =
-          storage.resolveIndexEngineByOwnerWithStateLock(descriptorIdentity).engineIdentifier();
+      resolved = stateLockHeld
+          ? storage.resolveIndexEngineByOwnerWithStateLock(descriptorIdentity)
+          : storage.resolveIndexEngineByOwner(descriptorIdentity);
     } catch (StaleIndexEngineException exception) {
       throw new StaleIndexEngineException(
           storage.getName(),
           "Cannot recover index '" + getName() + "' for descriptor " + descriptorIdentity
               + ": no registered engine has that owner");
     }
-    indexId = resolvedIdentifier;
-    return resolvedIdentifier;
+
+    final var latest = state();
+    final var replacement = new IndexHandleState(
+        resolved.engineIdentifier(), resolved.engineReference(), descriptorIdentity,
+        latest.lifecycleCell());
+    if (handleState.compareAndSet(expected, replacement)) {
+      return replacement;
+    }
+    return state();
+  }
+
+  protected final IndexHandleState state() {
+    return handleState.get();
+  }
+
+  public void setHandleStateForTest(
+      int engineIdentifier, @Nullable RID descriptorIdentity) {
+    handleState.set(new IndexHandleState(engineIdentifier, null, descriptorIdentity, null));
+  }
+
+  public void setEngineIdentifierForTest(int engineIdentifier) {
+    final var current = state();
+    setHandleStateForTest(engineIdentifier, current.descriptorIdentity());
+  }
+
+  public void setDescriptorIdentityForTest(@Nullable RID descriptorIdentity) {
+    final var current = state();
+    setHandleStateForTest(current.engineIdentifier(), descriptorIdentity);
+  }
+
+  private void publishEngine(int engineIdentifier) {
+    final var engineReference = storage.getIndexEngineReference(engineIdentifier);
+    updateState(current -> new IndexHandleState(
+        engineIdentifier, engineReference, current.descriptorIdentity(), current.lifecycleCell()));
+  }
+
+  private void publishReplacementEngineAndClearIdentity(int engineIdentifier) {
+    final var engineReference = storage.getIndexEngineReference(engineIdentifier);
+    updateState(current -> new IndexHandleState(engineIdentifier, engineReference, null, null));
+  }
+
+  private void publishEngineDetached(boolean releaseLifecycle) {
+    updateState(current -> new IndexHandleState(
+        -1, null, current.descriptorIdentity(), releaseLifecycle ? null : current.lifecycleCell()));
+  }
+
+  private void publishDescriptorIdentity(RID descriptorIdentity) {
+    final RID publishedIdentity = descriptorIdentity.isPersistent()
+        ? immutableIdentity(descriptorIdentity)
+        : descriptorIdentity;
+    updateState(current -> {
+      final var existing = current.descriptorIdentity();
+      if (existing != null && existing.isPersistent()) {
+        if (existing.equals(publishedIdentity)) {
+          return current;
+        }
+        if (current.lifecycleCell() != null || !publishedIdentity.isPersistent()) {
+          throw new IllegalStateException("A live durable descriptor identity cannot be replaced");
+        }
+      }
+      return new IndexHandleState(
+          current.engineIdentifier(), current.engineReference(), publishedIdentity,
+          current.lifecycleCell());
+    });
+    if (!descriptorIdentity.isPersistent() && descriptorIdentity instanceof ChangeableIdentity id) {
+      id.addIdentityChangeListener(identityChangeListener);
+    }
+  }
+
+  private void updateState(java.util.function.UnaryOperator<IndexHandleState> update) {
+    while (true) {
+      final var current = state();
+      final var replacement = update.apply(current);
+      if (replacement.equals(current) || handleState.compareAndSet(current, replacement)) {
+        return;
+      }
+    }
+  }
+
+  private static RID immutableIdentity(RID identity) {
+    return ((RecordIdInternal) identity).copy();
   }
 
   private void load(FrontendTransactionImpl transaction) {
-    var entity = transaction.loadEntity(identity);
+    var entity = transaction.loadEntity(state().descriptorIdentity());
     final var indexMetadata = loadMetadata(transaction, entity.toMap(false));
 
     this.im = indexMetadata;
     collectionsToIndex.clear();
 
     collectionsToIndex.addAll(indexMetadata.getCollectionsToIndex());
-    indexId = storage.loadIndexEngine(im.getName());
+    var engineIdentifier = storage.loadIndexEngine(im.getName());
 
-    if (indexId == -1) {
+    if (engineIdentifier == -1) {
       Map<String, String> engineProperties = new HashMap<>();
-      indexId = storage.loadExternalIndexEngine(indexMetadata, engineProperties,
+      engineIdentifier = storage.loadExternalIndexEngine(indexMetadata, engineProperties,
           transaction.getAtomicOperation());
     }
 
-    if (indexId == -1) {
+    if (engineIdentifier == -1) {
       throw new IllegalStateException("Index " + im.getName() + " can not be loaded");
     }
 
+    publishEngine(engineIdentifier);
     attachDescriptorIdentityLocked();
-    onIndexEngineChange(transaction.getDatabaseSession(), indexId);
+    onIndexEngineChange(transaction.getDatabaseSession(), state());
   }
 
   void attachDescriptorIdentity() {
@@ -658,60 +727,63 @@ public abstract class IndexAbstract implements Index {
       throw new IllegalStateException("Index identity attachment requires the handle write lock");
     }
 
-    final var descriptorIdentity = identity;
-    final var engineIdentifier = indexId;
-    if (descriptorIdentity == null || !descriptorIdentity.isPersistent() || engineIdentifier < 0) {
-      return;
+    while (true) {
+      final var current = state();
+      final var descriptorIdentity = current.descriptorIdentity();
+      if (descriptorIdentity == null || !descriptorIdentity.isPersistent()
+          || !current.hasEngine()) {
+        return;
+      }
+
+      final var durableIdentity = immutableIdentity(descriptorIdentity);
+      final var boundReference = storage.attachIndexEngineOwner(
+          current.engineIdentifier(), durableIdentity, current.engineReference());
+      final var lifecycleCell = storage.getOrCreateIndexLifecycle(durableIdentity);
+      final var replacement = new IndexHandleState(
+          current.engineIdentifier(), boundReference, durableIdentity, lifecycleCell);
+      if (replacement.equals(current) || handleState.compareAndSet(current, replacement)) {
+        if (descriptorIdentity instanceof ChangeableIdentity changeableIdentity) {
+          changeableIdentity.removeIdentityChangeListener(identityChangeListener);
+        }
+        return;
+      }
     }
-
-    final var currentReference = storage.getIndexEngineReference(engineIdentifier);
-    final var currentAttachment = identityAttachment;
-    if (currentAttachment != null
-        && currentAttachment.descriptorIdentity().equals(descriptorIdentity)
-        && referencesSameEngine(currentAttachment.engineReference(), currentReference)) {
-      return;
-    }
-
-    final var boundReference = storage.attachIndexEngineOwner(
-        engineIdentifier, descriptorIdentity, currentReference);
-    final var lifecycleCell = storage.getOrCreateIndexLifecycle(descriptorIdentity);
-    identityAttachment =
-        new IdentityAttachment(descriptorIdentity, lifecycleCell, boundReference);
-  }
-
-  private static boolean referencesSameEngine(
-      @Nullable IndexEngineReference first, @Nullable IndexEngineReference second) {
-    return first == second;
   }
 
   @Nullable IndexLifecycleCell getLifecycleCell() {
-    final var attachment = identityAttachment;
-    return attachment == null ? null : attachment.lifecycleCell();
+    return state().lifecycleCell();
   }
 
   @Nullable IndexEngineReference getEngineReference() {
-    final var attachment = identityAttachment;
-    return attachment == null ? null : attachment.engineReference();
+    return state().engineReference();
   }
 
   void removeLifecycleRegistration() {
     acquireExclusiveLock();
     try {
-      final var attachment = identityAttachment;
-      final var descriptorIdentity =
-          attachment == null ? identity : attachment.descriptorIdentity();
+      final var current = state();
+      final var descriptorIdentity = current.descriptorIdentity();
       if (descriptorIdentity != null && descriptorIdentity.isPersistent()) {
         storage.removeIndexLifecycle(descriptorIdentity);
       }
+      publishEngineDetached(true);
     } finally {
       releaseExclusiveLock();
     }
   }
 
-  private record IdentityAttachment(
-      RID descriptorIdentity,
-      IndexLifecycleCell lifecycleCell,
-      @Nullable IndexEngineReference engineReference) {
+  private final class DescriptorIdentityListener implements IdentityChangeListener {
+
+    @Override
+    public void onBeforeIdentityChange(Object source) {
+    }
+
+    @Override
+    public void onAfterIdentityChange(Object source) {
+      if (source instanceof RID descriptorIdentity && descriptorIdentity.isPersistent()) {
+        publishDescriptorIdentity(descriptorIdentity);
+      }
+    }
   }
 
   @Override
@@ -760,7 +832,7 @@ public abstract class IndexAbstract implements Index {
     acquireExclusiveLock();
     try {
       try {
-        if (indexId >= 0) {
+        if (state().hasEngine()) {
           session.executeInTxInternal(transaction -> {
             // Same explicit unlink + suppressed tracker as delete(): the old index record may
             // be bag-less (commit-created), so the tracked deletion arm cannot auto-clean the
@@ -771,9 +843,10 @@ public abstract class IndexAbstract implements Index {
             final var priorLinkConsistency = session.isLinkConsistencyEnabled();
             session.disableLinkConsistencyCheck();
             try {
-              if (identity != null) {
+              final var descriptorIdentity = state().descriptorIdentity();
+              if (descriptorIdentity != null) {
                 session.getSharedContext().getIndexManager()
-                    .unlinkIndexRecord(transaction, identity);
+                    .unlinkIndexRecord(transaction, descriptorIdentity);
               }
               doDelete(transaction);
             } finally {
@@ -787,19 +860,19 @@ public abstract class IndexAbstract implements Index {
         LogManager.instance().error(this, "Error during index '%s' delete", e, im.getName());
       }
 
-      final var oldDescriptorIdentity = identity;
+      final var oldDescriptorIdentity = state().descriptorIdentity();
       if (oldDescriptorIdentity != null) {
         storage.removeIndexLifecycle(oldDescriptorIdentity);
       }
-      identityAttachment = null;
+      publishEngineDetached(true);
 
-      // Clear the deleted descriptor before publishing the replacement engine identifier. This
-      // prevents any observer from pairing the new engine with the old durable identity.
-      identity = null;
       Map<String, String> engineProperties = new HashMap<>();
-      indexId = storage.addIndexEngine(im, engineProperties);
+      final var engineIdentifier = storage.addIndexEngine(im, engineProperties);
+      // The replacement and identity clear are one publication. A failed add leaves the stale
+      // durable identity visible, so reads fail closed instead of returning an empty result.
+      publishReplacementEngineAndClearIdentity(engineIdentifier);
 
-      onIndexEngineChange(session, indexId);
+      onIndexEngineChange(session, state());
 
       // The old metadata entity was deleted by doDelete() above. save() now creates a fresh entity
       // and registers it in the IndexManager's CONFIG_INDEXES link set, so the index survives crash
@@ -812,8 +885,9 @@ public abstract class IndexAbstract implements Index {
       attachDescriptorIdentityLocked();
     } catch (Exception e) {
       try {
-        if (indexId >= 0) {
-          storage.clearIndex(indexId);
+        final var current = state();
+        if (current.hasEngine()) {
+          storage.clearIndex(current.engineIdentifier());
         }
       } catch (Exception e2) {
         LogManager.instance().error(this, "Error during index rebuild", e2);
@@ -855,7 +929,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(indexId);
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var mgr = btreeEngine.getHistogramManager();
           if (mgr != null) {
@@ -867,7 +941,7 @@ public abstract class IndexAbstract implements Index {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -890,7 +964,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(indexId);
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           if (btreeEngine.getHistogramManager() != null) {
             try {
@@ -913,7 +987,7 @@ public abstract class IndexAbstract implements Index {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -929,20 +1003,21 @@ public abstract class IndexAbstract implements Index {
       LogManager.instance().error(this, "Error during index rebuild", e);
       var clearSucceeded = false;
       try {
-        if (indexId >= 0) {
-          storage.clearIndex(indexId);
+        final var current = state();
+        if (current.hasEngine()) {
+          storage.clearIndex(current.engineIdentifier());
           clearSucceeded = true;
         }
       } catch (Exception e2) {
         LogManager.instance().error(this,
             "Error during clearIndex after failed rebuild of index '%s' (id=%d)",
-            e2, im.getName(), indexId);
+            e2, im.getName(), state().engineIdentifier());
         // IGNORE EXCEPTION: IF THE REBUILD WAS LAUNCHED IN CASE OF RID INVALID CLEAR ALWAYS GOES IN
         // ERROR
       }
       LogManager.instance().info(this,
           "fillIndex failed for '%s' (id=%d): clearIndex %s. Cause: %s",
-          im.getName(), indexId,
+          im.getName(), state().engineIdentifier(),
           clearSucceeded ? "succeeded" : "FAILED or skipped",
           e.getClass().getSimpleName());
 
@@ -1022,7 +1097,7 @@ public abstract class IndexAbstract implements Index {
       DatabaseSessionEmbedded session)
       throws InvalidIndexEngineIdException {
     var tx = session.getActiveTransaction();
-    return storage.removeKeyFromIndex(indexId, key, tx.getAtomicOperation());
+    return storage.removeKeyFromIndex(state().engineIdentifier(), key, tx.getAtomicOperation());
   }
 
   @Override
@@ -1046,8 +1121,10 @@ public abstract class IndexAbstract implements Index {
       final var priorLinkConsistency = session.isLinkConsistencyEnabled();
       session.disableLinkConsistencyCheck();
       try {
-        if (identity != null) {
-          session.getSharedContext().getIndexManager().unlinkIndexRecord(transaction, identity);
+        final var descriptorIdentity = state().descriptorIdentity();
+        if (descriptorIdentity != null) {
+          session.getSharedContext().getIndexManager()
+              .unlinkIndexRecord(transaction, descriptorIdentity);
         }
         doDelete(transaction);
       } finally {
@@ -1078,19 +1155,22 @@ public abstract class IndexAbstract implements Index {
           // Just log errors of removing keys while dropping and keep dropping
         }
 
-        storage.deleteIndexEngine(indexId);
+        storage.deleteIndexEngine(state().engineIdentifier());
+        publishEngineDetached(false);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
 
-    var entity = transaction.loadEntity(identity);
-    entity.delete();
+    final var descriptorIdentity = state().descriptorIdentity();
+    if (descriptorIdentity != null) {
+      transaction.loadEntity(descriptorIdentity).delete();
+    }
   }
 
   private void clearAllEntries(DatabaseSessionEmbedded session) {
@@ -1266,10 +1346,11 @@ public abstract class IndexAbstract implements Index {
    */
   private void saveFrom(final IndexMetadata source, FrontendTransaction transaction) {
     Entity entity;
-    if (identity == null) {
+    final var descriptorIdentity = state().descriptorIdentity();
+    if (descriptorIdentity == null) {
       entity = transaction.getDatabaseSession().newInternalInstance();
     } else {
-      entity = transaction.loadEntity(identity);
+      entity = transaction.loadEntity(descriptorIdentity);
     }
 
     entity.setString(CONFIG_TYPE, source.getType());
@@ -1291,7 +1372,7 @@ public abstract class IndexAbstract implements Index {
       entity.setEmbeddedMap(METADATA, session.newEmbeddedMap(source.getMetadata()));
     }
 
-    identity = entity.getIdentity();
+    publishDescriptorIdentity(entity.getIdentity());
   }
 
   /**
@@ -1333,7 +1414,7 @@ public abstract class IndexAbstract implements Index {
         map.put(METADATA, session.newEmbeddedMap(im.getMetadata()));
       }
 
-      map.put(EntityHelper.ATTRIBUTE_RID, identity);
+      map.put(EntityHelper.ATTRIBUTE_RID, state().descriptorIdentity());
       return map;
     } finally {
       releaseSharedLock();
@@ -1381,12 +1462,12 @@ public abstract class IndexAbstract implements Index {
       boolean recovered = false;
       while (true) {
         try {
-          return storage.getIndexKeyStream(indexId, operation);
+          return storage.getIndexKeyStream(state().engineIdentifier(), operation);
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
             throw staleAfterOwnerRecovery();
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -1429,7 +1510,7 @@ public abstract class IndexAbstract implements Index {
 
   @Override
   public int getIndexId() {
-    return indexId;
+    return state().engineIdentifier();
   }
 
   @Override
@@ -1463,13 +1544,13 @@ public abstract class IndexAbstract implements Index {
 
     while (true) {
       try {
-        engine = storage.getIndexEngineWithStateLock(indexId);
+        engine = storage.getIndexEngineWithStateLock(state().engineIdentifier());
         break;
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifierWithStateLock();
+        resolveOwnedEngineWithStateLock();
         recovered = true;
       }
     }
@@ -1482,13 +1563,13 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(indexId);
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         return engine.getStatistics();
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -1499,13 +1580,13 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(indexId);
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         return engine.getHistogram();
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -1516,7 +1597,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(indexId);
+        var engine = storage.getIndexEngine(state().engineIdentifier());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var manager = btreeEngine.getHistogramManager();
           if (manager != null) {
@@ -1528,7 +1609,7 @@ public abstract class IndexAbstract implements Index {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        resolveOwnedEngineIdentifier();
+        resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -1608,14 +1689,15 @@ public abstract class IndexAbstract implements Index {
     rwLock.readLock().lock();
   }
 
-  protected void onIndexEngineChange(DatabaseSessionEmbedded session, final int indexId) {
-    int currentIndexId = indexId;
+  protected void onIndexEngineChange(
+      DatabaseSessionEmbedded session, IndexHandleState initialState) {
+    var current = initialState;
     boolean recovered = false;
     while (true) {
       try {
         storage.callIndexEngine(
             false,
-            currentIndexId,
+            current.engineIdentifier(),
             engine -> {
               engine.init(session, im);
               return null;
@@ -1625,7 +1707,7 @@ public abstract class IndexAbstract implements Index {
         if (recovered) {
           throw staleAfterOwnerRecovery();
         }
-        currentIndexId = resolveOwnedEngineIdentifier();
+        current = resolveOwnedEngine();
         recovered = true;
       }
     }
@@ -1635,7 +1717,7 @@ public abstract class IndexAbstract implements Index {
     return new StaleIndexEngineException(
         storage.getName(),
         "Index '" + getName() + "' remained stale after owner-bound recovery for descriptor "
-            + identity);
+            + state().descriptorIdentity());
   }
 
   /**
@@ -1740,6 +1822,6 @@ public abstract class IndexAbstract implements Index {
 
   @Nullable @Override
   public RID getIdentity() {
-    return identity;
+    return state().descriptorIdentity();
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -34,6 +34,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysGreaterKey;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysLessKey;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
@@ -565,6 +566,48 @@ public abstract class IndexAbstract implements Index {
     } finally {
       releaseExclusiveLock();
     }
+  }
+
+  protected final int resolveOwnedEngineIdentifier() {
+    final var descriptorIdentity = identity;
+    if (descriptorIdentity == null) {
+      throw new StaleIndexEngineException(
+          storage.getName(),
+          "Cannot recover index '" + getName() + "' for descriptor null: the handle has no owner");
+    }
+
+    final int resolvedIdentifier;
+    try {
+      resolvedIdentifier = storage.resolveIndexEngineByOwner(descriptorIdentity);
+    } catch (StaleIndexEngineException exception) {
+      throw new StaleIndexEngineException(
+          storage.getName(),
+          "Cannot recover index '" + getName() + "' for descriptor " + descriptorIdentity
+              + ": no registered engine has that owner");
+    }
+    indexId = resolvedIdentifier;
+    return resolvedIdentifier;
+  }
+
+  private int resolveOwnedEngineIdentifierWithStateLock() {
+    final var descriptorIdentity = identity;
+    if (descriptorIdentity == null) {
+      throw new StaleIndexEngineException(
+          storage.getName(),
+          "Cannot recover index '" + getName() + "' for descriptor null: the handle has no owner");
+    }
+
+    final int resolvedIdentifier;
+    try {
+      resolvedIdentifier = storage.resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
+    } catch (StaleIndexEngineException exception) {
+      throw new StaleIndexEngineException(
+          storage.getName(),
+          "Cannot recover index '" + getName() + "' for descriptor " + descriptorIdentity
+              + ": no registered engine has that owner");
+    }
+    indexId = resolvedIdentifier;
+    return resolvedIdentifier;
   }
 
   protected void doReloadIndexEngine() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -87,8 +87,7 @@ public abstract class IndexAbstract implements Index {
   private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
 
   protected volatile int indexId = -1;
-  @Nullable private volatile IndexEngineReference engineReference;
-  @Nullable private volatile IndexLifecycleCell lifecycleCell;
+  @Nullable private volatile IdentityAttachment identityAttachment;
 
   @Nonnull
   protected Set<String> collectionsToIndex = new HashSet<>();
@@ -210,7 +209,7 @@ public abstract class IndexAbstract implements Index {
       onIndexEngineChange(transaction.getDatabaseSession(), indexId);
 
       save(transaction);
-      attachDescriptorIdentity();
+      attachDescriptorIdentityLocked();
     } catch (Exception e) {
       LogManager.instance().error(this, "Exception during index '%s' creation", e, im.getName());
       // index is created inside of storage
@@ -561,7 +560,7 @@ public abstract class IndexAbstract implements Index {
       // the recorded ids, so recording only after a fully-successful build would leave such a
       // failure's engine behind as a phantom registration no revert arm ever removes.
       createdEngineExternalIds.add(indexId);
-      attachDescriptorIdentity();
+      attachDescriptorIdentityLocked();
       onIndexEngineChange(transaction.getDatabaseSession(), indexId);
     } finally {
       releaseExclusiveLock();
@@ -604,29 +603,74 @@ public abstract class IndexAbstract implements Index {
       throw new IllegalStateException("Index " + im.getName() + " can not be loaded");
     }
 
-    attachDescriptorIdentity();
+    attachDescriptorIdentityLocked();
     onIndexEngineChange(transaction.getDatabaseSession(), indexId);
   }
 
   void attachDescriptorIdentity() {
-    if (identity == null || !identity.isPersistent()) {
+    acquireExclusiveLock();
+    try {
+      attachDescriptorIdentityLocked();
+    } finally {
+      releaseExclusiveLock();
+    }
+  }
+
+  private void attachDescriptorIdentityLocked() {
+    if (!rwLock.isWriteLockedByCurrentThread()) {
+      throw new IllegalStateException("Index identity attachment requires the handle write lock");
+    }
+
+    final var descriptorIdentity = identity;
+    final var engineIdentifier = indexId;
+    if (descriptorIdentity == null || !descriptorIdentity.isPersistent() || engineIdentifier < 0) {
       return;
     }
 
-    lifecycleCell = storage.getOrCreateIndexLifecycle(identity);
-    if (indexId >= 0) {
-      engineReference = storage.bindIndexEngineToDescriptor(indexId, identity);
+    final var currentAttachment = identityAttachment;
+    if (currentAttachment != null
+        && currentAttachment.descriptorIdentity().equals(descriptorIdentity)
+        && currentAttachment.engineReference().slot()
+            == AbstractStorage.extractInternalId(engineIdentifier)) {
+      return;
+    }
+
+    final var expectedReference = storage.getIndexEngineReference(engineIdentifier);
+    final var boundReference = storage.bindIndexEngineToDescriptor(
+        engineIdentifier, descriptorIdentity, expectedReference);
+    final var lifecycleCell = storage.getOrCreateIndexLifecycle(descriptorIdentity);
+    identityAttachment =
+        new IdentityAttachment(descriptorIdentity, lifecycleCell, boundReference);
+  }
+
+  @Nullable IndexLifecycleCell getLifecycleCell() {
+    final var attachment = identityAttachment;
+    return attachment == null ? null : attachment.lifecycleCell();
+  }
+
+  @Nullable IndexEngineReference getEngineReference() {
+    final var attachment = identityAttachment;
+    return attachment == null ? null : attachment.engineReference();
+  }
+
+  void removeLifecycleRegistration() {
+    acquireExclusiveLock();
+    try {
+      final var attachment = identityAttachment;
+      final var descriptorIdentity =
+          attachment == null ? identity : attachment.descriptorIdentity();
+      if (descriptorIdentity != null && descriptorIdentity.isPersistent()) {
+        storage.removeIndexLifecycle(descriptorIdentity);
+      }
+    } finally {
+      releaseExclusiveLock();
     }
   }
 
-  IndexLifecycleCell getLifecycleCell() {
-    attachDescriptorIdentity();
-    return lifecycleCell;
-  }
-
-  IndexEngineReference getEngineReference() {
-    attachDescriptorIdentity();
-    return engineReference;
+  private record IdentityAttachment(
+      RID descriptorIdentity,
+      IndexLifecycleCell lifecycleCell,
+      IndexEngineReference engineReference) {
   }
 
   @Override
@@ -702,22 +746,29 @@ public abstract class IndexAbstract implements Index {
         LogManager.instance().error(this, "Error during index '%s' delete", e, im.getName());
       }
 
+      final var oldDescriptorIdentity = identity;
+      if (oldDescriptorIdentity != null) {
+        storage.removeIndexLifecycle(oldDescriptorIdentity);
+      }
+      identityAttachment = null;
+
+      // Clear the deleted descriptor before publishing the replacement engine identifier. This
+      // prevents any observer from pairing the new engine with the old durable identity.
+      identity = null;
       Map<String, String> engineProperties = new HashMap<>();
       indexId = storage.addIndexEngine(im, engineProperties);
 
       onIndexEngineChange(session, indexId);
 
-      // The old metadata entity was deleted by doDelete() above. Reset identity
-      // so save() creates a fresh entity instead of trying to update the deleted one.
-      // Then persist the metadata and register it in the IndexManager's CONFIG_INDEXES
-      // link set, so the index survives crash + WAL replay.
-      identity = null;
+      // The old metadata entity was deleted by doDelete() above. save() now creates a fresh entity
+      // and registers it in the IndexManager's CONFIG_INDEXES link set, so the index survives crash
+      // and WAL replay.
       session.executeInTxInternal(tx -> {
         save(tx);
         session.getSharedContext().getIndexManager()
             .addIndexInternal(session, tx, this, true);
       });
-      attachDescriptorIdentity();
+      attachDescriptorIdentityLocked();
     } catch (Exception e) {
       try {
         if (indexId >= 0) {
@@ -1317,9 +1368,6 @@ public abstract class IndexAbstract implements Index {
 
   @Override
   public int getIndexId() {
-    // Newly created descriptor RIDs become persistent after their creating transaction applies.
-    // Attach before the first writer can dereference the engine through this identifier.
-    attachDescriptorIdentity();
     return indexId;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -39,8 +39,10 @@ import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysLessKey;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.EquiDepthHistogram;
 import com.jetbrains.youtrackdb.internal.core.index.engine.HistogramSnapshot;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexStatistics;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityHelper;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
@@ -85,6 +87,8 @@ public abstract class IndexAbstract implements Index {
   private final ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock();
 
   protected volatile int indexId = -1;
+  @Nullable private volatile IndexEngineReference engineReference;
+  @Nullable private volatile IndexLifecycleCell lifecycleCell;
 
   @Nonnull
   protected Set<String> collectionsToIndex = new HashSet<>();
@@ -206,6 +210,7 @@ public abstract class IndexAbstract implements Index {
       onIndexEngineChange(transaction.getDatabaseSession(), indexId);
 
       save(transaction);
+      attachDescriptorIdentity();
     } catch (Exception e) {
       LogManager.instance().error(this, "Exception during index '%s' creation", e, im.getName());
       // index is created inside of storage
@@ -556,6 +561,7 @@ public abstract class IndexAbstract implements Index {
       // the recorded ids, so recording only after a fully-successful build would leave such a
       // failure's engine behind as a phantom registration no revert arm ever removes.
       createdEngineExternalIds.add(indexId);
+      attachDescriptorIdentity();
       onIndexEngineChange(transaction.getDatabaseSession(), indexId);
     } finally {
       releaseExclusiveLock();
@@ -598,7 +604,29 @@ public abstract class IndexAbstract implements Index {
       throw new IllegalStateException("Index " + im.getName() + " can not be loaded");
     }
 
+    attachDescriptorIdentity();
     onIndexEngineChange(transaction.getDatabaseSession(), indexId);
+  }
+
+  void attachDescriptorIdentity() {
+    if (identity == null || !identity.isPersistent()) {
+      return;
+    }
+
+    lifecycleCell = storage.getOrCreateIndexLifecycle(identity);
+    if (indexId >= 0) {
+      engineReference = storage.bindIndexEngineToDescriptor(indexId, identity);
+    }
+  }
+
+  IndexLifecycleCell getLifecycleCell() {
+    attachDescriptorIdentity();
+    return lifecycleCell;
+  }
+
+  IndexEngineReference getEngineReference() {
+    attachDescriptorIdentity();
+    return engineReference;
   }
 
   @Override
@@ -689,6 +717,7 @@ public abstract class IndexAbstract implements Index {
         session.getSharedContext().getIndexManager()
             .addIndexInternal(session, tx, this, true);
       });
+      attachDescriptorIdentity();
     } catch (Exception e) {
       try {
         if (indexId >= 0) {
@@ -1288,6 +1317,9 @@ public abstract class IndexAbstract implements Index {
 
   @Override
   public int getIndexId() {
+    // Newly created descriptor RIDs become persistent after their creating transaction applies.
+    // Attach before the first writer can dereference the engine through this identifier.
+    attachDescriptorIdentity();
     return indexId;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -568,6 +568,14 @@ public abstract class IndexAbstract implements Index {
     }
   }
 
+  /**
+   * Resolves this handle through its descriptor owner instead of its reusable index name.
+   *
+   * <p>Recovery fails closed while index creation has not saved the descriptor, while rebuild has
+   * cleared the descriptor identity, and while manager publication precedes descriptor attachment.
+   * An engine published before its owner binding also cannot be recovered. Track 20 closes these
+   * ownerless and unbound publication windows.
+   */
   protected final int resolveOwnedEngineIdentifier() {
     final var descriptorIdentity = identity;
     if (descriptorIdentity == null) {
@@ -608,22 +616,6 @@ public abstract class IndexAbstract implements Index {
     }
     indexId = resolvedIdentifier;
     return resolvedIdentifier;
-  }
-
-  protected void doReloadIndexEngine() {
-    indexId = storage.loadIndexEngine(im.getName());
-    checkReloadedIndexId();
-  }
-
-  private void doReloadIndexEngineWithStateLock() {
-    indexId = storage.loadIndexEngineWithStateLock(im.getName());
-    checkReloadedIndexId();
-  }
-
-  private void checkReloadedIndexId() {
-    if (indexId < 0) {
-      throw new IllegalStateException("Index " + im.getName() + " can not be loaded");
-    }
   }
 
   private void load(FrontendTransactionImpl transaction) {
@@ -860,6 +852,7 @@ public abstract class IndexAbstract implements Index {
    * overhead from N individual findBucket() calls during population.
    */
   private void setBulkLoading(boolean bulkLoading) {
+    boolean recovered = false;
     while (true) {
       try {
         var engine = storage.getIndexEngine(indexId);
@@ -871,7 +864,11 @@ public abstract class IndexAbstract implements Index {
         }
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
   }
@@ -890,6 +887,7 @@ public abstract class IndexAbstract implements Index {
    * and require a valid commit timestamp for WAL record emission.
    */
   private void buildHistogramAfterFill() {
+    boolean recovered = false;
     while (true) {
       try {
         var engine = storage.getIndexEngine(indexId);
@@ -912,7 +910,11 @@ public abstract class IndexAbstract implements Index {
         }
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
   }
@@ -1064,6 +1066,7 @@ public abstract class IndexAbstract implements Index {
   }
 
   protected void doDelete(FrontendTransaction transaction) {
+    boolean recovered = false;
     while (true) {
       try {
         try {
@@ -1078,7 +1081,11 @@ public abstract class IndexAbstract implements Index {
         storage.deleteIndexEngine(indexId);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
 
@@ -1371,11 +1378,16 @@ public abstract class IndexAbstract implements Index {
   public Stream<Object> keyStream(@Nonnull AtomicOperation operation) {
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           return storage.getIndexKeyStream(indexId, operation);
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw staleAfterOwnerRecovery();
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -1447,13 +1459,18 @@ public abstract class IndexAbstract implements Index {
   @Override
   public boolean acquireAtomicExclusiveLock(AtomicOperation atomicOperation) {
     BaseIndexEngine engine;
+    boolean recovered = false;
 
     while (true) {
       try {
         engine = storage.getIndexEngineWithStateLock(indexId);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngineWithStateLock();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifierWithStateLock();
+        recovered = true;
       }
     }
 
@@ -1462,30 +1479,41 @@ public abstract class IndexAbstract implements Index {
 
   @Nullable @Override
   public IndexStatistics getStatistics(DatabaseSessionEmbedded session) {
+    boolean recovered = false;
     while (true) {
       try {
         var engine = storage.getIndexEngine(indexId);
         return engine.getStatistics();
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
   }
 
   @Nullable @Override
   public EquiDepthHistogram getHistogram(DatabaseSessionEmbedded session) {
+    boolean recovered = false;
     while (true) {
       try {
         var engine = storage.getIndexEngine(indexId);
         return engine.getHistogram();
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
   }
 
   @Nullable @Override
   public HistogramSnapshot analyzeHistogram(DatabaseSessionEmbedded session) {
+    boolean recovered = false;
     while (true) {
       try {
         var engine = storage.getIndexEngine(indexId);
@@ -1497,7 +1525,11 @@ public abstract class IndexAbstract implements Index {
         }
         return null;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
   }
@@ -1577,20 +1609,33 @@ public abstract class IndexAbstract implements Index {
   }
 
   protected void onIndexEngineChange(DatabaseSessionEmbedded session, final int indexId) {
+    int currentIndexId = indexId;
+    boolean recovered = false;
     while (true) {
       try {
         storage.callIndexEngine(
             false,
-            indexId,
+            currentIndexId,
             engine -> {
               engine.init(session, im);
               return null;
             });
         break;
       } catch (InvalidIndexEngineIdException ignore) {
-        doReloadIndexEngine();
+        if (recovered) {
+          throw staleAfterOwnerRecovery();
+        }
+        currentIndexId = resolveOwnedEngineIdentifier();
+        recovered = true;
       }
     }
+  }
+
+  private StaleIndexEngineException staleAfterOwnerRecovery() {
+    return new StaleIndexEngineException(
+        storage.getName(),
+        "Index '" + getName() + "' remained stale after owner-bound recovery for descriptor "
+            + identity);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -586,7 +586,8 @@ public abstract class IndexAbstract implements Index {
 
     final int resolvedIdentifier;
     try {
-      resolvedIdentifier = storage.resolveIndexEngineByOwner(descriptorIdentity);
+      resolvedIdentifier =
+          storage.resolveIndexEngineByOwner(descriptorIdentity).engineIdentifier();
     } catch (StaleIndexEngineException exception) {
       throw new StaleIndexEngineException(
           storage.getName(),
@@ -607,7 +608,8 @@ public abstract class IndexAbstract implements Index {
 
     final int resolvedIdentifier;
     try {
-      resolvedIdentifier = storage.resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
+      resolvedIdentifier =
+          storage.resolveIndexEngineByOwnerWithStateLock(descriptorIdentity).engineIdentifier();
     } catch (StaleIndexEngineException exception) {
       throw new StaleIndexEngineException(
           storage.getName(),
@@ -670,7 +672,7 @@ public abstract class IndexAbstract implements Index {
       return;
     }
 
-    final var boundReference = storage.bindIndexEngineToDescriptor(
+    final var boundReference = storage.attachIndexEngineOwner(
         engineIdentifier, descriptorIdentity, currentReference);
     final var lifecycleCell = storage.getOrCreateIndexLifecycle(descriptorIdentity);
     identityAttachment =
@@ -678,10 +680,8 @@ public abstract class IndexAbstract implements Index {
   }
 
   private static boolean referencesSameEngine(
-      IndexEngineReference first, IndexEngineReference second) {
-    return first.slot() == second.slot()
-        && first.apiVersion() == second.apiVersion()
-        && first.generation() == second.generation();
+      @Nullable IndexEngineReference first, @Nullable IndexEngineReference second) {
+    return first == second;
   }
 
   @Nullable IndexLifecycleCell getLifecycleCell() {
@@ -711,7 +711,7 @@ public abstract class IndexAbstract implements Index {
   private record IdentityAttachment(
       RID descriptorIdentity,
       IndexLifecycleCell lifecycleCell,
-      IndexEngineReference engineReference) {
+      @Nullable IndexEngineReference engineReference) {
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -631,6 +631,15 @@ public abstract class IndexAbstract implements Index {
     return true;
   }
 
+  protected final IndexHandleState engineStateForRead() {
+    final var current = state();
+    if (isNeverBuilt(current)) {
+      throw new StaleIndexEngineException(
+          storage.getName(), "Index '" + getName() + "' has not built its engine yet");
+    }
+    return current;
+  }
+
   void setHandleStateForTest(
       int engineIdentifier, @Nullable RID descriptorIdentity) {
     handleState.set(new IndexHandleState(engineIdentifier, null, descriptorIdentity, null));
@@ -638,14 +647,13 @@ public abstract class IndexAbstract implements Index {
 
   void setEngineIdentifierForTest(int engineIdentifier) {
     updateState(current -> new IndexHandleState(
-        engineIdentifier, current.engineReference(), current.descriptorIdentity(),
-        current.lifecycleCell()));
+        engineIdentifier, null, current.descriptorIdentity(), current.lifecycleCell()));
   }
 
   void setDescriptorIdentityForTest(@Nullable RID descriptorIdentity) {
     updateState(current -> new IndexHandleState(
         current.engineIdentifier(), current.engineReference(), descriptorIdentity,
-        descriptorIdentity != null && descriptorIdentity.isPersistent()
+        descriptorIdentity != null && descriptorIdentity.equals(current.descriptorIdentity())
             ? current.lifecycleCell()
             : null));
   }
@@ -979,7 +987,7 @@ public abstract class IndexAbstract implements Index {
       try {
         final var current = state();
         if (current.hasEngine()) {
-          storage.clearIndex(current.engineIdentifier());
+          storage.clearIndex(current.engineIdentifier(), current.engineReference());
         }
       } catch (Exception e2) {
         LogManager.instance().error(this, "Error during index rebuild", e2);
@@ -1021,7 +1029,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(engineIdentifierForRebuildTail());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var mgr = btreeEngine.getHistogramManager();
           if (mgr != null) {
@@ -1052,11 +1060,20 @@ public abstract class IndexAbstract implements Index {
    * B-tree writes inside {@code buildInitialHistogram} happen immediately
    * and require a valid commit timestamp for WAL record emission.
    */
+  private int engineIdentifierForRebuildTail() {
+    final var current = state();
+    if (!current.hasEngine()) {
+      throw new StaleIndexEngineException(
+          storage.getName(), "Index '" + getName() + "' became detached during rebuild");
+    }
+    return current.engineIdentifier();
+  }
+
   private void buildHistogramAfterFill() {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(engineIdentifierForRebuildTail());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           if (btreeEngine.getHistogramManager() != null) {
             try {
@@ -1097,7 +1114,7 @@ public abstract class IndexAbstract implements Index {
       try {
         final var current = state();
         if (current.hasEngine()) {
-          storage.clearIndex(current.engineIdentifier());
+          storage.clearIndex(current.engineIdentifier(), current.engineReference());
           clearSucceeded = true;
         }
       } catch (Exception e2) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -785,6 +785,12 @@ public abstract class IndexAbstract implements Index {
     }
   }
 
+  void removeLifecycleRegistrationIfDetached() {
+    if (!state().hasEngine()) {
+      removeLifecycleRegistration();
+    }
+  }
+
   private final class DescriptorIdentityListener implements IdentityChangeListener {
 
     @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -627,20 +627,26 @@ public abstract class IndexAbstract implements Index {
       return;
     }
 
+    final var currentReference = storage.getIndexEngineReference(engineIdentifier);
     final var currentAttachment = identityAttachment;
     if (currentAttachment != null
         && currentAttachment.descriptorIdentity().equals(descriptorIdentity)
-        && currentAttachment.engineReference().slot()
-            == AbstractStorage.extractInternalId(engineIdentifier)) {
+        && referencesSameEngine(currentAttachment.engineReference(), currentReference)) {
       return;
     }
 
-    final var expectedReference = storage.getIndexEngineReference(engineIdentifier);
     final var boundReference = storage.bindIndexEngineToDescriptor(
-        engineIdentifier, descriptorIdentity, expectedReference);
+        engineIdentifier, descriptorIdentity, currentReference);
     final var lifecycleCell = storage.getOrCreateIndexLifecycle(descriptorIdentity);
     identityAttachment =
         new IdentityAttachment(descriptorIdentity, lifecycleCell, boundReference);
+  }
+
+  private static boolean referencesSameEngine(
+      IndexEngineReference first, IndexEngineReference second) {
+    return first.slot() == second.slot()
+        && first.apiVersion() == second.apiVersion()
+        && first.generation() == second.generation();
   }
 
   @Nullable IndexLifecycleCell getLifecycleCell() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -669,7 +669,10 @@ public abstract class IndexAbstract implements Index {
     var current = state();
     for (var attempt = 0; attempt < 3; attempt++) {
       if (!current.hasEngine()) {
-        isNeverBuilt(current);
+        if (isNeverBuilt(current)) {
+          throw new StaleIndexEngineException(
+              storage.getName(), "Index '" + getName() + "' has not built its engine yet");
+        }
       }
       try {
         return operation.apply(current);
@@ -691,7 +694,10 @@ public abstract class IndexAbstract implements Index {
     var current = state();
     for (var attempt = 0; attempt < 3; attempt++) {
       if (!current.hasEngine()) {
-        isNeverBuilt(current);
+        if (isNeverBuilt(current)) {
+          throw new StaleIndexEngineException(
+              storage.getName(), "Index '" + getName() + "' has not built its engine yet");
+        }
       }
       try {
         return operation.apply(current);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -620,6 +620,19 @@ public abstract class IndexAbstract implements Index {
     return handleState.get();
   }
 
+  protected final boolean isNeverBuilt(IndexHandleState current) {
+    if (current.hasEngine()) {
+      return false;
+    }
+    if (current.isDurablyIdentified()) {
+      throw new StaleIndexEngineException(
+          storage.getName(),
+          "Index '" + getName() + "' has no engine for descriptor "
+              + current.descriptorIdentity());
+    }
+    return true;
+  }
+
   public void setHandleStateForTest(
       int engineIdentifier, @Nullable RID descriptorIdentity) {
     handleState.set(new IndexHandleState(engineIdentifier, null, descriptorIdentity, null));
@@ -754,7 +767,7 @@ public abstract class IndexAbstract implements Index {
     return state().lifecycleCell();
   }
 
-  @Nullable IndexEngineReference getEngineReference() {
+  @Nullable public IndexEngineReference getEngineReference() {
     return state().engineReference();
   }
 
@@ -929,7 +942,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var mgr = btreeEngine.getHistogramManager();
           if (mgr != null) {
@@ -964,7 +977,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           if (btreeEngine.getHistogramManager() != null) {
             try {
@@ -1097,7 +1110,8 @@ public abstract class IndexAbstract implements Index {
       DatabaseSessionEmbedded session)
       throws InvalidIndexEngineIdException {
     var tx = session.getActiveTransaction();
-    return storage.removeKeyFromIndex(state().engineIdentifier(), key, tx.getAtomicOperation());
+    return storage.removeKeyFromIndex(state().engineIdentifier(), state().engineReference(), key,
+        tx.getAtomicOperation());
   }
 
   @Override
@@ -1155,7 +1169,8 @@ public abstract class IndexAbstract implements Index {
           // Just log errors of removing keys while dropping and keep dropping
         }
 
-        storage.deleteIndexEngine(state().engineIdentifier());
+        final var current = state();
+        storage.deleteIndexEngine(current.engineIdentifier(), current.engineReference());
         publishEngineDetached(false);
         break;
       } catch (InvalidIndexEngineIdException ignore) {
@@ -1462,7 +1477,8 @@ public abstract class IndexAbstract implements Index {
       boolean recovered = false;
       while (true) {
         try {
-          return storage.getIndexKeyStream(state().engineIdentifier(), operation);
+          return storage.getIndexKeyStream(state().engineIdentifier(), state().engineReference(),
+              operation);
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
             throw staleAfterOwnerRecovery();
@@ -1544,7 +1560,8 @@ public abstract class IndexAbstract implements Index {
 
     while (true) {
       try {
-        engine = storage.getIndexEngineWithStateLock(state().engineIdentifier());
+        engine = storage.getIndexEngineWithStateLock(
+            state().engineIdentifier(), state().engineReference());
         break;
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
@@ -1563,7 +1580,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
         return engine.getStatistics();
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
@@ -1580,7 +1597,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
         return engine.getHistogram();
       } catch (InvalidIndexEngineIdException ignore) {
         if (recovered) {
@@ -1597,7 +1614,7 @@ public abstract class IndexAbstract implements Index {
     boolean recovered = false;
     while (true) {
       try {
-        var engine = storage.getIndexEngine(state().engineIdentifier());
+        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
         if (engine instanceof BTreeIndexEngine btreeEngine) {
           var manager = btreeEngine.getHistogramManager();
           if (manager != null) {
@@ -1698,6 +1715,7 @@ public abstract class IndexAbstract implements Index {
         storage.callIndexEngine(
             false,
             current.engineIdentifier(),
+            current.engineReference(),
             engine -> {
               engine.init(session, im);
               return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -40,7 +40,6 @@ import com.jetbrains.youtrackdb.internal.core.id.IdentityChangeListener;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysGreaterKey;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysLessKey;
-import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.EquiDepthHistogram;
 import com.jetbrains.youtrackdb.internal.core.index.engine.HistogramSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
@@ -96,6 +95,8 @@ public abstract class IndexAbstract implements Index {
       new AtomicReference<>(IndexHandleState.EMPTY);
   @Nonnull
   private final IdentityChangeListener identityChangeListener = new DescriptorIdentityListener();
+  @Nonnull
+  private final AtomicReference<ChangeableIdentity> identitySubscription = new AtomicReference<>();
 
   @Nonnull
   protected Set<String> collectionsToIndex = new HashSet<>();
@@ -238,13 +239,10 @@ public abstract class IndexAbstract implements Index {
   public void markDeferred(final IndexMetadata indexMetadata) {
     acquireExclusiveLock();
     try {
-      // A transaction-deferred create: record the definition so the handle answers metadata and
-      // size() queries on the public path, but do not build or load a storage engine. indexId
-      // stays -1 (unbuilt); the engine build and shared registration happen at commit. A deferred
-      // handle answers name/definition/collection queries, size() (zero), and value lookups
-      // (get()/getRids(), which short-circuit to no rids); any other engine-backed read (the range
-      // streams, statistics, the histogram) is unsupported until commit builds the engine, because
-      // indexId = -1 cannot be dereferenced by the storage layer.
+      // A transaction-deferred create records the definition without an engine. The carrier keeps
+      // its engine identifier at minus one until commit builds and registers the engine. Value
+      // lookups and size return empty results for this never-built shape. Other engine-backed reads
+      // remain unsupported until commit publishes the engine-bearing carrier.
       this.im = indexMetadata;
       var deferredCollections = indexMetadata.getCollectionsToIndex();
       this.collectionsToIndex =
@@ -541,7 +539,7 @@ public abstract class IndexAbstract implements Index {
    * created the source collections and after the record apply, with {@code stateLock.writeLock()}
    * held and the commit window open. It creates the engine through the storage's commit-window
    * primitive (which allocates a commit-local engine id and buffers the engine files as WAL-reverted
-   * intent), sets {@code indexId} to the built engine's id, and wires the engine.
+   * intent), publishes that engine in the handle carrier, and wires the engine.
    *
    * <p>The engine is created but not yet populated; {@link IndexManagerEmbedded} runs the final-state
    * re-derivation that feeds the transaction's own records into it right after this returns.
@@ -581,7 +579,7 @@ public abstract class IndexAbstract implements Index {
     return resolveOwnedEngine(false);
   }
 
-  private IndexHandleState resolveOwnedEngineWithStateLock() {
+  IndexHandleState resolveOwnedEngineWithStateLock() {
     return resolveOwnedEngine(true);
   }
 
@@ -633,19 +631,82 @@ public abstract class IndexAbstract implements Index {
     return true;
   }
 
-  public void setHandleStateForTest(
+  void setHandleStateForTest(
       int engineIdentifier, @Nullable RID descriptorIdentity) {
     handleState.set(new IndexHandleState(engineIdentifier, null, descriptorIdentity, null));
   }
 
-  public void setEngineIdentifierForTest(int engineIdentifier) {
-    final var current = state();
-    setHandleStateForTest(engineIdentifier, current.descriptorIdentity());
+  void setEngineIdentifierForTest(int engineIdentifier) {
+    updateState(current -> new IndexHandleState(
+        engineIdentifier, current.engineReference(), current.descriptorIdentity(),
+        current.lifecycleCell()));
   }
 
-  public void setDescriptorIdentityForTest(@Nullable RID descriptorIdentity) {
+  void setDescriptorIdentityForTest(@Nullable RID descriptorIdentity) {
+    updateState(current -> new IndexHandleState(
+        current.engineIdentifier(), current.engineReference(), descriptorIdentity,
+        descriptorIdentity != null && descriptorIdentity.isPersistent()
+            ? current.lifecycleCell()
+            : null));
+  }
+
+  public EngineSnapshot engineSnapshot() {
     final var current = state();
-    setHandleStateForTest(current.engineIdentifier(), descriptorIdentity);
+    return new EngineSnapshot(current.engineIdentifier(), current.engineReference());
+  }
+
+  public record EngineSnapshot(
+      int engineIdentifier, @Nullable IndexEngineReference engineReference) {
+  }
+
+  @FunctionalInterface
+  protected interface StateOperation<T> {
+
+    T apply(IndexHandleState current) throws InvalidIndexEngineIdException;
+  }
+
+  protected final <T> T withOwnedEngine(StateOperation<T> operation) {
+    var current = state();
+    for (var attempt = 0; attempt < 3; attempt++) {
+      if (!current.hasEngine()) {
+        isNeverBuilt(current);
+      }
+      try {
+        return operation.apply(current);
+      } catch (InvalidIndexEngineIdException exception) {
+        if (attempt == 2) {
+          throw staleAfterOwnerRecovery(current);
+        }
+        final var resolved = resolveOwnedEngine();
+        if (resolved == current) {
+          throw staleAfterOwnerRecovery(current);
+        }
+        current = resolved;
+      }
+    }
+    throw new AssertionError("Unreachable index engine retry state");
+  }
+
+  private <T> T withOwnedEngineAndStateLock(StateOperation<T> operation) {
+    var current = state();
+    for (var attempt = 0; attempt < 3; attempt++) {
+      if (!current.hasEngine()) {
+        isNeverBuilt(current);
+      }
+      try {
+        return operation.apply(current);
+      } catch (InvalidIndexEngineIdException exception) {
+        if (attempt == 2) {
+          throw staleAfterOwnerRecovery(current);
+        }
+        final var resolved = resolveOwnedEngineWithStateLock();
+        if (resolved == current) {
+          throw staleAfterOwnerRecovery(current);
+        }
+        current = resolved;
+      }
+    }
+    throw new AssertionError("Unreachable index engine retry state");
   }
 
   private void publishEngine(int engineIdentifier) {
@@ -671,7 +732,7 @@ public abstract class IndexAbstract implements Index {
     updateState(current -> {
       final var existing = current.descriptorIdentity();
       if (existing != null && existing.isPersistent()) {
-        if (existing.equals(publishedIdentity)) {
+        if (existing.equals(publishedIdentity) && !(existing instanceof ChangeableIdentity)) {
           return current;
         }
         if (current.lifecycleCell() != null || !publishedIdentity.isPersistent()) {
@@ -683,6 +744,7 @@ public abstract class IndexAbstract implements Index {
           current.lifecycleCell());
     });
     if (!descriptorIdentity.isPersistent() && descriptorIdentity instanceof ChangeableIdentity id) {
+      identitySubscription.set(id);
       id.addIdentityChangeListener(identityChangeListener);
     }
   }
@@ -691,7 +753,7 @@ public abstract class IndexAbstract implements Index {
     while (true) {
       final var current = state();
       final var replacement = update.apply(current);
-      if (replacement.equals(current) || handleState.compareAndSet(current, replacement)) {
+      if (replacement == current || handleState.compareAndSet(current, replacement)) {
         return;
       }
     }
@@ -755,11 +817,16 @@ public abstract class IndexAbstract implements Index {
       final var replacement = new IndexHandleState(
           current.engineIdentifier(), boundReference, durableIdentity, lifecycleCell);
       if (replacement.equals(current) || handleState.compareAndSet(current, replacement)) {
-        if (descriptorIdentity instanceof ChangeableIdentity changeableIdentity) {
-          changeableIdentity.removeIdentityChangeListener(identityChangeListener);
-        }
+        cancelDescriptorIdentitySubscription();
         return;
       }
+    }
+  }
+
+  private void cancelDescriptorIdentitySubscription() {
+    final var subscription = identitySubscription.getAndSet(null);
+    if (subscription != null) {
+      subscription.removeIdentityChangeListener(identityChangeListener);
     }
   }
 
@@ -767,7 +834,7 @@ public abstract class IndexAbstract implements Index {
     return state().lifecycleCell();
   }
 
-  @Nullable public IndexEngineReference getEngineReference() {
+  @Nullable IndexEngineReference getEngineReference() {
     return state().engineReference();
   }
 
@@ -1116,8 +1183,8 @@ public abstract class IndexAbstract implements Index {
       DatabaseSessionEmbedded session)
       throws InvalidIndexEngineIdException {
     var tx = session.getActiveTransaction();
-    return storage.removeKeyFromIndex(state().engineIdentifier(), state().engineReference(), key,
-        tx.getAtomicOperation());
+    return withOwnedEngine(current -> storage.removeKeyFromIndex(
+        current.engineIdentifier(), current.engineReference(), key, tx.getAtomicOperation()));
   }
 
   @Override
@@ -1486,19 +1553,8 @@ public abstract class IndexAbstract implements Index {
   public Stream<Object> keyStream(@Nonnull AtomicOperation operation) {
     acquireSharedLock();
     try {
-      boolean recovered = false;
-      while (true) {
-        try {
-          return storage.getIndexKeyStream(state().engineIdentifier(), state().engineReference(),
-              operation);
-        } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
-            throw staleAfterOwnerRecovery();
-          }
-          resolveOwnedEngine();
-          recovered = true;
-        }
-      }
+      return withOwnedEngine(current -> storage.getIndexKeyStream(
+          current.engineIdentifier(), current.engineReference(), operation));
     } finally {
       releaseSharedLock();
     }
@@ -1567,81 +1623,34 @@ public abstract class IndexAbstract implements Index {
 
   @Override
   public boolean acquireAtomicExclusiveLock(AtomicOperation atomicOperation) {
-    BaseIndexEngine engine;
-    boolean recovered = false;
-
-    while (true) {
-      try {
-        engine = storage.getIndexEngineWithStateLock(
-            state().engineIdentifier(), state().engineReference());
-        break;
-      } catch (InvalidIndexEngineIdException ignore) {
-        if (recovered) {
-          throw staleAfterOwnerRecovery();
-        }
-        resolveOwnedEngineWithStateLock();
-        recovered = true;
-      }
-    }
-
-    return engine.acquireAtomicExclusiveLock(atomicOperation);
+    return withOwnedEngineAndStateLock(current -> storage.getIndexEngineWithStateLock(
+        current.engineIdentifier(), current.engineReference()))
+        .acquireAtomicExclusiveLock(atomicOperation);
   }
 
   @Nullable @Override
   public IndexStatistics getStatistics(DatabaseSessionEmbedded session) {
-    boolean recovered = false;
-    while (true) {
-      try {
-        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
-        return engine.getStatistics();
-      } catch (InvalidIndexEngineIdException ignore) {
-        if (recovered) {
-          throw staleAfterOwnerRecovery();
-        }
-        resolveOwnedEngine();
-        recovered = true;
-      }
-    }
+    return withOwnedEngine(current -> storage.getIndexEngine(
+        current.engineIdentifier(), current.engineReference())).getStatistics();
   }
 
   @Nullable @Override
   public EquiDepthHistogram getHistogram(DatabaseSessionEmbedded session) {
-    boolean recovered = false;
-    while (true) {
-      try {
-        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
-        return engine.getHistogram();
-      } catch (InvalidIndexEngineIdException ignore) {
-        if (recovered) {
-          throw staleAfterOwnerRecovery();
-        }
-        resolveOwnedEngine();
-        recovered = true;
-      }
-    }
+    return withOwnedEngine(current -> storage.getIndexEngine(
+        current.engineIdentifier(), current.engineReference())).getHistogram();
   }
 
   @Nullable @Override
   public HistogramSnapshot analyzeHistogram(DatabaseSessionEmbedded session) {
-    boolean recovered = false;
-    while (true) {
-      try {
-        var engine = storage.getIndexEngine(state().engineIdentifier(), state().engineReference());
-        if (engine instanceof BTreeIndexEngine btreeEngine) {
-          var manager = btreeEngine.getHistogramManager();
-          if (manager != null) {
-            return manager.analyzeIndex();
-          }
-        }
-        return null;
-      } catch (InvalidIndexEngineIdException ignore) {
-        if (recovered) {
-          throw staleAfterOwnerRecovery();
-        }
-        resolveOwnedEngine();
-        recovered = true;
+    final var engine = withOwnedEngine(current -> storage.getIndexEngine(
+        current.engineIdentifier(), current.engineReference()));
+    if (engine instanceof BTreeIndexEngine btreeEngine) {
+      var manager = btreeEngine.getHistogramManager();
+      if (manager != null) {
+        return manager.analyzeIndex();
       }
     }
+    return null;
   }
 
   private long[] indexCollection(
@@ -1720,34 +1729,28 @@ public abstract class IndexAbstract implements Index {
 
   protected void onIndexEngineChange(
       DatabaseSessionEmbedded session, IndexHandleState initialState) {
-    var current = initialState;
-    boolean recovered = false;
-    while (true) {
-      try {
-        storage.callIndexEngine(
-            false,
-            current.engineIdentifier(),
-            current.engineReference(),
-            engine -> {
-              engine.init(session, im);
-              return null;
-            });
-        break;
-      } catch (InvalidIndexEngineIdException ignore) {
-        if (recovered) {
-          throw staleAfterOwnerRecovery();
-        }
-        current = resolveOwnedEngine();
-        recovered = true;
-      }
-    }
+    withOwnedEngine(current -> {
+      storage.callIndexEngine(
+          false,
+          current.engineIdentifier(),
+          current.engineReference(),
+          engine -> {
+            engine.init(session, im);
+            return null;
+          });
+      return null;
+    });
   }
 
   private StaleIndexEngineException staleAfterOwnerRecovery() {
+    return staleAfterOwnerRecovery(state());
+  }
+
+  private StaleIndexEngineException staleAfterOwnerRecovery(IndexHandleState current) {
     return new StaleIndexEngineException(
         storage.getName(),
         "Index '" + getName() + "' remained stale after owner-bound recovery for descriptor "
-            + state().descriptorIdentity());
+            + current.descriptorIdentity());
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -99,7 +99,7 @@ public abstract class IndexAbstract implements Index {
   // metadata) stale through a racing read of the new reference.
   @Nullable protected volatile IndexMetadata im;
 
-  @Nullable protected RID identity;
+  @Nullable protected volatile RID identity;
 
   public IndexAbstract(@Nullable RID identity,
       @Nonnull FrontendTransactionImpl transaction, @Nonnull final Storage storage) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -181,6 +181,7 @@ public abstract class IndexAbstract implements Index {
 
     @SuppressWarnings("unchecked")
     var metadataEntity = (Map<String, Object>) config.get(METADATA);
+    IndexMetadataValidator.validate(metadataEntity);
     return new IndexMetadata(
         indexName,
         loadedIndexDefinition,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstract.java
@@ -21,6 +21,7 @@ package com.jetbrains.youtrackdb.internal.core.index;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.api.exception.RecordDuplicatedException;
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.common.concur.lock.OneEntryPerKeyLockManager;
 import com.jetbrains.youtrackdb.internal.common.concur.lock.PartitionedLockManager;
 import com.jetbrains.youtrackdb.internal.common.listener.ProgressListener;
@@ -270,6 +271,16 @@ public abstract class IndexAbstract implements Index {
     } finally {
       releaseExclusiveLock();
     }
+  }
+
+  /** Links the descriptor to its lifecycle record before the atomic record apply. */
+  void linkLifecycleRecordAtCommit(FrontendTransaction transaction, RID lifecycleIdentity) {
+    var descriptor = transaction.loadEntity(state().descriptorIdentity());
+    var existing = descriptor.getLink(Index.LIFECYCLE_RECORD);
+    if (existing != null) {
+      throw new IllegalStateException("Index descriptor already has a lifecycle record link");
+    }
+    descriptor.setLink(Index.LIFECYCLE_RECORD, lifecycleIdentity);
   }
 
   /**
@@ -526,7 +537,7 @@ public abstract class IndexAbstract implements Index {
     try {
       final var descriptorIdentity = state().descriptorIdentity();
       if (descriptorIdentity != null) {
-        transaction.loadEntity(descriptorIdentity).delete();
+        deleteDescriptorAndLifecycle(transaction, descriptorIdentity);
       }
     } finally {
       releaseExclusiveLock();
@@ -568,7 +579,7 @@ public abstract class IndexAbstract implements Index {
       // the recorded ids, so recording only after a fully-successful build would leave such a
       // failure's engine behind as a phantom registration no revert arm ever removes.
       createdEngineExternalIds.add(engineIdentifier);
-      attachDescriptorIdentityLocked();
+      bindEngineOwnerBeforeLifecyclePublication();
       onIndexEngineChange(transaction.getDatabaseSession(), state());
     } finally {
       releaseExclusiveLock();
@@ -803,6 +814,21 @@ public abstract class IndexAbstract implements Index {
     onIndexEngineChange(transaction.getDatabaseSession(), state());
   }
 
+  private void bindEngineOwnerBeforeLifecyclePublication() {
+    var current = state();
+    var descriptorIdentity = current.descriptorIdentity();
+    if (descriptorIdentity == null || !descriptorIdentity.isPersistent()) {
+      throw new IllegalStateException("Index engine owner requires a durable descriptor identity");
+    }
+    var durableIdentity = immutableIdentity(descriptorIdentity);
+    var boundReference =
+        storage.attachIndexEngineOwner(
+            current.engineIdentifier(), durableIdentity, current.engineReference());
+    handleState.set(
+        new IndexHandleState(
+            current.engineIdentifier(), boundReference, durableIdentity, null));
+  }
+
   void attachDescriptorIdentity() {
     acquireExclusiveLock();
     try {
@@ -980,6 +1006,7 @@ public abstract class IndexAbstract implements Index {
       // and WAL replay.
       session.executeInTxInternal(tx -> {
         save(tx);
+        storage.registerTopLevelIndexLifecycle(tx, getIdentity());
         session.getSharedContext().getIndexManager()
             .addIndexInternal(session, tx, this, true);
       });
@@ -1287,8 +1314,24 @@ public abstract class IndexAbstract implements Index {
 
     final var descriptorIdentity = state().descriptorIdentity();
     if (descriptorIdentity != null) {
-      transaction.loadEntity(descriptorIdentity).delete();
+      deleteDescriptorAndLifecycle(transaction, descriptorIdentity);
     }
+  }
+
+  /** Enrolls the descriptor and linked lifecycle deletion in one transaction. */
+  private static void deleteDescriptorAndLifecycle(
+      FrontendTransaction transaction, RID descriptorIdentity) {
+    var descriptor = transaction.loadEntity(descriptorIdentity);
+    var lifecycleIdentity = descriptor.getLink(Index.LIFECYCLE_RECORD);
+    if (lifecycleIdentity != null) {
+      try {
+        transaction.loadRecord(lifecycleIdentity).delete();
+      } catch (RecordNotFoundException ignored) {
+        // A dangling lifecycle link already has no lifecycle record to delete.
+      }
+      descriptor.setLink(Index.LIFECYCLE_RECORD, null);
+    }
+    descriptor.delete();
   }
 
   private void clearAllEntries(DatabaseSessionEmbedded session) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleState.java
@@ -18,6 +18,11 @@ record IndexHandleState(
     if (engineIdentifier < 0 && engineReference != null) {
       throw new IllegalStateException("An absent index engine cannot carry a reference");
     }
+    if (engineReference != null
+        && (engineReference.slot() != (engineIdentifier & 0x7_FF_FF_FF)
+            || engineReference.apiVersion() != engineIdentifier >>> (Integer.SIZE - 5))) {
+      throw new IllegalStateException("An index engine identifier must match its reference");
+    }
     if (lifecycleCell != null
         && (descriptorIdentity == null || !descriptorIdentity.isPersistent())) {
       throw new IllegalStateException("A lifecycle cell requires a durable descriptor identity");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleState.java
@@ -1,0 +1,34 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
+import javax.annotation.Nullable;
+
+/** One immutable and coherently published snapshot of an index handle. */
+record IndexHandleState(
+    int engineIdentifier,
+    @Nullable IndexEngineReference engineReference,
+    @Nullable RID descriptorIdentity,
+    @Nullable IndexLifecycleCell lifecycleCell) {
+
+  static final IndexHandleState EMPTY = new IndexHandleState(-1, null, null, null);
+
+  IndexHandleState {
+    if (engineIdentifier < 0 && engineReference != null) {
+      throw new IllegalStateException("An absent index engine cannot carry a reference");
+    }
+    if (lifecycleCell != null
+        && (descriptorIdentity == null || !descriptorIdentity.isPersistent())) {
+      throw new IllegalStateException("A lifecycle cell requires a durable descriptor identity");
+    }
+  }
+
+  boolean hasEngine() {
+    return engineIdentifier >= 0;
+  }
+
+  boolean isDurablyIdentified() {
+    return descriptorIdentity != null && descriptorIdentity.isPersistent();
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
@@ -265,11 +265,15 @@ public abstract class IndexManagerAbstract implements CloseableInStorage {
 
   protected void addIndexInternalNoLock(final Index index, FrontendTransaction transaction,
       boolean updateEntity) {
-    if (index instanceof IndexAbstract indexAbstract) {
-      // A newly saved descriptor may receive its persistent RID only when its transaction applies.
-      // Bind storage-scoped state before publishing the handle to writers.
-      indexAbstract.attachDescriptorIdentity();
+    if (!(index instanceof IndexAbstract indexAbstract)) {
+      throw new IllegalStateException(
+          "index '" + index.getName() + "' has unexpected handle type "
+              + index.getClass().getName() + "; expected " + IndexAbstract.class.getName());
     }
+
+    // A newly saved descriptor may receive its persistent RID only when its transaction applies.
+    // Bind storage-scoped state before publishing the handle to writers.
+    indexAbstract.attachDescriptorIdentity();
 
     if (updateEntity) {
       var indexEntity = transaction.loadEntity(indexManagerIdentity);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
@@ -265,6 +265,12 @@ public abstract class IndexManagerAbstract implements CloseableInStorage {
 
   protected void addIndexInternalNoLock(final Index index, FrontendTransaction transaction,
       boolean updateEntity) {
+    if (index instanceof IndexAbstract indexAbstract) {
+      // A newly saved descriptor may receive its persistent RID only when its transaction applies.
+      // Bind storage-scoped state before publishing the handle to writers.
+      indexAbstract.attachDescriptorIdentity();
+    }
+
     if (updateEntity) {
       var indexEntity = transaction.loadEntity(indexManagerIdentity);
       indexEntity.getOrCreateLinkSet(CONFIG_INDEXES).add(index.getIdentity());

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerAbstract.java
@@ -229,6 +229,8 @@ public abstract class IndexManagerAbstract implements CloseableInStorage {
   }
 
   protected void load(FrontendTransactionImpl transaction, EntityImpl entity) {
+    storage.validateIndexBuildStateCollection();
+
     indexes.clear();
     classPropertyIndex.clear();
 
@@ -236,8 +238,10 @@ public abstract class IndexManagerAbstract implements CloseableInStorage {
     if (indexEntities != null) {
       for (var indexIdentifiable : indexEntities) {
         var indexEntity = transaction.loadEntity(indexIdentifiable);
-        final var newIndexMetadata = IndexAbstract.loadMetadataFromMap(transaction,
-            indexEntity.toMap(false));
+        var lifecycleIdentity = indexEntity.getLink(Index.LIFECYCLE_RECORD);
+        storage.recoverIndexLifecycle(indexIdentifiable.getIdentity(), lifecycleIdentity);
+        final var newIndexMetadata =
+            IndexAbstract.loadMetadataFromMap(transaction, indexEntity.toMap(false));
         var index =
             createIndexInstance(transaction, indexIdentifiable, newIndexMetadata);
         addIndexInternalNoLock(index, transaction, false);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -981,8 +981,11 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       }
       return (IndexAbstract) index;
     });
-    // The descriptor RID becomes persistent when computeInTxInternal returns. Attach before fill or
-    // any caller can reach the newly published handle.
+    // The descriptor RID becomes persistent only when computeInTxInternal returns. The manager map
+    // can therefore expose this handle briefly without an attachment, despite the pre-publication
+    // attempt in addIndexInternalNoLock. That window is harmless today because attachment accessors
+    // explicitly return empty and no production path consumes them. Attach before fill returns the
+    // handle to its creator. Later consumers must preserve the defined empty-result handling.
     idx.attachDescriptorIdentity();
 
     if (progressListener == null)

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -1525,11 +1525,20 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       // deltas net to a replace (the name stays in both the tx-dropped and tx-created sets), so
       // building the new engine first would collide with the still-registered old one.
       for (final var droppedIndex : plan.dropped()) {
-        final var engineId = droppedIndex.getIndexId();
-        if (engineId >= 0) {
-          final var droppedEngine =
-              ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(
-                  engineId, ((IndexAbstract) droppedIndex).getEngineReference(), atomicOperation);
+        final var handle = (IndexAbstract) droppedIndex;
+        var snapshot = handle.engineSnapshot();
+        if (snapshot.engineIdentifier() >= 0) {
+          AbstractStorage.DroppedIndexEngine droppedEngine;
+          try {
+            droppedEngine = ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(
+                snapshot.engineIdentifier(), snapshot.engineReference(), atomicOperation);
+          } catch (InvalidIndexEngineIdException exception) {
+            // A failed earlier commit can restore the same owner with a fresh engine generation.
+            // Refresh under the commit-window state lock, then retry the side-effect-free check once.
+            final var resolved = handle.resolveOwnedEngineWithStateLock();
+            droppedEngine = ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(
+                resolved.engineIdentifier(), resolved.engineReference(), atomicOperation);
+          }
           // Capture the dropped engine so the failure path can reconstruct it: the delete tore the
           // engine out of the in-memory registry synchronously, and a failed commit must put it back.
           plan.droppedEngines().add(droppedEngine);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -981,6 +981,9 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       }
       return (IndexAbstract) index;
     });
+    // The descriptor RID becomes persistent when computeInTxInternal returns. Attach before fill or
+    // any caller can reach the newly published handle.
+    idx.attachDescriptorIdentity();
 
     if (progressListener == null)
     // ASSIGN DEFAULT PROGRESS LISTENER
@@ -1187,20 +1190,24 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       return;
     }
 
+    final IndexAbstract[] droppedIndex = new IndexAbstract[1];
     session.executeInTxInternal(transaction -> {
       acquireExclusiveLock(transaction);
       try {
-        Index idx;
-        idx = indexes.get(iIndexName);
+        final var idx = indexes.get(iIndexName);
         if (idx != null) {
           removeClassPropertyIndexInternal(idx);
           idx.delete(transaction);
           indexes.remove(iIndexName);
+          droppedIndex[0] = (IndexAbstract) idx;
         }
       } finally {
         releaseExclusiveLock(session, true);
       }
     });
+    if (droppedIndex[0] != null) {
+      droppedIndex[0].removeLifecycleRegistration();
+    }
   }
 
   /**
@@ -1646,6 +1653,7 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
     for (final var droppedIndex : plan.dropped()) {
       removeClassPropertyIndexInternal(droppedIndex);
       indexes.remove(droppedIndex.getName());
+      ((IndexAbstract) droppedIndex).removeLifecycleRegistration();
     }
     // The rename re-association's in-memory half: install the replacement metadata wholesale (a
     // single reference swap — lock-free readers see either the old or the new fully-built

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -1534,7 +1534,7 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
                 snapshot.engineIdentifier(), snapshot.engineReference(), atomicOperation);
           } catch (InvalidIndexEngineIdException exception) {
             // A failed earlier commit can restore the same owner with a fresh engine generation.
-            // Refresh under the commit-window state lock, then retry the side-effect-free check once.
+            // Refresh under the commit-window state lock, then retry the validated deletion once.
             final var resolved = handle.resolveOwnedEngineWithStateLock();
             droppedEngine = ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(
                 resolved.engineIdentifier(), resolved.engineReference(), atomicOperation);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -1194,22 +1194,25 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
     }
 
     final IndexAbstract[] droppedIndex = new IndexAbstract[1];
-    session.executeInTxInternal(transaction -> {
-      acquireExclusiveLock(transaction);
-      try {
-        final var idx = indexes.get(iIndexName);
-        if (idx != null) {
-          removeClassPropertyIndexInternal(idx);
-          idx.delete(transaction);
-          indexes.remove(iIndexName);
-          droppedIndex[0] = (IndexAbstract) idx;
+    try {
+      session.executeInTxInternal(transaction -> {
+        acquireExclusiveLock(transaction);
+        try {
+          final var idx = indexes.get(iIndexName);
+          if (idx != null) {
+            droppedIndex[0] = (IndexAbstract) idx;
+            removeClassPropertyIndexInternal(idx);
+            idx.delete(transaction);
+            indexes.remove(iIndexName);
+          }
+        } finally {
+          releaseExclusiveLock(session, true);
         }
-      } finally {
-        releaseExclusiveLock(session, true);
+      });
+    } finally {
+      if (droppedIndex[0] != null) {
+        droppedIndex[0].removeLifecycleRegistrationIfDetached();
       }
-    });
-    if (droppedIndex[0] != null) {
-      droppedIndex[0].removeLifecycleRegistration();
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -1525,8 +1525,8 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
         final var engineId = droppedIndex.getIndexId();
         if (engineId >= 0) {
           final var droppedEngine =
-              ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(engineId,
-                  atomicOperation);
+              ((AbstractStorage) storage).deleteIndexEngineInCommitWindow(
+                  engineId, ((IndexAbstract) droppedIndex).getEngineReference(), atomicOperation);
           // Capture the dropped engine so the failure path can reconstruct it: the delete tore the
           // engine out of the in-memory registry synchronously, and a failed commit must put it back.
           plan.droppedEngines().add(droppedEngine);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -30,6 +30,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildStateStore;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaShared;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.TxSchemaState;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityResourceProperty;
@@ -977,17 +978,16 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
                 metadata);
 
         index = createIndexFromMetadata(transaction, storage, im);
+        ((AbstractStorage) storage)
+            .registerTopLevelIndexLifecycle(transaction, index.getIdentity());
         addIndexInternalNoLock(index, transaction, true);
       } finally {
         releaseExclusiveLock(session, true);
       }
       return (IndexAbstract) index;
     });
-    // The descriptor RID becomes persistent only when computeInTxInternal returns. The manager map
-    // can therefore expose this handle briefly without an attachment, despite the pre-publication
-    // attempt in addIndexInternalNoLock. That window is harmless today because attachment accessors
-    // explicitly return empty and no production path consumes them. Attach before fill returns the
-    // handle to its creator. Later consumers must preserve the defined empty-result handling.
+    // The descriptor and lifecycle record are durable now. The commit publishes the lifecycle
+    // snapshot before this attachment exposes the stable lifecycle cell on the index handle.
     idx.attachDescriptorIdentity();
 
     if (progressListener == null)
@@ -1280,7 +1280,14 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       List<ReassociatedIndex> reassociated,
       List<AppliedMembership> appliedMembership,
       List<Integer> createdEngineExternalIds,
-      List<AbstractStorage.DroppedIndexEngine> droppedEngines) {
+      List<AbstractStorage.DroppedIndexEngine> droppedEngines,
+      List<CreatedIndexLifecycle> createdLifecycles) {
+
+  }
+
+  /** A created index and the lifecycle record committed with the index artifacts. */
+  public record CreatedIndexLifecycle(
+      IndexAbstract index, IndexBuildStateStore.CreatedLifecycleRecord lifecycle) {
 
   }
 
@@ -1444,7 +1451,7 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       return null;
     }
     return new ReconciledIndexPlan(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
   }
 
   /**
@@ -1496,6 +1503,22 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
                 + " source collection in this version; collection '" + collectionName + "' is not"
                 + " empty. The unbounded populated-class in-commit build is tracked by YTDB-1064.");
       }
+    }
+  }
+
+  /** Creates and links lifecycle records after descriptor RIDs become durable addresses. */
+  public void createReconciledIndexLifecycles(
+      FrontendTransaction transaction, AtomicOperation atomicOperation, ReconciledIndexPlan plan) {
+    var localStorage = (AbstractStorage) storage;
+    for (var index : plan.created()) {
+      var descriptorIdentity = index.getIdentity();
+      var descriptor = transaction.loadEntity(descriptorIdentity);
+      var existingLifecycleIdentity = descriptor.getLink(Index.LIFECYCLE_RECORD);
+      var lifecycle =
+          localStorage.createInitialIndexLifecycle(
+              descriptorIdentity, existingLifecycleIdentity, atomicOperation);
+      index.linkLifecycleRecordAtCommit(transaction, lifecycle.identity());
+      plan.createdLifecycles().add(new CreatedIndexLifecycle(index, lifecycle));
     }
   }
 
@@ -1691,10 +1714,12 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
         removeClassPropertyIndexInternal(reassociated.index(), oldClassName);
       }
     }
-    for (final var handle : plan.created()) {
-      // The engine is built and the record durable, so register the handle in the shared lookup maps
-      // exactly as the non-transactional create's addIndexInternalNoLock does, without re-updating the
-      // index-manager entity (its link set was updated in the enroll phase and is already durable).
+    for (final var createdLifecycle : plan.createdLifecycles()) {
+      var handle = createdLifecycle.index();
+      ((AbstractStorage) storage)
+          .publishInitialIndexLifecycle(
+              handle.getIdentity(), createdLifecycle.lifecycle().snapshot());
+      // The engine and all linked records are durable before the handle becomes shared.
       addIndexInternalNoLock(handle, transaction, false);
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -847,6 +847,8 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       Map<String, Object> metadata,
       String algorithm) {
 
+    IndexMetadataValidator.validate(metadata);
+
     final var manualIndexesAreUsed =
         indexDefinition == null
             || indexDefinition.getClassName() == null

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMetadata.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMetadata.java
@@ -20,6 +20,8 @@
 package com.jetbrains.youtrackdb.internal.core.index;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -55,9 +57,8 @@ public class IndexMetadata {
 
     this.algorithm = algorithm;
     this.version = version;
-    this.metadata = metadata;
+    this.metadata = copyValidatedMetadata(metadata);
   }
-
 
   @Nonnull
   public String getName() {
@@ -132,6 +133,15 @@ public class IndexMetadata {
   }
 
   public void setMetadata(Map<String, Object> metadata) {
-    this.metadata = metadata;
+    this.metadata = copyValidatedMetadata(metadata);
+  }
+
+  private static Map<String, Object> copyValidatedMetadata(Map<String, Object> metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    var copy = Collections.unmodifiableMap(new HashMap<>(metadata));
+    IndexMetadataValidator.validate(copy);
+    return copy;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMetadataValidator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMetadataValidator.java
@@ -1,0 +1,24 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import java.util.Map;
+
+/** Validates the user-controlled index metadata namespace. */
+public final class IndexMetadataValidator {
+
+  public static final String RESERVED_PREFIX = "__ytdb_";
+
+  private IndexMetadataValidator() {
+  }
+
+  public static void validate(Map<String, ?> metadata) {
+    if (metadata == null) {
+      return;
+    }
+    for (var key : metadata.keySet()) {
+      if (key != null && key.startsWith(RESERVED_PREFIX)) {
+        throw new IllegalArgumentException(
+            "Index metadata key '" + key + "' uses reserved prefix " + RESERVED_PREFIX);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
@@ -92,7 +92,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
         return Stream.empty();
       }
       Stream<RID> stream;
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -194,7 +194,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -262,7 +262,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -329,7 +329,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
 
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -452,7 +452,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     final var entryKey = key;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -511,7 +511,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -550,7 +550,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -649,7 +649,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
@@ -85,7 +85,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RID> backedStream;
     acquireSharedLock();
     try {
-      if (indexId < 0) {
+      if (!state().hasEngine()) {
         // Unbuilt, transaction-deferred index: no engine yet, so a value lookup finds nothing.
         // Returning an empty stream keeps get()/getRids() on a deferred handle NPE-free and
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
@@ -96,7 +96,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          stream = storage.getIndexValues(indexId, collatedKey, transaction.getAtomicOperation());
+          stream = storage.getIndexValues(state().engineIdentifier(), collatedKey,
+              transaction.getAtomicOperation());
           backedStream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
@@ -104,9 +105,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -165,7 +166,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    doPutV1(storage, transaction.getAtomicOperation(), indexId, key, rid);
+    doPutV1(storage, transaction.getAtomicOperation(), state().engineIdentifier(), key, rid);
   }
 
   private static void doPutV1(
@@ -180,7 +181,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
       Object key, RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    return doRemoveV1(indexId, storage, key, rid, transaction.getAtomicOperation());
+    return doRemoveV1(state().engineIdentifier(), storage, key, rid,
+        transaction.getAtomicOperation());
   }
 
   private static boolean doRemoveV1(
@@ -207,7 +209,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesBetween(
-                      indexId,
+                      state().engineIdentifier(),
                       fromKey,
                       fromInclusive,
                       toKey,
@@ -220,9 +222,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -274,7 +276,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMajor(
-                      indexId, fromKey, fromInclusive, ascOrder, MultiValuesTransformer.INSTANCE,
+                      state().engineIdentifier(), fromKey, fromInclusive, ascOrder,
+                      MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -283,9 +286,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -340,7 +343,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMinor(
-                      indexId, toKey, toInclusive, ascOrder, MultiValuesTransformer.INSTANCE,
+                      state().engineIdentifier(), toKey, toInclusive, ascOrder,
+                      MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -349,9 +353,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -457,16 +461,16 @@ public abstract class IndexMultiValues extends IndexAbstract {
       boolean recovered = false;
       while (true) {
         try {
-          return storage.getIndexValues(indexId, key, atomicOperation)
+          return storage.getIndexValues(state().engineIdentifier(), key, atomicOperation)
               .map((rid) -> new RawPair<>(entryKey, rid));
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -507,7 +511,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     acquireSharedLock();
     long tot;
     try {
-      if (indexId < 0) {
+      if (!state().hasEngine()) {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
@@ -515,7 +519,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          tot = storage.getIndexSize(indexId, MultiValuesTransformer.INSTANCE,
+          tot = storage.getIndexSize(state().engineIdentifier(), MultiValuesTransformer.INSTANCE,
               transaction.getAtomicOperation());
           break;
         } catch (InvalidIndexEngineIdException ignore) {
@@ -523,9 +527,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -555,7 +559,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexStream(indexId, MultiValuesTransformer.INSTANCE,
+                  this,
+                  storage.getIndexStream(state().engineIdentifier(),
+                      MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -564,9 +570,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -652,7 +658,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexDescStream(indexId, MultiValuesTransformer.INSTANCE,
+                  this,
+                  storage.getIndexDescStream(state().engineIdentifier(),
+                      MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -661,9 +669,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
@@ -85,7 +85,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RID> backedStream;
     acquireSharedLock();
     try {
-      if (!state().hasEngine()) {
+      if (isNeverBuilt(state())) {
         // Unbuilt, transaction-deferred index: no engine yet, so a value lookup finds nothing.
         // Returning an empty stream keeps get()/getRids() on a deferred handle NPE-free and
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
@@ -96,7 +96,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          stream = storage.getIndexValues(state().engineIdentifier(), collatedKey,
+          stream = storage.getIndexValues(state().engineIdentifier(), state().engineReference(),
+              collatedKey,
               transaction.getAtomicOperation());
           backedStream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
@@ -166,14 +167,10 @@ public abstract class IndexMultiValues extends IndexAbstract {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    doPutV1(storage, transaction.getAtomicOperation(), state().engineIdentifier(), key, rid);
-  }
-
-  private static void doPutV1(
-      AbstractStorage storage, @Nonnull AtomicOperation atomicOperation, int indexId, Object key,
-      RID identity)
-      throws InvalidIndexEngineIdException {
-    storage.putRidIndexEntry(indexId, key, identity, atomicOperation);
+    final var current = state();
+    storage.putRidIndexEntry(
+        current.engineIdentifier(), current.engineReference(), key, rid,
+        transaction.getAtomicOperation());
   }
 
   @Override
@@ -181,15 +178,10 @@ public abstract class IndexMultiValues extends IndexAbstract {
       Object key, RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    return doRemoveV1(state().engineIdentifier(), storage, key, rid,
+    final var current = state();
+    return storage.removeRidIndexEntry(
+        current.engineIdentifier(), current.engineReference(), key, rid,
         transaction.getAtomicOperation());
-  }
-
-  private static boolean doRemoveV1(
-      int indexId, AbstractStorage storage, Object key, Identifiable value,
-      AtomicOperation atomicOperation)
-      throws InvalidIndexEngineIdException {
-    return storage.removeRidIndexEntry(indexId, key, value.getIdentity(), atomicOperation);
   }
 
   @Override
@@ -461,7 +453,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
       boolean recovered = false;
       while (true) {
         try {
-          return storage.getIndexValues(state().engineIdentifier(), key, atomicOperation)
+          return storage
+              .getIndexValues(state().engineIdentifier(), state().engineReference(), key,
+                  atomicOperation)
               .map((rid) -> new RawPair<>(entryKey, rid));
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
@@ -511,7 +505,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     acquireSharedLock();
     long tot;
     try {
-      if (!state().hasEngine()) {
+      if (isNeverBuilt(state())) {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
@@ -519,7 +513,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          tot = storage.getIndexSize(state().engineIdentifier(), MultiValuesTransformer.INSTANCE,
+          tot = storage.getIndexSize(state().engineIdentifier(), state().engineReference(),
+              MultiValuesTransformer.INSTANCE,
               transaction.getAtomicOperation());
           break;
         } catch (InvalidIndexEngineIdException ignore) {
@@ -560,7 +555,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexStream(state().engineIdentifier(),
+                  storage.getIndexStream(state().engineIdentifier(), state().engineReference(),
                       MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
@@ -659,7 +654,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexDescStream(state().engineIdentifier(),
+                  storage.getIndexDescStream(state().engineIdentifier(), state().engineReference(),
                       MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
@@ -27,6 +27,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.DBRecord;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AscComparator;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.DescComparator;
@@ -91,6 +92,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
         return Stream.empty();
       }
       Stream<RID> stream;
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -98,7 +100,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
           backedStream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -190,6 +199,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -206,7 +216,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -249,6 +266,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -261,7 +279,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -307,6 +332,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
 
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -319,7 +345,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -421,12 +454,20 @@ public abstract class IndexMultiValues extends IndexAbstract {
     final var entryKey = key;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           return storage.getIndexValues(indexId, key, atomicOperation)
               .map((rid) -> new RawPair<>(entryKey, rid));
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -470,6 +511,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -477,7 +519,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
               transaction.getAtomicOperation());
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -500,6 +549,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -510,7 +560,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -589,6 +646,7 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -599,7 +657,14 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValues.java
@@ -92,24 +92,24 @@ public abstract class IndexMultiValues extends IndexAbstract {
         return Stream.empty();
       }
       Stream<RID> stream;
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          stream = storage.getIndexValues(state().engineIdentifier(), state().engineReference(),
+          stream = storage.getIndexValues(current.engineIdentifier(), current.engineReference(),
               collatedKey,
               transaction.getAtomicOperation());
           backedStream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -167,10 +167,12 @@ public abstract class IndexMultiValues extends IndexAbstract {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    final var current = state();
-    storage.putRidIndexEntry(
-        current.engineIdentifier(), current.engineReference(), key, rid,
-        transaction.getAtomicOperation());
+    withOwnedEngine(current -> {
+      storage.putRidIndexEntry(
+          current.engineIdentifier(), current.engineReference(), key, rid,
+          transaction.getAtomicOperation());
+      return null;
+    });
   }
 
   @Override
@@ -178,10 +180,9 @@ public abstract class IndexMultiValues extends IndexAbstract {
       Object key, RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    final var current = state();
-    return storage.removeRidIndexEntry(
+    return withOwnedEngine(current -> storage.removeRidIndexEntry(
         current.engineIdentifier(), current.engineReference(), key, rid,
-        transaction.getAtomicOperation());
+        transaction.getAtomicOperation()));
   }
 
   @Override
@@ -193,7 +194,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -201,7 +203,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesBetween(
-                      state().engineIdentifier(),
+                      current.engineIdentifier(),
+                      current.engineReference(),
                       fromKey,
                       fromInclusive,
                       toKey,
@@ -210,14 +213,13 @@ public abstract class IndexMultiValues extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -260,7 +262,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -268,20 +271,19 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMajor(
-                      state().engineIdentifier(), fromKey, fromInclusive, ascOrder,
-                      MultiValuesTransformer.INSTANCE,
+                      current.engineIdentifier(), current.engineReference(),
+                      fromKey, fromInclusive, ascOrder, MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -327,7 +329,8 @@ public abstract class IndexMultiValues extends IndexAbstract {
 
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -335,20 +338,19 @@ public abstract class IndexMultiValues extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMinor(
-                      state().engineIdentifier(), toKey, toInclusive, ascOrder,
-                      MultiValuesTransformer.INSTANCE,
+                      current.engineIdentifier(), current.engineReference(),
+                      toKey, toInclusive, ascOrder, MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -450,22 +452,22 @@ public abstract class IndexMultiValues extends IndexAbstract {
     final var entryKey = key;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           return storage
-              .getIndexValues(state().engineIdentifier(), state().engineReference(), key,
+              .getIndexValues(current.engineIdentifier(), current.engineReference(), key,
                   atomicOperation)
               .map((rid) -> new RawPair<>(entryKey, rid));
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -509,23 +511,23 @@ public abstract class IndexMultiValues extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          tot = storage.getIndexSize(state().engineIdentifier(), state().engineReference(),
+          tot = storage.getIndexSize(current.engineIdentifier(), current.engineReference(),
               MultiValuesTransformer.INSTANCE,
               transaction.getAtomicOperation());
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -548,27 +550,27 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexStream(state().engineIdentifier(), state().engineReference(),
+                  storage.getIndexStream(current.engineIdentifier(), current.engineReference(),
                       MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -647,27 +649,27 @@ public abstract class IndexMultiValues extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexDescStream(state().engineIdentifier(), state().engineReference(),
+                  storage.getIndexDescStream(current.engineIdentifier(), current.engineReference(),
                       MultiValuesTransformer.INSTANCE,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
@@ -27,6 +27,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.DBRecord;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AscComparator;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.DescComparator;
@@ -90,6 +91,7 @@ public abstract class IndexOneValue extends IndexAbstract {
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
         return Stream.empty();
       }
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -97,7 +99,14 @@ public abstract class IndexOneValue extends IndexAbstract {
           stream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -159,6 +168,7 @@ public abstract class IndexOneValue extends IndexAbstract {
                       final var collatedKey = getCollatingValue(key);
                       acquireSharedLock();
                       try {
+                        boolean recovered = false;
                         while (true) {
                           try {
                             return storage
@@ -166,7 +176,15 @@ public abstract class IndexOneValue extends IndexAbstract {
                                     transaction.getAtomicOperation())
                                 .map((rid) -> new RawPair<>(collatedKey, rid));
                           } catch (InvalidIndexEngineIdException ignore) {
-                            doReloadIndexEngine();
+                            if (recovered) {
+                              throw new StaleIndexEngineException(
+                                  storage.getName(),
+                                  "Index '" + getName()
+                                      + "' remained stale after owner-bound recovery for"
+                                      + " descriptor " + identity);
+                            }
+                            resolveOwnedEngineIdentifier();
+                            recovered = true;
                           }
                         }
                       } finally {
@@ -210,6 +228,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -222,7 +241,14 @@ public abstract class IndexOneValue extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -265,6 +291,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -277,7 +304,14 @@ public abstract class IndexOneValue extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -324,6 +358,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -335,7 +370,14 @@ public abstract class IndexOneValue extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
 
@@ -383,12 +425,20 @@ public abstract class IndexOneValue extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           return storage.getIndexSize(indexId, null, transaction.getAtomicOperation());
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -401,6 +451,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -411,7 +462,14 @@ public abstract class IndexOneValue extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {
@@ -441,6 +499,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
+      boolean recovered = false;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -451,7 +510,14 @@ public abstract class IndexOneValue extends IndexAbstract {
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          doReloadIndexEngine();
+          if (recovered) {
+            throw new StaleIndexEngineException(
+                storage.getName(),
+                "Index '" + getName() + "' remained stale after owner-bound recovery for"
+                    + " descriptor " + identity);
+          }
+          resolveOwnedEngineIdentifier();
+          recovered = true;
         }
       }
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
@@ -91,24 +91,24 @@ public abstract class IndexOneValue extends IndexAbstract {
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
         return Stream.empty();
       }
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
-              storage.getIndexValues(state().engineIdentifier(), state().engineReference(), key,
+              storage.getIndexValues(current.engineIdentifier(), current.engineReference(), key,
                   transaction.getAtomicOperation());
           stream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -170,23 +170,24 @@ public abstract class IndexOneValue extends IndexAbstract {
                       final var collatedKey = getCollatingValue(key);
                       acquireSharedLock();
                       try {
-                        boolean recovered = false;
+                        var current = state();
+                        var recoveryAttempts = 0;
                         while (true) {
                           try {
                             return storage
-                                .getIndexValues(state().engineIdentifier(), collatedKey,
-                                    transaction.getAtomicOperation())
+                                .getIndexValues(
+                                    current.engineIdentifier(), current.engineReference(),
+                                    collatedKey, transaction.getAtomicOperation())
                                 .map((rid) -> new RawPair<>(collatedKey, rid));
                           } catch (InvalidIndexEngineIdException ignore) {
-                            if (recovered) {
+                            if (++recoveryAttempts >= 3) {
                               throw new StaleIndexEngineException(
                                   storage.getName(),
                                   "Index '" + getName()
                                       + "' remained stale after owner-bound recovery for"
-                                      + " descriptor " + state().descriptorIdentity());
+                                      + " descriptor " + current.descriptorIdentity());
                             }
-                            resolveOwnedEngine();
-                            recovered = true;
+                            current = resolveOwnedEngine();
                           }
                         }
                       } finally {
@@ -230,7 +231,8 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -238,20 +240,19 @@ public abstract class IndexOneValue extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesBetween(
-                      state().engineIdentifier(), fromKey, fromInclusive, toKey, toInclusive,
-                      ascOrder, null,
+                      current.engineIdentifier(), current.engineReference(),
+                      fromKey, fromInclusive, toKey, toInclusive, ascOrder, null,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -294,7 +295,8 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
@@ -302,19 +304,19 @@ public abstract class IndexOneValue extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMajor(
-                      state().engineIdentifier(), fromKey, fromInclusive, ascOrder, null,
+                      current.engineIdentifier(), current.engineReference(),
+                      fromKey, fromInclusive, ascOrder, null,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -361,28 +363,28 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.iterateIndexEntriesMinor(state().engineIdentifier(),
-                      state().engineReference(), toKey, toInclusive,
+                  storage.iterateIndexEntriesMinor(
+                      current.engineIdentifier(), current.engineReference(), toKey, toInclusive,
                       ascOrder,
                       null, transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
 
@@ -430,21 +432,21 @@ public abstract class IndexOneValue extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          return storage.getIndexSize(state().engineIdentifier(), state().engineReference(), null,
+          return storage.getIndexSize(current.engineIdentifier(), current.engineReference(), null,
               transaction.getAtomicOperation());
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -457,27 +459,27 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexStream(state().engineIdentifier(), state().engineReference(),
+                  storage.getIndexStream(current.engineIdentifier(), current.engineReference(),
                       null,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {
@@ -507,27 +509,27 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      boolean recovered = false;
+      var current = state();
+      var recoveryAttempts = 0;
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.getIndexDescStream(state().engineIdentifier(), state().engineReference(),
+                  storage.getIndexDescStream(current.engineIdentifier(), current.engineReference(),
                       null,
                       transaction.getAtomicOperation()),
                   session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
-          if (recovered) {
+          if (++recoveryAttempts >= 3) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + state().descriptorIdentity());
+                    + " descriptor " + current.descriptorIdentity());
           }
-          resolveOwnedEngine();
-          recovered = true;
+          current = resolveOwnedEngine();
         }
       }
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
@@ -85,7 +85,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     acquireSharedLock();
     Stream<RID> stream;
     try {
-      if (!state().hasEngine()) {
+      if (isNeverBuilt(state())) {
         // Unbuilt, transaction-deferred index: no engine yet, so a value lookup finds nothing.
         // Returning an empty stream keeps get()/getRids() on a deferred handle NPE-free and
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
@@ -95,8 +95,9 @@ public abstract class IndexOneValue extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          stream = storage.getIndexValues(state().engineIdentifier(), key,
-              transaction.getAtomicOperation());
+          stream =
+              storage.getIndexValues(state().engineIdentifier(), state().engineReference(), key,
+                  transaction.getAtomicOperation());
           stream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
@@ -367,7 +368,8 @@ public abstract class IndexOneValue extends IndexAbstract {
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.iterateIndexEntriesMinor(state().engineIdentifier(), toKey, toInclusive,
+                  storage.iterateIndexEntriesMinor(state().engineIdentifier(),
+                      state().engineReference(), toKey, toInclusive,
                       ascOrder,
                       null, transaction.getAtomicOperation()),
                   session);
@@ -424,7 +426,7 @@ public abstract class IndexOneValue extends IndexAbstract {
   public long size(DatabaseSessionEmbedded session) {
     acquireSharedLock();
     try {
-      if (!state().hasEngine()) {
+      if (isNeverBuilt(state())) {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
@@ -432,7 +434,7 @@ public abstract class IndexOneValue extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          return storage.getIndexSize(state().engineIdentifier(), null,
+          return storage.getIndexSize(state().engineIdentifier(), state().engineReference(), null,
               transaction.getAtomicOperation());
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
@@ -461,7 +463,9 @@ public abstract class IndexOneValue extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexStream(state().engineIdentifier(), null,
+                  this,
+                  storage.getIndexStream(state().engineIdentifier(), state().engineReference(),
+                      null,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -509,7 +513,9 @@ public abstract class IndexOneValue extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexDescStream(state().engineIdentifier(), null,
+                  this,
+                  storage.getIndexDescStream(state().engineIdentifier(), state().engineReference(),
+                      null,
                       transaction.getAtomicOperation()),
                   session);
           break;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
@@ -91,7 +91,7 @@ public abstract class IndexOneValue extends IndexAbstract {
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
         return Stream.empty();
       }
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -170,7 +170,7 @@ public abstract class IndexOneValue extends IndexAbstract {
                       final var collatedKey = getCollatingValue(key);
                       acquireSharedLock();
                       try {
-                        var current = state();
+                        var current = engineStateForRead();
                         var recoveryAttempts = 0;
                         while (true) {
                           try {
@@ -231,7 +231,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -295,7 +295,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -363,7 +363,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -432,7 +432,7 @@ public abstract class IndexOneValue extends IndexAbstract {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -459,7 +459,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {
@@ -509,7 +509,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     Stream<RawPair<Object, RID>> stream;
     acquireSharedLock();
     try {
-      var current = state();
+      var current = engineStateForRead();
       var recoveryAttempts = 0;
       while (true) {
         try {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValue.java
@@ -85,7 +85,7 @@ public abstract class IndexOneValue extends IndexAbstract {
     acquireSharedLock();
     Stream<RID> stream;
     try {
-      if (indexId < 0) {
+      if (!state().hasEngine()) {
         // Unbuilt, transaction-deferred index: no engine yet, so a value lookup finds nothing.
         // Returning an empty stream keeps get()/getRids() on a deferred handle NPE-free and
         // consistent with size() == 0, rather than passing indexId = -1 into the storage engine.
@@ -95,7 +95,8 @@ public abstract class IndexOneValue extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          stream = storage.getIndexValues(indexId, key, transaction.getAtomicOperation());
+          stream = storage.getIndexValues(state().engineIdentifier(), key,
+              transaction.getAtomicOperation());
           stream = IndexStreamSecurityDecorator.decorateRidStream(this, stream, session);
           break;
         } catch (InvalidIndexEngineIdException ignore) {
@@ -103,9 +104,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -172,7 +173,7 @@ public abstract class IndexOneValue extends IndexAbstract {
                         while (true) {
                           try {
                             return storage
-                                .getIndexValues(indexId, collatedKey,
+                                .getIndexValues(state().engineIdentifier(), collatedKey,
                                     transaction.getAtomicOperation())
                                 .map((rid) -> new RawPair<>(collatedKey, rid));
                           } catch (InvalidIndexEngineIdException ignore) {
@@ -181,9 +182,9 @@ public abstract class IndexOneValue extends IndexAbstract {
                                   storage.getName(),
                                   "Index '" + getName()
                                       + "' remained stale after owner-bound recovery for"
-                                      + " descriptor " + identity);
+                                      + " descriptor " + state().descriptorIdentity());
                             }
-                            resolveOwnedEngineIdentifier();
+                            resolveOwnedEngine();
                             recovered = true;
                           }
                         }
@@ -236,7 +237,8 @@ public abstract class IndexOneValue extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesBetween(
-                      indexId, fromKey, fromInclusive, toKey, toInclusive, ascOrder, null,
+                      state().engineIdentifier(), fromKey, fromInclusive, toKey, toInclusive,
+                      ascOrder, null,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -245,9 +247,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -299,7 +301,7 @@ public abstract class IndexOneValue extends IndexAbstract {
               IndexStreamSecurityDecorator.decorateStream(
                   this,
                   storage.iterateIndexEntriesMajor(
-                      indexId, fromKey, fromInclusive, ascOrder, null,
+                      state().engineIdentifier(), fromKey, fromInclusive, ascOrder, null,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -308,9 +310,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -365,7 +367,8 @@ public abstract class IndexOneValue extends IndexAbstract {
           stream =
               IndexStreamSecurityDecorator.decorateStream(
                   this,
-                  storage.iterateIndexEntriesMinor(indexId, toKey, toInclusive, ascOrder,
+                  storage.iterateIndexEntriesMinor(state().engineIdentifier(), toKey, toInclusive,
+                      ascOrder,
                       null, transaction.getAtomicOperation()),
                   session);
           break;
@@ -374,9 +377,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -421,7 +424,7 @@ public abstract class IndexOneValue extends IndexAbstract {
   public long size(DatabaseSessionEmbedded session) {
     acquireSharedLock();
     try {
-      if (indexId < 0) {
+      if (!state().hasEngine()) {
         // Unbuilt, transaction-deferred index: no engine yet, so it holds nothing.
         return 0;
       }
@@ -429,15 +432,16 @@ public abstract class IndexOneValue extends IndexAbstract {
       while (true) {
         try {
           var transaction = session.getActiveTransaction();
-          return storage.getIndexSize(indexId, null, transaction.getAtomicOperation());
+          return storage.getIndexSize(state().engineIdentifier(), null,
+              transaction.getAtomicOperation());
         } catch (InvalidIndexEngineIdException ignore) {
           if (recovered) {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -457,7 +461,7 @@ public abstract class IndexOneValue extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexStream(indexId, null,
+                  this, storage.getIndexStream(state().engineIdentifier(), null,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -466,9 +470,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }
@@ -505,7 +509,7 @@ public abstract class IndexOneValue extends IndexAbstract {
           var transaction = session.getActiveTransaction();
           stream =
               IndexStreamSecurityDecorator.decorateStream(
-                  this, storage.getIndexDescStream(indexId, null,
+                  this, storage.getIndexDescStream(state().engineIdentifier(), null,
                       transaction.getAtomicOperation()),
                   session);
           break;
@@ -514,9 +518,9 @@ public abstract class IndexOneValue extends IndexAbstract {
             throw new StaleIndexEngineException(
                 storage.getName(),
                 "Index '" + getName() + "' remained stale after owner-bound recovery for"
-                    + " descriptor " + identity);
+                    + " descriptor " + state().descriptorIdentity());
           }
-          resolveOwnedEngineIdentifier();
+          resolveOwnedEngine();
           recovered = true;
         }
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
@@ -55,7 +55,7 @@ public class IndexUnique extends IndexOneValue {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    storage.validatedPutIndexValue(indexId, key, rid, uniqueValidator,
+    storage.validatedPutIndexValue(state().engineIdentifier(), key, rid, uniqueValidator,
         transaction.getAtomicOperation());
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
@@ -55,9 +55,9 @@ public class IndexUnique extends IndexOneValue {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    storage.validatedPutIndexValue(state().engineIdentifier(), state().engineReference(), key, rid,
-        uniqueValidator,
-        transaction.getAtomicOperation());
+    withOwnedEngine(current -> storage.validatedPutIndexValue(
+        current.engineIdentifier(), current.engineReference(), key, rid, uniqueValidator,
+        transaction.getAtomicOperation()));
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexUnique.java
@@ -55,7 +55,8 @@ public class IndexUnique extends IndexOneValue {
       RID rid)
       throws InvalidIndexEngineIdException {
     var transaction = session.getActiveTransaction();
-    storage.validatedPutIndexValue(state().engineIdentifier(), key, rid, uniqueValidator,
+    storage.validatedPutIndexValue(state().engineIdentifier(), state().engineReference(), key, rid,
+        uniqueValidator,
         transaction.getAtomicOperation());
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/Indexes.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/Indexes.java
@@ -133,15 +133,28 @@ public final class Indexes {
       @Nonnull Storage storage)
       throws ConfigurationException, IndexException {
 
-    return findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(indexType, storage);
+    var index = findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(indexType, storage);
+    return validateIndexHandle(indexType, algorithm, index);
   }
 
   public static Index createIndexInstance(@Nonnull String indexType, @Nullable String algorithm,
       @Nonnull Storage storage, @Nonnull FrontendTransactionImpl transaction, @Nonnull RID identity)
       throws ConfigurationException, IndexException {
 
-    return findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(indexType, identity,
+    var index = findFactoryByAlgorithmAndType(algorithm, indexType).createIndex(indexType, identity,
         transaction, storage);
+    return validateIndexHandle(indexType, algorithm, index);
+  }
+
+  private static Index validateIndexHandle(String indexType, String algorithm, Index index) {
+    if (!(index instanceof IndexAbstract)) {
+      var concreteClass = index == null ? "null" : index.getClass().getName();
+      throw new IllegalStateException(
+          "Index factory returned an unexpected handle for type '" + indexType
+              + "', algorithm '" + algorithm + "': " + concreteClass
+              + "; expected " + IndexAbstract.class.getName());
+    }
+    return index;
   }
 
   private static IndexFactory findFactoryByAlgorithmAndType(String algorithm, String indexType) {
@@ -150,7 +163,7 @@ public final class Indexes {
       if (indexType == null
           || indexType.isEmpty()
           || (factory.getTypes().contains(indexType)
-          && factory.getAlgorithms().contains(algorithm))) {
+              && factory.getAlgorithms().contains(algorithm))) {
         return factory;
       }
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
@@ -17,10 +17,10 @@ public interface BaseIndexEngine {
   int getId();
 
   /**
-   * Returns process-local identity for engines published in a local storage registry.
+   * Returns this engine's process-local registry identity.
    *
-   * <p>Remote engines intentionally return {@code null}. They are not held in the local storage
-   * engine list, so slot generations and descriptor ownership do not apply to them.
+   * <p>An engine published in a local storage engine registry must return a reference. Only an
+   * engine that is never published in that registry may return {@code null}.
    */
   @Nullable default IndexEngineReference getEngineReference() {
     return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
@@ -19,8 +19,9 @@ public interface BaseIndexEngine {
   /**
    * Returns this engine's process-local registry identity.
    *
-   * <p>An engine published in a local storage engine registry must return a reference. Only an
-   * engine that is never published in that registry may return {@code null}.
+   * <p>An engine published in a local storage engine registry is expected to return a reference.
+   * Owner resolution skips an engine that does not. A handle for that index cannot recover by owner
+   * and fails closed instead.
    */
   @Nullable default IndexEngineReference getEngineReference() {
     return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/BaseIndexEngine.java
@@ -16,6 +16,16 @@ public interface BaseIndexEngine {
 
   int getId();
 
+  /**
+   * Returns process-local identity for engines published in a local storage registry.
+   *
+   * <p>Remote engines intentionally return {@code null}. They are not held in the local storage
+   * engine list, so slot generations and descriptor ownership do not apply to them.
+   */
+  @Nullable default IndexEngineReference getEngineReference() {
+    return null;
+  }
+
   void init(DatabaseSessionEmbedded session, IndexMetadata metadata);
 
   void flush();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/HistogramDeltaHolder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/HistogramDeltaHolder.java
@@ -73,6 +73,13 @@ public final class HistogramDeltaHolder {
   }
 
   /**
+   * Discards work accumulated for an engine slot whose owner is being deleted or replaced.
+   */
+  public void discard(int engineId) {
+    deltas.remove(engineId);
+  }
+
+  /**
    * Marks this holder as already applied to the in-memory CHM cache.
    * Idempotent: calling twice in a row is harmless.
    */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexCountDeltaHolder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexCountDeltaHolder.java
@@ -88,6 +88,13 @@ public final class IndexCountDeltaHolder {
   }
 
   /**
+   * Discards work accumulated for an engine slot whose owner is being deleted or replaced.
+   */
+  public void discard(int engineId) {
+    deltas.remove(engineId);
+  }
+
+  /**
    * Marks this holder as already persisted to the BTree entry-point pages.
    * Idempotent: calling twice in a row is harmless.
    */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexEngineReference.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexEngineReference.java
@@ -1,0 +1,56 @@
+package com.jetbrains.youtrackdb.internal.core.index.engine;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Process-local engine identity, including a generation that cannot fit in the packed id. */
+public final class IndexEngineReference {
+
+  private final int slot;
+  private final int apiVersion;
+  private final long generation;
+  @Nullable private volatile RID ownerDescriptorIdentity;
+
+  public IndexEngineReference(int slot, int apiVersion, long generation) {
+    if (slot < 0) {
+      throw new IllegalArgumentException("Engine slot must be non-negative");
+    }
+    if (generation <= 0) {
+      throw new IllegalArgumentException("Engine generation must be positive");
+    }
+
+    this.slot = slot;
+    this.apiVersion = apiVersion;
+    this.generation = generation;
+  }
+
+  public int slot() {
+    return slot;
+  }
+
+  public int apiVersion() {
+    return apiVersion;
+  }
+
+  public long generation() {
+    return generation;
+  }
+
+  @Nullable public RID ownerDescriptorIdentity() {
+    return ownerDescriptorIdentity;
+  }
+
+  public synchronized void bindOwner(@Nonnull RID ownerDescriptorIdentity) {
+    if (this.ownerDescriptorIdentity == null) {
+      this.ownerDescriptorIdentity = ownerDescriptorIdentity;
+      return;
+    }
+
+    if (!this.ownerDescriptorIdentity.equals(ownerDescriptorIdentity)) {
+      throw new IllegalStateException(
+          "Index engine owner is already bound to " + this.ownerDescriptorIdentity
+              + " and cannot be rebound to " + ownerDescriptorIdentity);
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -151,6 +152,12 @@ public class IndexHistogramManager extends StorageComponent {
 
   /** Prevents concurrent rebalances for the same index. */
   private final AtomicBoolean rebalanceInProgress = new AtomicBoolean(false);
+
+  /** Permanently blocks publication and background work after this manager loses its engine slot. */
+  private volatile boolean detached;
+
+  /** Runs immediately before a publication remap. Tests use it to stage slot reuse. */
+  @Nullable private volatile Runnable prePublicationTestHook;
 
   /**
    * Monotonic timestamp ({@link System#nanoTime()}) of last rebalance failure.
@@ -265,6 +272,14 @@ public class IndexHistogramManager extends StorageComponent {
     this.bulkLoading = bulkLoading;
   }
 
+  void setPrePublicationTestHook(@Nullable Runnable hook) {
+    prePublicationTestHook = hook;
+  }
+
+  boolean isDetached() {
+    return detached;
+  }
+
   /**
    * Sets the IO executor for background rebalance scheduling. Called by
    * the storage layer after the database is fully open and the executor
@@ -293,6 +308,15 @@ public class IndexHistogramManager extends StorageComponent {
   }
 
   // ---- Lifecycle ----
+
+  /** Permanently blocks this manager from publishing into its former engine slot. */
+  public void detach() {
+    if (detached) {
+      return;
+    }
+    detached = true;
+    cache.remove(engineId);
+  }
 
   /**
    * Checks if the .ixs file exists. Used by the storage layer to decide
@@ -386,8 +410,8 @@ public class IndexHistogramManager extends StorageComponent {
       logger.warn("Failed to flush histogram stats on close for {}",
           getName(), e);
     }
-    cache.remove(engineId);
     fileId = -1;
+    detach();
   }
 
   /**
@@ -401,8 +425,8 @@ public class IndexHistogramManager extends StorageComponent {
     if (fileId != -1) {
       deleteFile(op, fileId);
     }
-    cache.remove(engineId);
     fileId = -1;
+    detach();
   }
 
   /**
@@ -559,12 +583,9 @@ public class IndexHistogramManager extends StorageComponent {
    * @param delta the accumulated delta for this engine
    */
   public void applyDelta(HistogramDelta delta) {
-    cache.compute(engineId, (id, old) -> {
-      if (old == null) {
-        return null; // engine deleted — discard delta silently
-      }
-      return computeNewSnapshot(old, delta);
-    });
+    if (!publish(old -> old == null ? null : computeNewSnapshot(old, delta))) {
+      return;
+    }
     long newDirty =
         (long) DIRTY_MUTATIONS.getAndAdd(this, delta.mutationCount)
             + delta.mutationCount;
@@ -587,6 +608,35 @@ public class IndexHistogramManager extends StorageComponent {
         }
       }
     }
+  }
+
+  /**
+   * Publishes through one atomic remap so detach and slot replacement cannot interleave.
+   *
+   * @return {@code true} when the merge published a new snapshot
+   */
+  private boolean publish(UnaryOperator<HistogramSnapshot> merge) {
+    final var hook = prePublicationTestHook;
+    if (hook != null) {
+      hook.run();
+    }
+
+    final var published = new boolean[1];
+    cache.compute(engineId, (slot, current) -> {
+      if (detached) {
+        return current;
+      }
+      final var next = merge.apply(current);
+      if (next == null) {
+        return current;
+      }
+      published[0] = true;
+      return next;
+    });
+    if (!published[0]) {
+      logger.debug("Declined histogram publication for detached or absent engine {}", engineId);
+    }
+    return published[0];
   }
 
   /**
@@ -691,10 +741,7 @@ public class IndexHistogramManager extends StorageComponent {
 
   // ---- Planner reads ----
 
-  /**
-   * Returns the current index statistics from the CHM cache.
-   * Reload from page on cache miss.
-   */
+  /** Returns the current index statistics from the CHM cache, or null on a cache miss. */
   @Nullable public IndexStatistics getStatistics() {
     var snapshot = cache.get(engineId);
     if (snapshot != null) {
@@ -762,8 +809,9 @@ public class IndexHistogramManager extends StorageComponent {
       var stats = new IndexStatistics(totalCount, nonNullCount, nullCount);
       var snapshot = new HistogramSnapshot(
           stats, null, 0, totalCount, 0, false, null, false);
-      cache.put(engineId, snapshot);
-      writeSnapshotToPage(op, snapshot);
+      if (publish(current -> snapshot)) {
+        writeSnapshotToPage(op, snapshot);
+      }
       // Early exit: return approximate count (no stream consumed).
       // Callers' "recalibration" is effectively a no-op for small indexes.
       return nonNullCount;
@@ -805,8 +853,9 @@ public class IndexHistogramManager extends StorageComponent {
       var stats = new IndexStatistics(totalCount, 0, nullCount);
       var snapshot = new HistogramSnapshot(
           stats, null, 0, totalCount, 0, false, null, false);
-      cache.put(engineId, snapshot);
-      writeSnapshotToPage(op, snapshot);
+      if (publish(current -> snapshot)) {
+        writeSnapshotToPage(op, snapshot);
+      }
       return 0;
     }
 
@@ -830,8 +879,9 @@ public class IndexHistogramManager extends StorageComponent {
     var stats = new IndexStatistics(totalCount, exactDistinctCount, nullCount);
     var snapshot = new HistogramSnapshot(
         stats, histogram, 0, totalCount, 0, false, hll, hllOnPage1);
-    cache.put(engineId, snapshot);
-    writeSnapshotToPage(op, snapshot);
+    if (publish(current -> snapshot)) {
+      writeSnapshotToPage(op, snapshot);
+    }
     return scannedNonNull;
   }
 
@@ -847,7 +897,7 @@ public class IndexHistogramManager extends StorageComponent {
    */
   public void maybeScheduleHistogramWork(
       @Nullable ExecutorService executor) {
-    if (executor == null) {
+    if (detached || executor == null) {
       return;
     }
     var snapshot = cache.get(engineId);
@@ -882,7 +932,7 @@ public class IndexHistogramManager extends StorageComponent {
    * @return the refreshed snapshot, or null if the index is empty
    */
   @Nullable public HistogramSnapshot analyzeIndex() {
-    if (keyStreamSupplier == null) {
+    if (detached || keyStreamSupplier == null) {
       return null;
     }
 
@@ -908,7 +958,9 @@ public class IndexHistogramManager extends StorageComponent {
    */
   public void resetOnClear(AtomicOperation op) throws IOException {
     var emptySnapshot = createEmptySnapshot();
-    cache.put(engineId, emptySnapshot);
+    if (!publish(current -> emptySnapshot)) {
+      return;
+    }
     DIRTY_MUTATIONS.setRelease(this, 0L);
 
     if (fileId != -1) {
@@ -931,6 +983,9 @@ public class IndexHistogramManager extends StorageComponent {
    * checkpoint/shutdown path uses the no-arg {@link #flushIfDirty()} instead.
    */
   public void flushIfDirty(AtomicOperation op) throws IOException {
+    if (detached) {
+      return;
+    }
     long observed = (long) DIRTY_MUTATIONS.getAcquire(this);
     if (observed > 0 && fileId != -1
         && DIRTY_MUTATIONS.compareAndSet(this, observed, 0L)) {
@@ -958,6 +1013,9 @@ public class IndexHistogramManager extends StorageComponent {
    * best-effort and must not block checkpoint or shutdown.
    */
   public void flushIfDirty() {
+    if (detached) {
+      return;
+    }
     long observed = (long) DIRTY_MUTATIONS.getAcquire(this);
     if (observed > 0
         && DIRTY_MUTATIONS.compareAndSet(this, observed, 0L)) {
@@ -1731,9 +1789,9 @@ public class IndexHistogramManager extends StorageComponent {
       final var finalHll = newHll;
       final long finalNDV = scannedDistinctCount;
       final boolean finalHllOnPage1 = hllOnPage1;
-      cache.compute(engineId, (id, old) -> {
+      final var published = publish(old -> {
         if (old == null) {
-          return null; // engine deleted during rebalance
+          return null;
         }
         // Use CHM's totalCount/nullCount (most up-to-date — includes concurrent
         // commits after the scan) rather than the scanned values. For distinctCount,
@@ -1754,6 +1812,9 @@ public class IndexHistogramManager extends StorageComponent {
             finalHll,
             finalHllOnPage1);
       });
+      if (!published) {
+        return;
+      }
 
       // Persist the new snapshot. On failure, mark dirty so the next
       // checkpoint or commit-path batch flush retries the persistence.
@@ -1965,6 +2026,9 @@ public class IndexHistogramManager extends StorageComponent {
    * component-lock wrap closes the race.
    */
   private void flushSnapshotToPage() throws IOException {
+    if (detached) {
+      return;
+    }
     var snapshot = cache.get(engineId);
     if (snapshot == null || fileId == -1) {
       return;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
@@ -583,18 +583,15 @@ public class IndexHistogramManager extends StorageComponent {
    * @param delta the accumulated delta for this engine
    */
   public void applyDelta(HistogramDelta delta) {
-    if (!publish(old -> old == null ? null : computeNewSnapshot(old, delta))) {
+    var published = publish(delta);
+    if (published == null || detached) {
       return;
     }
-    long newDirty =
-        (long) DIRTY_MUTATIONS.getAndAdd(this, delta.mutationCount)
-            + delta.mutationCount;
+    long newDirty = (long) DIRTY_MUTATIONS.getAcquire(this);
 
     // Use getAndSet(0) so exactly one thread claims the dirty count and
-    // flushes. Any mutations added by concurrent threads between the
-    // getAndAdd above and the getAndSet here become part of the next batch
-    // (their count is already reflected in the VarHandle and will be
-    // re-accumulated by subsequent applyDelta calls).
+    // flushes. Mutations added after the successful remap become part of
+    // this batch or the next batch, depending on which thread claims them.
     if (newDirty >= persistBatchSize) {
       long claimed = (long) DIRTY_MUTATIONS.getAndSet(this, 0L);
       if (claimed > 0) {
@@ -613,30 +610,50 @@ public class IndexHistogramManager extends StorageComponent {
   /**
    * Publishes through one atomic remap so detach and slot replacement cannot interleave.
    *
-   * @return {@code true} when the merge published a new snapshot
+   * @return the value retained in the cache after the remap
    */
-  private boolean publish(UnaryOperator<HistogramSnapshot> merge) {
+  @Nullable private HistogramSnapshot publish(UnaryOperator<HistogramSnapshot> merge) {
     final var hook = prePublicationTestHook;
     if (hook != null) {
       hook.run();
     }
 
-    final var published = new boolean[1];
-    cache.compute(engineId, (slot, current) -> {
+    final var result = cache.compute(engineId, (slot, current) -> {
       if (detached) {
         return current;
       }
       final var next = merge.apply(current);
-      if (next == null) {
-        return current;
-      }
-      published[0] = true;
-      return next;
+      return next != null ? next : current;
     });
-    if (!published[0]) {
+    if (result == null || detached) {
       logger.debug("Declined histogram publication for detached or absent engine {}", engineId);
     }
-    return published[0];
+    return result;
+  }
+
+  /**
+   * Publishes a commit delta without the helper lambda and result-array allocations of the general
+   * merge path. The remaining lambda must capture the delta because {@code ConcurrentHashMap.compute}
+   * supplies only the key and current value. Dirty accounting stays inside that atomic remap.
+   */
+  @Nullable private HistogramSnapshot publish(HistogramDelta delta) {
+    final var hook = prePublicationTestHook;
+    if (hook != null) {
+      hook.run();
+    }
+
+    final var result = cache.compute(engineId, (slot, current) -> {
+      if (detached || current == null) {
+        return current;
+      }
+      final var next = computeNewSnapshot(current, delta);
+      DIRTY_MUTATIONS.getAndAdd(this, delta.mutationCount);
+      return next;
+    });
+    if (result == null || detached) {
+      logger.debug("Declined histogram publication for detached or absent engine {}", engineId);
+    }
+    return result;
   }
 
   /**
@@ -809,7 +826,7 @@ public class IndexHistogramManager extends StorageComponent {
       var stats = new IndexStatistics(totalCount, nonNullCount, nullCount);
       var snapshot = new HistogramSnapshot(
           stats, null, 0, totalCount, 0, false, null, false);
-      if (publish(current -> snapshot)) {
+      if (publish(current -> snapshot) == snapshot) {
         writeSnapshotToPage(op, snapshot);
       }
       // Early exit: return approximate count (no stream consumed).
@@ -853,7 +870,7 @@ public class IndexHistogramManager extends StorageComponent {
       var stats = new IndexStatistics(totalCount, 0, nullCount);
       var snapshot = new HistogramSnapshot(
           stats, null, 0, totalCount, 0, false, null, false);
-      if (publish(current -> snapshot)) {
+      if (publish(current -> snapshot) == snapshot) {
         writeSnapshotToPage(op, snapshot);
       }
       return 0;
@@ -879,7 +896,7 @@ public class IndexHistogramManager extends StorageComponent {
     var stats = new IndexStatistics(totalCount, exactDistinctCount, nullCount);
     var snapshot = new HistogramSnapshot(
         stats, histogram, 0, totalCount, 0, false, hll, hllOnPage1);
-    if (publish(current -> snapshot)) {
+    if (publish(current -> snapshot) == snapshot) {
       writeSnapshotToPage(op, snapshot);
     }
     return scannedNonNull;
@@ -958,7 +975,7 @@ public class IndexHistogramManager extends StorageComponent {
    */
   public void resetOnClear(AtomicOperation op) throws IOException {
     var emptySnapshot = createEmptySnapshot();
-    if (!publish(current -> emptySnapshot)) {
+    if (publish(current -> emptySnapshot) != emptySnapshot) {
       return;
     }
     DIRTY_MUTATIONS.setRelease(this, 0L);
@@ -1812,7 +1829,7 @@ public class IndexHistogramManager extends StorageComponent {
             finalHll,
             finalHllOnPage1);
       });
-      if (!published) {
+      if (published == null || detached) {
         return;
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
@@ -587,7 +587,12 @@ public class IndexHistogramManager extends StorageComponent {
     if (published == null || detached) {
       return;
     }
-    long newDirty = (long) DIRTY_MUTATIONS.getAcquire(this);
+    // ConcurrentHashMap.compute returns only after the new value is visible. Publishing first and
+    // adding second ensures a flusher that claims this count can also read its snapshot. This method
+    // invokes the remap once and adds once, while every declined result returns before this point.
+    long newDirty =
+        (long) DIRTY_MUTATIONS.getAndAdd(this, delta.mutationCount)
+            + delta.mutationCount;
 
     // Use getAndSet(0) so exactly one thread claims the dirty count and
     // flushes. Mutations added after the successful remap become part of
@@ -634,7 +639,7 @@ public class IndexHistogramManager extends StorageComponent {
   /**
    * Publishes a commit delta without the helper lambda and result-array allocations of the general
    * merge path. The remaining lambda must capture the delta because {@code ConcurrentHashMap.compute}
-   * supplies only the key and current value. Dirty accounting stays inside that atomic remap.
+   * supplies only the key and current value. The caller records dirty work after this remap returns.
    */
   @Nullable private HistogramSnapshot publish(HistogramDelta delta) {
     final var hook = prePublicationTestHook;
@@ -646,9 +651,7 @@ public class IndexHistogramManager extends StorageComponent {
       if (detached || current == null) {
         return current;
       }
-      final var next = computeNewSnapshot(current, delta);
-      DIRTY_MUTATIONS.getAndAdd(this, delta.mutationCount);
-      return next;
+      return computeNewSnapshot(current, delta);
     });
     if (result == null || detached) {
       logger.debug("Declined histogram publication for detached or absent engine {}", engineId);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramManager.java
@@ -1030,9 +1030,33 @@ public class IndexHistogramManager extends StorageComponent {
    * synch, close, and recovery.
    *
    * <p>Failures are logged but never propagated — histogram persistence is
-   * best-effort and must not block checkpoint or shutdown.
+   * best-effort and must not block checkpoint or shutdown. The strict variant
+   * {@link #flushIfDirtyOrFail()} reports every failure instead.
    */
   public void flushIfDirty() {
+    try {
+      flushIfDirtyOrFail();
+    } catch (IOException e) {
+      // The strict variant already restored the dirty count, so the next flush retries.
+      logger.warn("Failed to flush histogram stats for {}"
+          + " during checkpoint", getName(), e);
+    }
+  }
+
+  /**
+   * Persists the current snapshot of this index histogram, and reports every failure.
+   *
+   * <p>An index histogram is index statistics data that the index engine keeps in a separate
+   * file. The write-ahead log never carries that data, so a swallowed write failure loses that
+   * data forever. The durability barrier of storage birth therefore calls this strict variant.
+   *
+   * <p>The method restores the dirty-mutation count before the method reports a failure, so the
+   * next flush of this index histogram retries the write. The best-effort variant
+   * {@link #flushIfDirty()} logs the same failure and returns.
+   *
+   * @throws IOException when the write of the index statistics page fails
+   */
+  public void flushIfDirtyOrFail() throws IOException {
     if (detached) {
       return;
     }
@@ -1044,8 +1068,7 @@ public class IndexHistogramManager extends StorageComponent {
       } catch (IOException e) {
         // Restore the count so the next checkpoint or applyDelta re-triggers.
         DIRTY_MUTATIONS.getAndAdd(this, observed);
-        logger.warn("Failed to flush histogram stats for {}"
-            + " during checkpoint", getName(), e);
+        throw e;
       }
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
@@ -12,6 +12,7 @@ import com.jetbrains.youtrackdb.internal.core.index.IndexException;
 import com.jetbrains.youtrackdb.internal.core.index.IndexMetadata;
 import com.jetbrains.youtrackdb.internal.core.index.IndexesSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDelta;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexHistogramManager;
 import com.jetbrains.youtrackdb.internal.core.index.engine.MultiValueIndexEngine;
@@ -53,6 +54,7 @@ public final class BTreeMultiValueIndexEngine
 
   private final String name;
   private final int id;
+  private final IndexEngineReference engineReference;
   private final String nullTreeName;
   private final AbstractStorage storage;
 
@@ -89,10 +91,17 @@ public final class BTreeMultiValueIndexEngine
 
   public BTreeMultiValueIndexEngine(
       int id, int fileBaseId, @Nonnull String name, AbstractStorage storage, final int version) {
+    this(id, fileBaseId, name, storage, version, new IndexEngineReference(id, API_VERSION, 1));
+  }
+
+  public BTreeMultiValueIndexEngine(
+      int id, int fileBaseId, @Nonnull String name, AbstractStorage storage, final int version,
+      IndexEngineReference engineReference) {
     this.id = id;
     this.fileBaseId = fileBaseId;
     this.name = name;
     this.storage = storage;
+    this.engineReference = engineReference;
     // Both components (and therefore their files) are keyed by the stable file base id, not the
     // index name — the single name domain for engine storage components.
     final var stem = AbstractStorage.indexEngineFileStem(fileBaseId);
@@ -125,6 +134,11 @@ public final class BTreeMultiValueIndexEngine
   @Override
   public int getId() {
     return id;
+  }
+
+  @Override
+  public IndexEngineReference getEngineReference() {
+    return engineReference;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
@@ -91,17 +91,11 @@ public final class BTreeMultiValueIndexEngine
 
   public BTreeMultiValueIndexEngine(
       int id, int fileBaseId, @Nonnull String name, AbstractStorage storage, final int version) {
-    this(id, fileBaseId, name, storage, version, new IndexEngineReference(id, API_VERSION, 1));
-  }
-
-  public BTreeMultiValueIndexEngine(
-      int id, int fileBaseId, @Nonnull String name, AbstractStorage storage, final int version,
-      IndexEngineReference engineReference) {
     this.id = id;
     this.fileBaseId = fileBaseId;
     this.name = name;
     this.storage = storage;
-    this.engineReference = engineReference;
+    this.engineReference = storage.allocateIndexEngineReference(id, API_VERSION);
     // Both components (and therefore their files) are keyed by the stable file base id, not the
     // index name — the single name domain for engine storage components.
     final var stem = AbstractStorage.indexEngineFileStem(fileBaseId);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
@@ -80,17 +80,11 @@ public final class BTreeSingleValueIndexEngine
 
   public BTreeSingleValueIndexEngine(
       int id, int fileBaseId, String name, AbstractStorage storage, int version) {
-    this(id, fileBaseId, name, storage, version, new IndexEngineReference(id, API_VERSION, 1));
-  }
-
-  public BTreeSingleValueIndexEngine(
-      int id, int fileBaseId, String name, AbstractStorage storage, int version,
-      IndexEngineReference engineReference) {
     this.name = name;
     this.id = id;
     this.fileBaseId = fileBaseId;
     this.storage = storage;
-    this.engineReference = engineReference;
+    this.engineReference = storage.allocateIndexEngineReference(id, API_VERSION);
 
     if (version == 3 || version == 4) {
       // The component (and therefore its files) is keyed by the stable file base id, not the

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
@@ -12,6 +12,7 @@ import com.jetbrains.youtrackdb.internal.core.index.IndexException;
 import com.jetbrains.youtrackdb.internal.core.index.IndexMetadata;
 import com.jetbrains.youtrackdb.internal.core.index.IndexesSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDelta;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValidator;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexHistogramManager;
@@ -44,6 +45,7 @@ public final class BTreeSingleValueIndexEngine
   private final IndexesSnapshot indexesSnapshot;
   private final String name;
   private final int id;
+  private final IndexEngineReference engineReference;
 
   /**
    * The engine's stable, never-reused file base id. All storage-component names derive from it
@@ -78,10 +80,17 @@ public final class BTreeSingleValueIndexEngine
 
   public BTreeSingleValueIndexEngine(
       int id, int fileBaseId, String name, AbstractStorage storage, int version) {
+    this(id, fileBaseId, name, storage, version, new IndexEngineReference(id, API_VERSION, 1));
+  }
+
+  public BTreeSingleValueIndexEngine(
+      int id, int fileBaseId, String name, AbstractStorage storage, int version,
+      IndexEngineReference engineReference) {
     this.name = name;
     this.id = id;
     this.fileBaseId = fileBaseId;
     this.storage = storage;
+    this.engineReference = engineReference;
 
     if (version == 3 || version == 4) {
       // The component (and therefore its files) is keyed by the stable file base id, not the
@@ -102,6 +111,11 @@ public final class BTreeSingleValueIndexEngine
   @Override
   public int getId() {
     return id;
+  }
+
+  @Override
+  public IndexEngineReference getEngineReference() {
+    return engineReference;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildFailure.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildFailure.java
@@ -1,0 +1,6 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+/** Machine-readable reason attached to failed or invalid index build state. */
+public enum IndexBuildFailure {
+  NONE, UNIQUE_KEY_CONFLICT, INDEX_BUILD_STATE_MISSING
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildState.java
@@ -1,0 +1,86 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.util.Objects;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/** Immutable durable value for one index descriptor lifecycle. */
+public record IndexBuildState(
+    int formatVersion,
+    RID descriptorIdentity,
+    IndexLifecycle lifecycle,
+    UUID buildIncarnation,
+    @Nullable Long ownerEpoch,
+    @Nullable Long completionCut,
+    long completedUnits,
+    boolean suspended,
+    IndexBuildFailure failure,
+    @Nullable String failureMessage) {
+
+  public static final int CURRENT_FORMAT_VERSION = 1;
+
+  public IndexBuildState {
+    if (formatVersion != CURRENT_FORMAT_VERSION) {
+      throw new IllegalArgumentException("Unsupported index build state format " + formatVersion);
+    }
+    Objects.requireNonNull(descriptorIdentity, "descriptorIdentity");
+    Objects.requireNonNull(lifecycle, "lifecycle");
+    Objects.requireNonNull(buildIncarnation, "buildIncarnation");
+    Objects.requireNonNull(failure, "failure");
+    if (!descriptorIdentity.isPersistent()) {
+      throw new IllegalArgumentException("The index descriptor identity must be persistent");
+    }
+    if (ownerEpoch != null && ownerEpoch < 0) {
+      throw new IllegalArgumentException("The owner epoch cannot be negative");
+    }
+    if (completionCut != null && completionCut < 0) {
+      throw new IllegalArgumentException("The completion cut cannot be negative");
+    }
+    if (completedUnits < 0) {
+      throw new IllegalArgumentException("Completed units cannot be negative");
+    }
+    if (lifecycle == IndexLifecycle.INVALID && failure == IndexBuildFailure.NONE) {
+      throw new IllegalArgumentException("An invalid index requires a failure code");
+    }
+    if (lifecycle != IndexLifecycle.INVALID
+        && failure == IndexBuildFailure.INDEX_BUILD_STATE_MISSING) {
+      throw new IllegalArgumentException("Missing build state requires an invalid lifecycle");
+    }
+  }
+
+  public static IndexBuildState initial(RID descriptorIdentity) {
+    return new IndexBuildState(
+        CURRENT_FORMAT_VERSION,
+        descriptorIdentity,
+        IndexLifecycle.EXISTS,
+        UUID.randomUUID(),
+        null,
+        null,
+        0,
+        false,
+        IndexBuildFailure.NONE,
+        null);
+  }
+
+  public static IndexBuildState quarantineMissing(RID descriptorIdentity) {
+    return new IndexBuildState(
+        CURRENT_FORMAT_VERSION,
+        descriptorIdentity,
+        IndexLifecycle.INVALID,
+        UUID.randomUUID(),
+        null,
+        null,
+        0,
+        false,
+        IndexBuildFailure.INDEX_BUILD_STATE_MISSING,
+        "The durable index build state record was missing");
+  }
+
+  public static boolean isLegalTransition(IndexLifecycle current, IndexLifecycle replacement) {
+    return (current == IndexLifecycle.EXISTS && replacement == IndexLifecycle.MAINTAINED)
+        || (current == IndexLifecycle.MAINTAINED && replacement == IndexLifecycle.USABLE)
+        || (current == IndexLifecycle.MAINTAINED && replacement == IndexLifecycle.INVALID)
+        || (current == IndexLifecycle.INVALID && replacement == IndexLifecycle.MAINTAINED);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildState.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
 
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -63,18 +64,41 @@ public record IndexBuildState(
         null);
   }
 
-  public static IndexBuildState quarantineMissing(RID descriptorIdentity) {
+  public static IndexBuildState quarantineMissing(
+      RID descriptorIdentity, String diagnosticReason) {
+    Objects.requireNonNull(diagnosticReason, "diagnosticReason");
+    var incarnation =
+        UUID.nameUUIDFromBytes(
+            (descriptorIdentity + "\n" + diagnosticReason).getBytes(StandardCharsets.UTF_8));
     return new IndexBuildState(
         CURRENT_FORMAT_VERSION,
         descriptorIdentity,
         IndexLifecycle.INVALID,
-        UUID.randomUUID(),
+        incarnation,
         null,
         null,
         0,
         false,
         IndexBuildFailure.INDEX_BUILD_STATE_MISSING,
-        "The durable index build state record was missing");
+        diagnosticReason);
+  }
+
+  /** Returns this value without process-attempt ownership. */
+  public IndexBuildState withoutProcessOwnership() {
+    if (ownerEpoch == null) {
+      return this;
+    }
+    return new IndexBuildState(
+        formatVersion,
+        descriptorIdentity,
+        lifecycle,
+        buildIncarnation,
+        null,
+        completionCut,
+        completedUnits,
+        suspended,
+        failure,
+        failureMessage);
   }
 
   public static boolean isLegalTransition(IndexLifecycle current, IndexLifecycle replacement) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
@@ -86,6 +86,7 @@ public final class IndexBuildStateStore {
       IndexLifecycleSnapshot expected,
       IndexBuildState replacement) {
     verifyReplacementDescriptor(expected.buildState(), replacement, descriptorIdentity);
+    backend.checkStandaloneUpdateAllowed();
     var current = read(descriptorIdentity, lifecycleIdentity);
     if (current.recordVersion() != expected.recordVersion()
         || !current
@@ -222,6 +223,10 @@ public final class IndexBuildStateStore {
     Optional<VersionedRecord> read(RID recordIdentity);
 
     CreatedRecord create(Map<String, Object> value);
+
+    /** Rejects a protected caller before publication performs its internal record read. */
+    default void checkStandaloneUpdateAllowed() {
+    }
 
     VersionedRecord update(RID recordIdentity, long expectedVersion, Map<String, Object> value);
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
@@ -1,0 +1,184 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import javax.annotation.Nullable;
+
+/** Owns serialization and versioned persistence rules for index build state records. */
+public final class IndexBuildStateStore {
+
+  private static final String FORMAT_VERSION = "formatVersion";
+  private static final String DESCRIPTOR_IDENTITY = "descriptorIdentity";
+  private static final String LIFECYCLE = "lifecycle";
+  private static final String BUILD_INCARNATION = "buildIncarnation";
+  private static final String OWNER_EPOCH = "ownerEpoch";
+  private static final String COMPLETION_CUT = "completionCut";
+  private static final String COMPLETED_UNITS = "completedUnits";
+  private static final String SUSPENDED = "suspended";
+  private static final String FAILURE = "failure";
+  private static final String FAILURE_MESSAGE = "failureMessage";
+
+  private final Backend backend;
+
+  public IndexBuildStateStore(Backend backend) {
+    this.backend = Objects.requireNonNull(backend, "backend");
+  }
+
+  public IndexLifecycleSnapshot createInitial(RID descriptorIdentity) {
+    return create(IndexBuildState.initial(descriptorIdentity));
+  }
+
+  public IndexLifecycleSnapshot create(IndexBuildState state) {
+    var record = backend.create(state.descriptorIdentity(), serialize(state));
+    return snapshot(record);
+  }
+
+  public Optional<IndexLifecycleSnapshot> read(RID descriptorIdentity) {
+    return backend.read(descriptorIdentity).map(this::snapshot);
+  }
+
+  /** Recovers an existing record or creates a direct missing-record quarantine publication. */
+  public IndexLifecycleSnapshot recover(RID descriptorIdentity) {
+    var existing = read(descriptorIdentity);
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
+    }
+    return create(IndexBuildState.quarantineMissing(descriptorIdentity));
+  }
+
+  /**
+   * Updates one record after checking its durable version and then its lifecycle transition.
+   */
+  public IndexLifecycleSnapshot update(
+      RID descriptorIdentity, long expectedVersion, IndexBuildState replacement) {
+    var current = read(descriptorIdentity)
+        .orElseThrow(() -> new IllegalStateException("Index build state record is missing"));
+    if (current.recordVersion() != expectedVersion) {
+      throw new ConcurrentModificationException(
+          "Index build state version changed from " + expectedVersion + " to "
+              + current.recordVersion());
+    }
+
+    verifyReplacementDescriptor(current.buildState(), replacement, descriptorIdentity);
+    var currentLifecycle = current.lifecycle();
+    var replacementLifecycle = replacement.lifecycle();
+    if (currentLifecycle != replacementLifecycle
+        && !IndexBuildState.isLegalTransition(currentLifecycle, replacementLifecycle)) {
+      throw new IllegalArgumentException(
+          "Illegal index lifecycle transition from " + currentLifecycle + " to "
+              + replacementLifecycle);
+    }
+    if (currentLifecycle == IndexLifecycle.INVALID
+        && replacementLifecycle == IndexLifecycle.MAINTAINED) {
+      if (current.buildState().buildIncarnation().equals(replacement.buildIncarnation())) {
+        throw new IllegalArgumentException("A retry must start a new build incarnation");
+      }
+      if (replacement.ownerEpoch() != null) {
+        throw new IllegalArgumentException("A retry must clear the owner epoch");
+      }
+    }
+
+    return snapshot(backend.update(descriptorIdentity, expectedVersion, serialize(replacement)));
+  }
+
+  public void delete(RID descriptorIdentity, long expectedVersion) {
+    backend.delete(descriptorIdentity, expectedVersion);
+  }
+
+  Map<String, Object> serialize(IndexBuildState state) {
+    var record = new LinkedHashMap<String, Object>();
+    record.put(FORMAT_VERSION, state.formatVersion());
+    record.put(DESCRIPTOR_IDENTITY, state.descriptorIdentity().toString());
+    record.put(LIFECYCLE, state.lifecycle().name());
+    record.put(BUILD_INCARNATION, state.buildIncarnation().toString());
+    record.put(OWNER_EPOCH, state.ownerEpoch());
+    record.put(COMPLETION_CUT, state.completionCut());
+    record.put(COMPLETED_UNITS, state.completedUnits());
+    record.put(SUSPENDED, state.suspended());
+    record.put(FAILURE, state.failure().name());
+    record.put(FAILURE_MESSAGE, state.failureMessage());
+    return record;
+  }
+
+  IndexBuildState deserialize(Map<String, Object> record) {
+    return new IndexBuildState(
+        integer(record, FORMAT_VERSION),
+        RecordIdInternal.fromString(string(record, DESCRIPTOR_IDENTITY), false),
+        IndexLifecycle.valueOf(string(record, LIFECYCLE)),
+        UUID.fromString(string(record, BUILD_INCARNATION)),
+        nullableLong(record, OWNER_EPOCH),
+        nullableLong(record, COMPLETION_CUT),
+        longValue(record, COMPLETED_UNITS),
+        booleanValue(record, SUSPENDED),
+        IndexBuildFailure.valueOf(string(record, FAILURE)),
+        nullableString(record, FAILURE_MESSAGE));
+  }
+
+  private IndexLifecycleSnapshot snapshot(VersionedRecord record) {
+    return new IndexLifecycleSnapshot(deserialize(record.value()), record.version());
+  }
+
+  private static void verifyReplacementDescriptor(
+      IndexBuildState current, IndexBuildState replacement, RID descriptorIdentity) {
+    if (!current.descriptorIdentity().equals(descriptorIdentity)
+        || !replacement.descriptorIdentity().equals(descriptorIdentity)) {
+      throw new IllegalArgumentException("Index build state belongs to another descriptor");
+    }
+  }
+
+  private static String string(Map<String, Object> record, String field) {
+    return Objects.requireNonNull((String) record.get(field), field);
+  }
+
+  @Nullable private static String nullableString(Map<String, Object> record, String field) {
+    return (String) record.get(field);
+  }
+
+  private static int integer(Map<String, Object> record, String field) {
+    return ((Number) Objects.requireNonNull(record.get(field), field)).intValue();
+  }
+
+  private static long longValue(Map<String, Object> record, String field) {
+    return ((Number) Objects.requireNonNull(record.get(field), field)).longValue();
+  }
+
+  @Nullable private static Long nullableLong(Map<String, Object> record, String field) {
+    var value = (Number) record.get(field);
+    return value == null ? null : value.longValue();
+  }
+
+  private static boolean booleanValue(Map<String, Object> record, String field) {
+    return (Boolean) Objects.requireNonNull(record.get(field), field);
+  }
+
+  /** Durable record access supplied by the storage transaction integration. */
+  public interface Backend {
+
+    Optional<VersionedRecord> read(RID descriptorIdentity);
+
+    VersionedRecord create(RID descriptorIdentity, Map<String, Object> value);
+
+    VersionedRecord update(
+        RID descriptorIdentity, long expectedVersion, Map<String, Object> value);
+
+    void delete(RID descriptorIdentity, long expectedVersion);
+  }
+
+  /** One serialized durable record and its storage record version. */
+  public record VersionedRecord(Map<String, Object> value, long version) {
+
+    public VersionedRecord {
+      value = Collections.unmodifiableMap(new LinkedHashMap<>(value));
+      if (version < 0) {
+        throw new IllegalArgumentException("The record version cannot be negative");
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStore.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /** Owns serialization and versioned persistence rules for index build state records. */
@@ -31,42 +32,71 @@ public final class IndexBuildStateStore {
     this.backend = Objects.requireNonNull(backend, "backend");
   }
 
-  public IndexLifecycleSnapshot createInitial(RID descriptorIdentity) {
-    return create(IndexBuildState.initial(descriptorIdentity));
+  /** Creates an unlinked initial record after confirming that the descriptor has no link. */
+  public CreatedLifecycleRecord createInitial(
+      RID descriptorIdentity, @Nullable RID existingLifecycleIdentity) {
+    return create(IndexBuildState.initial(descriptorIdentity), existingLifecycleIdentity);
   }
 
-  public IndexLifecycleSnapshot create(IndexBuildState state) {
-    var record = backend.create(state.descriptorIdentity(), serialize(state));
-    return snapshot(record);
+  /** Creates an initial record through the creator of an enclosing atomic unit. */
+  public CreatedLifecycleRecord createInitial(
+      RID descriptorIdentity,
+      @Nullable RID existingLifecycleIdentity,
+      Function<Map<String, Object>, CreatedRecord> creator) {
+    return create(
+        IndexBuildState.initial(descriptorIdentity), existingLifecycleIdentity, creator);
   }
 
-  public Optional<IndexLifecycleSnapshot> read(RID descriptorIdentity) {
-    return backend.read(descriptorIdentity).map(this::snapshot);
+  /** Creates an unlinked record after confirming that the descriptor has no link. */
+  public CreatedLifecycleRecord create(
+      IndexBuildState state, @Nullable RID existingLifecycleIdentity) {
+    return create(state, existingLifecycleIdentity, backend::create);
   }
 
-  /** Recovers an existing record or creates a direct missing-record quarantine publication. */
-  public IndexLifecycleSnapshot recover(RID descriptorIdentity) {
-    var existing = read(descriptorIdentity);
-    if (existing.isPresent()) {
-      return existing.orElseThrow();
+  private CreatedLifecycleRecord create(
+      IndexBuildState state,
+      @Nullable RID existingLifecycleIdentity,
+      Function<Map<String, Object>, CreatedRecord> creator) {
+    if (existingLifecycleIdentity != null) {
+      throw new IllegalStateException("Index descriptor already has a lifecycle record link");
     }
-    return create(IndexBuildState.quarantineMissing(descriptorIdentity));
+    var created = creator.apply(serialize(state));
+    return new CreatedLifecycleRecord(created.identity(), snapshot(created.record()));
   }
 
-  /**
-   * Updates one record after checking its durable version and then its lifecycle transition.
-   */
-  public IndexLifecycleSnapshot update(
-      RID descriptorIdentity, long expectedVersion, IndexBuildState replacement) {
-    var current = read(descriptorIdentity)
-        .orElseThrow(() -> new IllegalStateException("Index build state record is missing"));
-    if (current.recordVersion() != expectedVersion) {
+  /** Reads the single lifecycle record named by the descriptor link. */
+  public IndexLifecycleSnapshot read(
+      RID descriptorIdentity, @Nullable RID lifecycleIdentity) {
+    if (lifecycleIdentity == null) {
+      throw new IllegalStateException("Index descriptor has no lifecycle record link");
+    }
+    var record =
+        backend
+            .read(lifecycleIdentity)
+            .orElseThrow(() -> new MissingLinkedRecordException(lifecycleIdentity));
+    var snapshot = snapshot(record);
+    verifyDescriptor(snapshot.buildState(), descriptorIdentity);
+    return snapshot;
+  }
+
+  /** Publishes one record after comparing the expected snapshot by value except owner epoch. */
+  public IndexLifecycleSnapshot publish(
+      RID descriptorIdentity,
+      RID lifecycleIdentity,
+      IndexLifecycleSnapshot expected,
+      IndexBuildState replacement) {
+    verifyReplacementDescriptor(expected.buildState(), replacement, descriptorIdentity);
+    var current = read(descriptorIdentity, lifecycleIdentity);
+    if (current.recordVersion() != expected.recordVersion()
+        || !current
+            .buildState()
+            .withoutProcessOwnership()
+            .equals(expected.buildState().withoutProcessOwnership())) {
       throw new ConcurrentModificationException(
-          "Index build state version changed from " + expectedVersion + " to "
-              + current.recordVersion());
+          "Index build state changed from expected revision " + expected.recordVersion()
+              + " to durable revision " + current.recordVersion());
     }
 
-    verifyReplacementDescriptor(current.buildState(), replacement, descriptorIdentity);
     var currentLifecycle = current.lifecycle();
     var replacementLifecycle = replacement.lifecycle();
     if (currentLifecycle != replacementLifecycle
@@ -85,11 +115,12 @@ public final class IndexBuildStateStore {
       }
     }
 
-    return snapshot(backend.update(descriptorIdentity, expectedVersion, serialize(replacement)));
+    return snapshot(
+        backend.update(lifecycleIdentity, current.recordVersion(), serialize(replacement)));
   }
 
-  public void delete(RID descriptorIdentity, long expectedVersion) {
-    backend.delete(descriptorIdentity, expectedVersion);
+  public void delete(RID lifecycleIdentity, long expectedVersion) {
+    backend.delete(lifecycleIdentity, expectedVersion);
   }
 
   Map<String, Object> serialize(IndexBuildState state) {
@@ -127,48 +158,92 @@ public final class IndexBuildStateStore {
 
   private static void verifyReplacementDescriptor(
       IndexBuildState current, IndexBuildState replacement, RID descriptorIdentity) {
-    if (!current.descriptorIdentity().equals(descriptorIdentity)
-        || !replacement.descriptorIdentity().equals(descriptorIdentity)) {
+    verifyDescriptor(current, descriptorIdentity);
+    verifyDescriptor(replacement, descriptorIdentity);
+  }
+
+  private static void verifyDescriptor(IndexBuildState state, RID descriptorIdentity) {
+    if (!state.descriptorIdentity().equals(descriptorIdentity)) {
       throw new IllegalArgumentException("Index build state belongs to another descriptor");
     }
   }
 
   private static String string(Map<String, Object> record, String field) {
-    return Objects.requireNonNull((String) record.get(field), field);
+    return requiredValue(record, field, String.class);
   }
 
   @Nullable private static String nullableString(Map<String, Object> record, String field) {
-    return (String) record.get(field);
+    return nullableValue(record, field, String.class);
   }
 
   private static int integer(Map<String, Object> record, String field) {
-    return ((Number) Objects.requireNonNull(record.get(field), field)).intValue();
+    return requiredValue(record, field, Integer.class);
   }
 
   private static long longValue(Map<String, Object> record, String field) {
-    return ((Number) Objects.requireNonNull(record.get(field), field)).longValue();
+    return requiredValue(record, field, Long.class);
   }
 
   @Nullable private static Long nullableLong(Map<String, Object> record, String field) {
-    var value = (Number) record.get(field);
-    return value == null ? null : value.longValue();
+    return nullableValue(record, field, Long.class);
   }
 
   private static boolean booleanValue(Map<String, Object> record, String field) {
-    return (Boolean) Objects.requireNonNull(record.get(field), field);
+    return requiredValue(record, field, Boolean.class);
+  }
+
+  private static <T> T requiredValue(
+      Map<String, Object> record, String field, Class<T> expectedType) {
+    return Objects.requireNonNull(nullableValue(record, field, expectedType), field);
+  }
+
+  @Nullable private static <T> T nullableValue(
+      Map<String, Object> record, String field, Class<T> expectedType) {
+    var value = record.get(field);
+    if (value != null && !expectedType.isInstance(value)) {
+      throw new IllegalArgumentException(
+          "Index build state field " + field + " must have type " + expectedType.getSimpleName());
+    }
+    return expectedType.cast(value);
+  }
+
+  /** Signals that the descriptor link names no durable lifecycle record. */
+  public static final class MissingLinkedRecordException extends IllegalStateException {
+
+    public MissingLinkedRecordException(RID lifecycleIdentity) {
+      super("Linked index build state record is missing");
+      Objects.requireNonNull(lifecycleIdentity, "lifecycleIdentity");
+    }
   }
 
   /** Durable record access supplied by the storage transaction integration. */
   public interface Backend {
 
-    Optional<VersionedRecord> read(RID descriptorIdentity);
+    Optional<VersionedRecord> read(RID recordIdentity);
 
-    VersionedRecord create(RID descriptorIdentity, Map<String, Object> value);
+    CreatedRecord create(Map<String, Object> value);
 
-    VersionedRecord update(
-        RID descriptorIdentity, long expectedVersion, Map<String, Object> value);
+    VersionedRecord update(RID recordIdentity, long expectedVersion, Map<String, Object> value);
 
-    void delete(RID descriptorIdentity, long expectedVersion);
+    void delete(RID recordIdentity, long expectedVersion);
+  }
+
+  /** The durable address and committed value of a newly created lifecycle record. */
+  public record CreatedRecord(RID identity, VersionedRecord record) {
+
+    public CreatedRecord {
+      Objects.requireNonNull(identity, "identity");
+      Objects.requireNonNull(record, "record");
+    }
+  }
+
+  /** The durable address and immutable snapshot of a newly created lifecycle record. */
+  public record CreatedLifecycleRecord(RID identity, IndexLifecycleSnapshot snapshot) {
+
+    public CreatedLifecycleRecord {
+      Objects.requireNonNull(identity, "identity");
+      Objects.requireNonNull(snapshot, "snapshot");
+    }
   }
 
   /** One serialized durable record and its storage record version. */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycle.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycle.java
@@ -1,0 +1,6 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+/** In-memory lifecycle state used to gate index maintenance and reads. */
+public enum IndexLifecycle {
+  EXISTS, MAINTAINED, USABLE, INVALID
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
@@ -1,0 +1,21 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import javax.annotation.Nonnull;
+
+/** Stable storage-scoped carrier shared by every handle for one durable index descriptor. */
+public final class IndexLifecycleCell {
+
+  private volatile IndexLifecycle value;
+
+  IndexLifecycleCell(@Nonnull IndexLifecycle value) {
+    this.value = value;
+  }
+
+  public IndexLifecycle get() {
+    return value;
+  }
+
+  public void set(@Nonnull IndexLifecycle value) {
+    this.value = value;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
@@ -1,21 +1,41 @@
 package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
 
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nonnull;
 
 /** Stable storage-scoped carrier shared by every handle for one durable index descriptor. */
 public final class IndexLifecycleCell {
 
-  private volatile IndexLifecycle value;
+  private final AtomicReference<IndexLifecycleSnapshot> snapshot;
 
-  IndexLifecycleCell(@Nonnull IndexLifecycle value) {
-    this.value = value;
+  IndexLifecycleCell(@Nonnull IndexLifecycleSnapshot snapshot) {
+    this.snapshot = new AtomicReference<>(snapshot);
+  }
+
+  public IndexLifecycleSnapshot snapshot() {
+    var current = snapshot.get();
+    if (current == null) {
+      throw new IllegalStateException("The lifecycle cell belongs to a retired storage lineage");
+    }
+    return current;
   }
 
   public IndexLifecycle get() {
-    return value;
+    return snapshot().lifecycle();
   }
 
-  public void set(@Nonnull IndexLifecycle value) {
-    this.value = value;
+  public boolean compareAndSet(
+      @Nonnull IndexLifecycleSnapshot expected, @Nonnull IndexLifecycleSnapshot replacement) {
+    if (replacement.recordVersion() < expected.recordVersion()) {
+      throw new IllegalArgumentException("A lifecycle snapshot cannot move to an older version");
+    }
+    if (snapshot.get() == null) {
+      throw new IllegalStateException("The lifecycle cell belongs to a retired storage lineage");
+    }
+    return snapshot.compareAndSet(expected, replacement);
+  }
+
+  void retire() {
+    snapshot.set(null);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleCell.java
@@ -26,13 +26,51 @@ public final class IndexLifecycleCell {
 
   public boolean compareAndSet(
       @Nonnull IndexLifecycleSnapshot expected, @Nonnull IndexLifecycleSnapshot replacement) {
-    if (replacement.recordVersion() < expected.recordVersion()) {
-      throw new IllegalArgumentException("A lifecycle snapshot cannot move to an older version");
+    var descriptorIdentity = expected.buildState().descriptorIdentity();
+    if (!descriptorIdentity.equals(replacement.buildState().descriptorIdentity())) {
+      throw new IllegalArgumentException("The lifecycle snapshot belongs to another descriptor");
     }
-    if (snapshot.get() == null) {
-      throw new IllegalStateException("The lifecycle cell belongs to a retired storage lineage");
+
+    while (true) {
+      var current = snapshot.get();
+      if (current == null) {
+        throw new IllegalStateException("The lifecycle cell belongs to a retired storage lineage");
+      }
+      if (!descriptorIdentity.equals(current.buildState().descriptorIdentity())) {
+        throw new IllegalArgumentException("The lifecycle snapshot belongs to another descriptor");
+      }
+      if (replacement.recordVersion() < current.recordVersion()) {
+        throw new IllegalArgumentException("A lifecycle snapshot cannot move to an older version");
+      }
+      if (!current.equals(expected)) {
+        return false;
+      }
+      if (snapshot.compareAndSet(current, replacement)) {
+        return true;
+      }
     }
-    return snapshot.compareAndSet(expected, replacement);
+  }
+
+  /** Publishes recovered state unless the cell already holds a newer durable revision. */
+  void recover(@Nonnull IndexLifecycleSnapshot replacement) {
+    while (true) {
+      var current = snapshot.get();
+      if (current == null) {
+        throw new IllegalStateException("The lifecycle cell belongs to a retired storage lineage");
+      }
+      if (!current.buildState().descriptorIdentity()
+          .equals(replacement.buildState().descriptorIdentity())) {
+        throw new IllegalArgumentException("The lifecycle snapshot belongs to another descriptor");
+      }
+      if (replacement.recordVersion() < current.recordVersion()
+          && replacement.buildState().failure()
+              != IndexBuildFailure.INDEX_BUILD_STATE_MISSING) {
+        return;
+      }
+      if (snapshot.compareAndSet(current, replacement)) {
+        return;
+      }
+    }
   }
 
   void retire() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
@@ -1,0 +1,20 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+
+/** Storage-scoped lifecycle cells keyed by durable index descriptor identity. */
+public final class IndexLifecycleRegistry {
+
+  private final ConcurrentHashMap<RID, IndexLifecycleCell> cells = new ConcurrentHashMap<>();
+
+  public IndexLifecycleCell getOrCreate(@Nonnull RID descriptorIdentity) {
+    return cells.computeIfAbsent(
+        descriptorIdentity, ignored -> new IndexLifecycleCell(IndexLifecycle.USABLE));
+  }
+
+  public void remove(@Nonnull RID descriptorIdentity) {
+    cells.remove(descriptorIdentity);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /** Storage-scoped lifecycle cells keyed by durable index descriptor identity. */
 public final class IndexLifecycleRegistry {
@@ -12,6 +13,10 @@ public final class IndexLifecycleRegistry {
   public IndexLifecycleCell getOrCreate(@Nonnull RID descriptorIdentity) {
     return cells.computeIfAbsent(
         descriptorIdentity, ignored -> new IndexLifecycleCell(IndexLifecycle.USABLE));
+  }
+
+  @Nullable public IndexLifecycleCell get(@Nonnull RID descriptorIdentity) {
+    return cells.get(descriptorIdentity);
   }
 
   public void remove(@Nonnull RID descriptorIdentity) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
@@ -43,6 +43,35 @@ public final class IndexLifecycleRegistry {
     }
   }
 
+  /** Publishes durable recovery state while preserving a current-lineage cell. */
+  public IndexLifecycleCell recover(
+      @Nonnull RID descriptorIdentity, @Nonnull IndexLifecycleSnapshot recoveredSnapshot) {
+    if (!descriptorIdentity.equals(recoveredSnapshot.buildState().descriptorIdentity())) {
+      throw new IllegalArgumentException("The lifecycle snapshot belongs to another descriptor");
+    }
+
+    while (true) {
+      var registration = cells.compute(
+          descriptorIdentity,
+          (ignored, existing) -> {
+            var lineage = currentLineage.get();
+            if (existing != null && existing.lineageIdentity().equals(lineage)) {
+              existing.cell().recover(recoveredSnapshot);
+              return existing;
+            }
+            if (existing != null) {
+              existing.cell().retire();
+            }
+            return new Registration(lineage, new IndexLifecycleCell(recoveredSnapshot));
+          });
+      if (registration.lineageIdentity().equals(currentLineage.get())) {
+        return registration.cell();
+      }
+      registration.cell().retire();
+      cells.remove(descriptorIdentity, registration);
+    }
+  }
+
   @Nullable public IndexLifecycleCell get(@Nonnull RID descriptorIdentity) {
     while (true) {
       var registration = cells.get(descriptorIdentity);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistry.java
@@ -1,25 +1,85 @@
 package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
 
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Storage-scoped lifecycle cells keyed by durable index descriptor identity. */
 public final class IndexLifecycleRegistry {
 
-  private final ConcurrentHashMap<RID, IndexLifecycleCell> cells = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<RID, Registration> cells = new ConcurrentHashMap<>();
+  private final Supplier<StorageLineageIdentity> currentLineage;
 
-  public IndexLifecycleCell getOrCreate(@Nonnull RID descriptorIdentity) {
-    return cells.computeIfAbsent(
-        descriptorIdentity, ignored -> new IndexLifecycleCell(IndexLifecycle.USABLE));
+  public IndexLifecycleRegistry(Supplier<StorageLineageIdentity> currentLineage) {
+    this.currentLineage = Objects.requireNonNull(currentLineage, "currentLineage");
+  }
+
+  public IndexLifecycleCell getOrCreate(
+      @Nonnull RID descriptorIdentity, @Nonnull IndexLifecycleSnapshot initialSnapshot) {
+    if (!descriptorIdentity.equals(initialSnapshot.buildState().descriptorIdentity())) {
+      throw new IllegalArgumentException("The lifecycle snapshot belongs to another descriptor");
+    }
+
+    while (true) {
+      var registration = cells.compute(descriptorIdentity, (ignored, existing) -> {
+        var lineage = currentLineage.get();
+        if (existing != null && existing.lineageIdentity().equals(lineage)) {
+          return existing;
+        }
+        if (existing != null) {
+          existing.cell().retire();
+        }
+        return new Registration(lineage, new IndexLifecycleCell(initialSnapshot));
+      });
+      if (registration.lineageIdentity().equals(currentLineage.get())) {
+        return registration.cell();
+      }
+      registration.cell().retire();
+      cells.remove(descriptorIdentity, registration);
+    }
   }
 
   @Nullable public IndexLifecycleCell get(@Nonnull RID descriptorIdentity) {
-    return cells.get(descriptorIdentity);
+    while (true) {
+      var registration = cells.get(descriptorIdentity);
+      if (registration == null) {
+        return null;
+      }
+      if (registration.lineageIdentity().equals(currentLineage.get())) {
+        return registration.cell();
+      }
+      registration.cell().retire();
+      cells.remove(descriptorIdentity, registration);
+    }
   }
 
   public void remove(@Nonnull RID descriptorIdentity) {
     cells.remove(descriptorIdentity);
+  }
+
+  /** Drops all cells created under a previous storage lineage. */
+  public void dropStale() {
+    var lineage = currentLineage.get();
+    cells.forEach((descriptorIdentity, ignored) -> cells.computeIfPresent(descriptorIdentity,
+        (descriptor, registration) -> {
+          if (registration.lineageIdentity().equals(lineage)) {
+            return registration;
+          }
+          registration.cell().retire();
+          return null;
+        }));
+  }
+
+  private record Registration(
+      StorageLineageIdentity lineageIdentity, IndexLifecycleCell cell) {
+
+    private Registration {
+      Objects.requireNonNull(lineageIdentity, "lineageIdentity");
+      Objects.requireNonNull(cell, "cell");
+    }
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleSnapshot.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleSnapshot.java
@@ -1,0 +1,18 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import java.util.Objects;
+
+/** Immutable in-memory view of one durable index build state revision. */
+public record IndexLifecycleSnapshot(IndexBuildState buildState, long recordVersion) {
+
+  public IndexLifecycleSnapshot {
+    Objects.requireNonNull(buildState, "buildState");
+    if (recordVersion < 0) {
+      throw new IllegalArgumentException("The record version cannot be negative");
+    }
+  }
+
+  public IndexLifecycle lifecycle() {
+    return buildState.lifecycle();
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/MetadataDefault.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/MetadataDefault.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 public class MetadataDefault implements MetadataInternal {
 
   public static final String COLLECTION_INTERNAL_NAME = "internal";
+  public static final String INDEX_BUILD_STATE_COLLECTION_NAME = "index_build_state";
 
   /**
    * The collection id of {@link #COLLECTION_INTERNAL_NAME}: always {@code 0} — it is the first

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/function/Function.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/function/Function.java
@@ -46,7 +46,7 @@ public class Function extends IdentityWrapper {
   public static final String LANGUAGE_PROPERTY = "language";
   public static final String PARAMETERS_PROPERTY = "parameters";
   public static final String IDEMPOTENT_PROPERTY = "idempotent";
-  private CallableFunction<Object, Map<Object, Object>> callback;
+  private volatile CallableFunction<Object, Map<Object, Object>> callback;
 
   private volatile String name;
   private volatile String code;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecurityShared.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecurityShared.java
@@ -686,6 +686,9 @@ public class SecurityShared implements SecurityInternal {
     writerRole.addRule(session,
         ResourceGeneric.COLLECTION,
         MetadataDefault.COLLECTION_INTERNAL_NAME, Role.PERMISSION_READ);
+    writerRole.addRule(session,
+        ResourceGeneric.COLLECTION,
+        MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME, Role.PERMISSION_READ);
     writerRole.addRule(session, ResourceGeneric.CLASS, null, Role.PERMISSION_ALL);
     writerRole.addRule(session, ResourceGeneric.CLASS, "OUser", Role.PERMISSION_READ);
     writerRole.addRule(session, ResourceGeneric.COLLECTION, null, Role.PERMISSION_ALL);
@@ -715,6 +718,13 @@ public class SecurityShared implements SecurityInternal {
         Rule.ResourceGeneric.COLLECTION.getLegacyName()
             + "."
             + MetadataDefault.COLLECTION_INTERNAL_NAME,
+        Role.PERMISSION_READ);
+    setSecurityPolicyWithBitmask(
+        session,
+        writerRole,
+        Rule.ResourceGeneric.COLLECTION.getLegacyName()
+            + "."
+            + MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME,
         Role.PERMISSION_READ);
     setSecurityPolicyWithBitmask(
         session,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/schedule/ScheduledEvent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/schedule/ScheduledEvent.java
@@ -23,6 +23,7 @@ import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBInternalEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.tool.DatabaseExportException;
 import com.jetbrains.youtrackdb.internal.core.metadata.function.Function;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
@@ -172,6 +173,28 @@ public class ScheduledEvent extends IdentityWrapper {
 
   private void setRunning(boolean running) {
     this.running.set(running);
+  }
+
+  static String summarizeResult(Object result) {
+    try {
+      if (result == null) {
+        return "<null>";
+      }
+
+      final var typeName = result.getClass().getName();
+      if (result instanceof Identifiable identifiable) {
+        return "%s rid=%s".formatted(typeName, identifiable.getIdentity());
+      }
+
+      return typeName;
+    } catch (RuntimeException exception) {
+      return "<unavailable>";
+    }
+  }
+
+  static String completionMessage(String eventName, long executionId, String resultSummary) {
+    return "Scheduled event '%s' executionId=%d completed with result: %s"
+        .formatted(eventName, executionId, resultSummary);
   }
 
   private static class ScheduledTimerTask implements Runnable {
@@ -337,21 +360,20 @@ public class ScheduledEvent extends IdentityWrapper {
     }
 
     private void executeEventFunction(DatabaseSessionEmbedded session) {
-      Object result = null;
+      String resultSummary = "<unavailable>";
       try {
         var context = new BasicCommandContext();
         context.setDatabaseSession(session);
 
-        result = session.computeInTx(
-            transaction -> event.getFunction().executeInContext(context, event.getArguments()));
+        resultSummary =
+            session.computeInTx(
+                transaction -> summarizeResult(
+                    event.getFunction().executeInContext(context, event.getArguments())));
       } finally {
         LogManager.instance()
             .info(
                 this,
-                "Scheduled event '%s' executionId=%d completed with result: %s",
-                event.getName(),
-                event.nextExecutionId.get(),
-                result);
+                completionMessage(event.getName(), event.nextExecutionId.get(), resultSummary));
         for (var retry = 0; retry < 10; ++retry) {
           session.executeInTx(
               transaction -> {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerImpl.java
@@ -120,12 +120,18 @@ public class SchedulerImpl {
       oldEvent.interrupt();
     }
     scheduleEvent(session, event);
-    LogManager.instance()
-        .debug(
-            this,
-            "Updated scheduled event '%s' rid=%s...",
-            logger, event,
-            event.getIdentity());
+    if (logger.isDebugEnabled()) {
+      LogManager.instance().debug(this, updatedEventMessage(event), logger);
+    }
+  }
+
+  static String updatedEventMessage(ScheduledEvent event) {
+    try {
+      return "Updated scheduled event '%s' rid=%s..."
+          .formatted(event.getName(), event.getIdentity());
+    } catch (RuntimeException exception) {
+      return "Updated scheduled event <unavailable>";
+    }
   }
 
   public Map<String, ScheduledEvent> getEvents() {
@@ -167,15 +173,15 @@ public class SchedulerImpl {
         .createClass(ScheduledEvent.CLASS_NAME);
 
     f.createProperty(ScheduledEvent.PROP_NAME, PropertyTypeInternal.STRING,
-            (PropertyTypeInternal) null,
-            true)
+        (PropertyTypeInternal) null,
+        true)
         .setMandatory(true)
         .setNotNull(true);
     f.createIndex(ScheduledEvent.PROP_NAME + "Index", SchemaClass.INDEX_TYPE.UNIQUE,
         ScheduledEvent.PROP_NAME);
     f.createProperty(ScheduledEvent.PROP_RULE, PropertyTypeInternal.STRING,
-            (PropertyTypeInternal) null,
-            true)
+        (PropertyTypeInternal) null,
+        true)
         .setMandatory(true)
         .setNotNull(true);
     f.createProperty(ScheduledEvent.PROP_ARGUMENTS, PropertyTypeInternal.EMBEDDEDMAP,
@@ -185,9 +191,9 @@ public class SchedulerImpl {
         (PropertyTypeInternal) null,
         true);
     f.createProperty(
-            ScheduledEvent.PROP_FUNC,
-            PropertyTypeInternal.LINK,
-            database.getMetadata().getSchema().getClass(Function.CLASS_NAME), true)
+        ScheduledEvent.PROP_FUNC,
+        PropertyTypeInternal.LINK,
+        database.getMetadata().getSchema().getClass(Function.CLASS_NAME), true)
         .setMandatory(true)
         .setNotNull(true);
     f.createProperty(ScheduledEvent.PROP_STARTTIME, PropertyTypeInternal.DATETIME,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
@@ -20,6 +20,7 @@ import com.jetbrains.youtrackdb.internal.core.config.StorageSegmentConfiguration
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
 import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
@@ -290,15 +291,18 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
       btree.load(COMPONENT_NAME, 1, null, StringSerializer.INSTANCE, atomicOperation);
 
       preloadIntProperties(atomicOperation);
-      // Reject-and-redirect gate for the storage format (the storage-format arm of the same
-      // policy SchemaShared.fromStream applies to the schema record). It must run here — before
-      // readConfiguration or any other property parse, and before any engine, index, or
-      // collection component touches its files — because this load is the single choke point
-      // every open path funnels through (AbstractStorage.open, DiskStorage.initConfiguration,
-      // and the incremental-restore reopen). Gating first means a mismatched format always
-      // surfaces as the clear redirect, never as a downstream parse error against a layout these
-      // binaries cannot know (and never as a raw file-does-not-exist crash in openIndexes).
-      validateStorageFormatVersion();
+      // Track 24 turned this later check into a consistency check. Storage admission already
+      // read the storage layout version from the bootstrap authority record and already accepted
+      // the storage image. This check therefore compares the storage configuration against that
+      // accepted record and never reverses the admission decision.
+      // The check must run here, before readConfiguration and before any other property parse.
+      // The check must also run before any engine, index, or collection component touches its
+      // files. This load is the single choke point of every open path, which covers
+      // AbstractStorage.open, DiskStorage.initConfiguration, and the incremental-restore reopen.
+      // Checking first means a mismatched layout always surfaces as the named
+      // inconsistent-metadata result. A mismatched layout never surfaces as a downstream parse
+      // error against a layout these binaries cannot know.
+      checkStorageLayoutVersionConsistency();
 
       readConfiguration(atomicOperation);
 
@@ -316,10 +320,10 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
       final var properties = (Map<String, String>) cache.get(PROPERTIES);
       validation = properties != null
           && "true".equalsIgnoreCase(properties.get(VALIDATION_PROPERTY));
-    } catch (ConfigurationException e) {
-      // The format-version gate's rejection is the user-facing redirect; rethrow it unwrapped so
-      // the export/import message is the primary error, not a cause buried under a generic
-      // "can not load storage configuration".
+    } catch (ConfigurationException | InconsistentStorageMetadataException e) {
+      // The layout consistency check and the schema-version gate both report a user-facing
+      // result. Rethrow each result unwrapped, so the result stays the primary error. A wrapped
+      // result would hide under a generic "can not load storage configuration" message.
       cache.clear();
       throw e;
     } catch (Exception e) {
@@ -332,28 +336,49 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
   }
 
   /**
-   * Rejects a database whose persisted storage-format version does not exactly match
-   * {@link #CURRENT_VERSION}. Both directions are rejected: an older format cannot be upgraded in
-   * place (the engine-file-id format has no computable default for pre-24 entries), and a newer
-   * format cannot be read by these binaries. Reads the just-preloaded cache directly instead of
-   * {@code getVersion} because the caller holds the non-reentrant write lock.
+   * Compares the storage layout version of the storage configuration against the storage layout
+   * version of the bootstrap authority record.
+   *
+   * <p>The bootstrap authority record is the durable record that names one storage identity, one
+   * storage lineage, and one lifecycle state. Storage admission accepts an image only when the
+   * record carries the supported storage layout version. The supported storage layout version is
+   * {@link #CURRENT_VERSION}. A comparison against that constant is therefore a comparison against
+   * the accepted record.
+   *
+   * <p>Both directions of a disagreement report the named inconsistent-metadata result. An older
+   * layout has no in-place upgrade, because the engine file base identifier format has no
+   * computable default for an entry written before version 24. A newer layout is unreadable for
+   * these binaries. The check reads the preloaded cache directly instead of {@code getVersion},
+   * because the caller holds the non-reentrant write lock.
+   *
+   * <p>Both messages name the two disagreeing sources and the operator action. Neither message
+   * describes the admission decision, because an operator cannot act on that internal detail.
    */
-  private void validateStorageFormatVersion() {
+  private void checkStorageLayoutVersionConsistency() {
     final var version = (Integer) cache.get(VERSION_PROPERTY);
     if (version == null || version < CURRENT_VERSION) {
-      throw new ConfigurationException(storage.getName(),
-          "Storage format version " + (version == null ? "<missing>" : version)
-              + " of database '" + storage.getName() + "' predates the current format (version "
-              + CURRENT_VERSION + "). Direct upgrade of the storage format is not supported:"
-              + " please export your old database with the previous version of YouTrackDB and"
-              + " reimport it using the current one.");
+      throw new InconsistentStorageMetadataException(storage.getName(),
+          InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+          "Inconsistent storage metadata of database '" + storage.getName()
+              + "'. The storage configuration reports storage layout version "
+              + (version == null ? "<missing>" : version)
+              + ". The bootstrap authority record reports storage layout version "
+              + CURRENT_VERSION
+              + ". A direct upgrade of the storage layout is not supported. Export database '"
+              + storage.getName()
+              + "' with the earlier version of YouTrackDB, and import that export with the"
+              + " current version of YouTrackDB.");
     }
     if (version > CURRENT_VERSION) {
-      throw new ConfigurationException(storage.getName(),
-          "Storage format version " + version + " of database '" + storage.getName()
-              + "' is newer than the format this version of YouTrackDB supports (version "
-              + CURRENT_VERSION + "). Please open the database with the YouTrackDB version that"
-              + " created it.");
+      throw new InconsistentStorageMetadataException(storage.getName(),
+          InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+          "Inconsistent storage metadata of database '" + storage.getName()
+              + "'. The storage configuration reports storage layout version " + version
+              + ". The bootstrap authority record reports storage layout version "
+              + CURRENT_VERSION
+              + ". The stored layout is newer than the layout of this build. Open database '"
+              + storage.getName()
+              + "' with the version of YouTrackDB that created the database.");
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
@@ -58,6 +58,11 @@ import com.jetbrains.youtrackdb.internal.core.storage.config.CollectionBasedStor
 import com.jetbrains.youtrackdb.internal.core.storage.fs.File;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.StartupMetadata;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.LineageFloorAdoption;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageStartupMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.operationsfreezer.FreezeKind;
@@ -227,7 +232,10 @@ public class DiskStorage extends AbstractStorage {
       BTreeMultiValueIndexEngine.M_CONTAINER_EXTENSION,
       IndexHistogramManager.IXS_EXTENSION,
       DoubleWriteLogGL.EXTENSION,
-      FreeSpaceMap.DEF_EXTENSION
+      FreeSpaceMap.DEF_EXTENSION,
+      ".bsm",
+      ".bsm.tmp",
+      ".bsml"
   };
 
   private static final int ONE_KB = 1024;
@@ -235,7 +243,11 @@ public class DiskStorage extends AbstractStorage {
   private final int deleteMaxRetries;
   private final int deleteWaitTime;
 
+  private static final FeatureFormatIdentity FEATURE_FORMAT = new FeatureFormatIdentity(1);
+
   private final StorageStartupMetadata startupMetadata;
+  @Nullable private StorageBootstrapMetadata bootstrapMetadata;
+  @Nullable private StorageBootstrapMetadata.Snapshot bootstrapSnapshot;
 
   private final Path storagePath;
   private final ClosableLinkedContainer<Long, File> files;
@@ -257,7 +269,7 @@ public class DiskStorage extends AbstractStorage {
       final long walMaxSegSize,
       long doubleWriteLogMaxSegSize,
       YouTrackDBInternalEmbedded context) {
-    super(name, filePath, id, context);
+    super(name, filePath, id, context, false);
 
     this.walMaxSegSize = walMaxSegSize;
     this.files = files;
@@ -317,6 +329,58 @@ public class DiskStorage extends AbstractStorage {
     }
 
     super.doCreate(contextConfiguration);
+  }
+
+  @Override
+  protected void prepareStorageBirth() {
+    try {
+      var birth = bootstrapMetadata().createBirth(StorageIdentity.random(),
+          StorageLineageIdentity.random());
+      bootstrapSnapshot = birth;
+      updateStorageIdentity(birth.storageIdentity(), birth.lineageIdentity());
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(name, "Cannot publish the storage bootstrap birth"),
+          exception,
+          name);
+    }
+  }
+
+  @Override
+  protected void activateStorageBirth() {
+    activateBootstrapSnapshot("Cannot activate the storage bootstrap birth");
+  }
+
+  @Override
+  protected void readStorageIdentity() {
+    try {
+      var active = bootstrapMetadata().readActiveRequired();
+      bootstrapSnapshot = active;
+      updateStorageIdentity(active.storageIdentity(), active.lineageIdentity());
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(name, "Cannot read the storage bootstrap authority"),
+          exception,
+          name);
+    }
+  }
+
+  private StorageBootstrapMetadata bootstrapMetadata() throws IOException {
+    if (bootstrapMetadata == null) {
+      bootstrapMetadata = new StorageBootstrapMetadata(storagePath, FEATURE_FORMAT);
+    }
+    return bootstrapMetadata;
+  }
+
+  void activateBootstrapSnapshot(String errorMessage) {
+    try {
+      var active = bootstrapMetadata().activate(
+          java.util.Objects.requireNonNull(bootstrapSnapshot, "bootstrapSnapshot"));
+      bootstrapSnapshot = active;
+      updateStorageIdentity(active.storageIdentity(), active.lineageIdentity());
+    } catch (IOException exception) {
+      throw BaseException.wrapException(new StorageException(name, errorMessage), exception, name);
+    }
   }
 
   @Override
@@ -1619,6 +1683,7 @@ public class DiskStorage extends AbstractStorage {
                   + "impossible.");
         }
 
+        beginLineageReplacement();
         var result = preprocessingIncrementalRestore();
         for (var ibuFilePair : tempIBUFiles) {
           var ibuPath = ibuFilePair.left();
@@ -1642,6 +1707,8 @@ public class DiskStorage extends AbstractStorage {
         }
 
         postProcessIncrementalRestore(result.contextConfiguration);
+        activateBootstrapSnapshot("Cannot activate the restored storage lineage");
+        dropStaleIndexLifecycles();
       } finally {
         PathUtils.deleteDirectory(tmpDirectory);
         LogManager.instance().info(this, "Temporary directory for backup restore %s deleted.",
@@ -1653,6 +1720,20 @@ public class DiskStorage extends AbstractStorage {
           new StorageException(name, "Error during restore from backup"), e, name);
     } finally {
       stateLock.writeLock().unlock();
+    }
+  }
+
+  void beginLineageReplacement() {
+    try {
+      var current = java.util.Objects.requireNonNull(bootstrapSnapshot, "bootstrapSnapshot");
+      var pending = bootstrapMetadata().beginLineageReplacement(
+          current, new LineageFloorAdoption(current.format(), current.sequenceFloor()));
+      bootstrapSnapshot = pending;
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(name, "Cannot publish the storage restore authority"),
+          exception,
+          name);
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
@@ -33,7 +33,9 @@ import com.jetbrains.youtrackdb.internal.common.serialization.types.ShortSeriali
 import com.jetbrains.youtrackdb.internal.core.YouTrackDBConstants;
 import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
 import com.jetbrains.youtrackdb.internal.core.config.ContextConfiguration;
+import com.jetbrains.youtrackdb.internal.core.config.StorageConfiguration;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBInternalEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.engine.local.EngineLocalPaginated;
@@ -60,6 +62,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.StartupMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.LineageFloorAdoption;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
@@ -89,9 +92,12 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -346,17 +352,204 @@ public class DiskStorage extends AbstractStorage {
     }
   }
 
+  /**
+   * Forces every genesis artifact of this disk image to durable media.
+   *
+   * <p>The barrier flushes dirty index histogram data first. An index histogram is index
+   * statistics data that the index engine keeps in a separate file. The barrier then flushes every
+   * index engine. The barrier then flushes the write-ahead log. The barrier then flushes the write
+   * cache, which synchronizes every storage file.
+   *
+   * <p>The plain flush helper {@code flushAllData} is insufficient alone. That helper skips index
+   * histogram data by contract. The barrier therefore uses the wider path.
+   *
+   * <p>The barrier fails closed. A storage in the internal error state and a failed flush both
+   * reach the caller. The creation path therefore publishes no active lifecycle state over content
+   * that never reached durable media.
+   */
+  @Override
+  protected void barrierOverGenesisArtifacts() {
+    barrierWithOwnStateLock();
+  }
+
   @Override
   protected void activateStorageBirth() {
     activateBootstrapSnapshot("Cannot activate the storage bootstrap birth");
   }
 
+  /**
+   * Publishes the restore-in-progress lifecycle state of this fresh restore target.
+   *
+   * <p>The restore path calls this method directly after the creation of the storage files. The
+   * creation published the birth-in-progress lifecycle state, and this method replaces that state
+   * without any activation. A restore target therefore never appears as an empty active database.
+   */
+  @Override
+  public void beginRestoreLifecycle() {
+    try {
+      var current = java.util.Objects.requireNonNull(bootstrapSnapshot, "bootstrapSnapshot");
+      bootstrapSnapshot = bootstrapMetadata().beginRestoreFromBirth(current);
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(name, "Cannot publish the restore-in-progress lifecycle state"),
+          exception,
+          name);
+    }
+  }
+
+  /**
+   * Deletes one interrupted restore target inside one exclusive unit.
+   *
+   * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+   * restore. This method performs the deletion part of that restart. The acceptance check and the
+   * deletion run under the authority lock of the target, so two concurrent restarts never destroy
+   * a healthy restored database. Before deletion, the unit attempts the existing normal database
+   * lock without waiting and holds an acquired lock through content deletion. The deletion removes
+   * every content file first and removes the authority copies last.
+   *
+   * <p>An absent target directory carries no evidence of an interrupted restore, so this method
+   * refuses an absent target directory.
+   *
+   * @param storagePath the directory of the restore target
+   * @throws StorageAdmissionException when the target is no interrupted restore target
+   */
+  public static void deleteInterruptedRestoreTarget(Path storagePath) throws IOException {
+    requireExistingRestoreTargetDirectory(storagePath);
+    new StorageBootstrapMetadata(storagePath, FEATURE_FORMAT)
+        .deleteInterruptedRestoreTarget(DiskStorage::deleteRestoreTargetContent);
+  }
+
+  /**
+   * Reports whether this image already holds content that a creation must not overwrite.
+   *
+   * <p>The deletion of a destructive restart keeps the authority lock file of the target. A
+   * directory whose only entry is that lock file therefore holds no storage content, and a
+   * creation over that directory overwrites nothing. The existence probe of the manager still
+   * reports such a directory as one database, so the birth residue stays visible to an operator.
+   */
+  @Override
+  protected boolean existsBeforeCreation() {
+    try {
+      if (status == STATUS.CLOSED
+          && StorageBootstrapMetadata.holdsOnlyTheAuthorityLockFile(storagePath)) {
+        return false;
+      }
+    } catch (IOException listingFailure) {
+      throw BaseException.wrapException(
+          new StorageException(name, "Cannot list the files of the storage directory"),
+          listingFailure,
+          name);
+    }
+    return exists();
+  }
+
+  /**
+   * Checks that one directory is a valid destructive restart target and changes no content.
+   *
+   * <p>The caller runs this check before the caller discards any in-memory state of the named
+   * database. A refused restart therefore keeps every file and every live session of a healthy
+   * database. The deletion repeats the same check inside its own exclusive unit.
+   *
+   * <p>The check requires positive evidence on disk. An absent target directory holds no such
+   * evidence, so the check refuses an absent target directory. The caller therefore never discards
+   * the in-memory state of a database that the named directory does not back. One example of such
+   * a database is a memory database of the same name.
+   *
+   * @param storagePath the directory of the restore target
+   * @throws StorageAdmissionException when the target is no interrupted restore target
+   */
+  public static void requireInterruptedRestoreTarget(Path storagePath) throws IOException {
+    requireExistingRestoreTargetDirectory(storagePath);
+    new StorageBootstrapMetadata(storagePath, FEATURE_FORMAT).requireInterruptedRestoreTarget();
+  }
+
+  /**
+   * Refuses a restore target whose directory exists nowhere.
+   *
+   * <p>The destructive restart reads the evidence of an interrupted restore from the target
+   * directory. An absent directory holds no bootstrap authority record, so the restart reports the
+   * missing-record admission reason for an absent directory.
+   *
+   * @param storagePath the directory of the restore target
+   * @throws StorageAdmissionException when the directory exists nowhere
+   */
+  private static void requireExistingRestoreTargetDirectory(Path storagePath) throws IOException {
+    if (isRealDirectory(storagePath)) {
+      return;
+    }
+    throw new StorageAdmissionException(
+        StorageAdmissionException.Reason.AUTHORITY_MISSING,
+        storagePath,
+        "The destructive restore restart requires an existing target directory");
+  }
+
+  /**
+   * Reports whether the given path is a real directory.
+   *
+   * <p>The check reads the attributes of the path itself and follows no symbolic link. A symbolic
+   * link named like a database would otherwise redirect a deletion outside of the databases
+   * directory.
+   *
+   * @return false when the path exists nowhere
+   * @throws IOException when the path exists and is no real directory
+   */
+  private static boolean isRealDirectory(Path storagePath) throws IOException {
+    final BasicFileAttributes attributes;
+    try {
+      attributes =
+          Files.readAttributes(storagePath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+    } catch (NoSuchFileException absentPath) {
+      return false;
+    }
+    if (!attributes.isDirectory()) {
+      throw new IOException(
+          "The destructive restore restart accepts a real directory only, and the path "
+              + storagePath
+              + " is no real directory");
+    }
+    return true;
+  }
+
+  /** Removes every file of one storage directory that is no bootstrap authority artifact. */
+  private static void deleteRestoreTargetContent(Path storageDirectory) throws IOException {
+    try (var entries = Files.list(storageDirectory)) {
+      for (var entry : entries.toList()) {
+        if (StorageBootstrapMetadata.isBootstrapArtifactName(
+            entry.getFileName().toString())) {
+          // The authority copies and the authority lock file leave after every content file.
+          continue;
+        }
+        if (Files.isDirectory(entry)) {
+          PathUtils.deleteDirectory(entry);
+        } else {
+          Files.deleteIfExists(entry);
+        }
+      }
+    }
+  }
+
+  /**
+   * Runs the single admission decision of this storage image.
+   *
+   * <p>Storage open calls this method before write-ahead log initialization and before recovery. A
+   * write-ahead log records a change before that change reaches its final file. A rejected image
+   * therefore never reaches recovery.
+   */
   @Override
   protected void readStorageIdentity() {
     try {
       var active = bootstrapMetadata().readActiveRequired();
       bootstrapSnapshot = active;
       updateStorageIdentity(active.storageIdentity(), active.lineageIdentity());
+    } catch (StorageAdmissionException rejection) {
+      // The cause already names the admission reason and the storage path. This message therefore
+      // states the cause in plain words and never repeats the reason identifier.
+      throw BaseException.wrapException(
+          new StorageException(
+              name,
+              "Cannot open database '" + name + "'. " + rejection.reason().description()),
+          rejection,
+          name);
     } catch (IOException exception) {
       throw BaseException.wrapException(
           new StorageException(name, "Cannot read the storage bootstrap authority"),
@@ -883,10 +1076,15 @@ public class DiskStorage extends AbstractStorage {
           stream.forEach(
               (p) -> {
                 final var fileName = p.getFileName().toString();
+                // A bootstrap authority artifact also proves an existing storage image. That
+                // artifact set covers the authority copies, the authority lock file, and the
+                // unfinished record candidate. An interrupted storage birth therefore stays
+                // visible instead of reporting a missing storage.
                 if (fileName.equals("database.ocf")
                     || (fileName.startsWith("config") && fileName.endsWith(".bd"))
                     || fileName.startsWith("dirty.fl")
-                    || fileName.startsWith("dirty.flb")) {
+                    || fileName.startsWith("dirty.flb")
+                    || StorageBootstrapMetadata.isBootstrapArtifactName(fileName)) {
                   exists[0] = true;
                 }
               });
@@ -1683,6 +1881,13 @@ public class DiskStorage extends AbstractStorage {
                   + "impossible.");
         }
 
+        // A restored image never shares its storage lineage with the backup source. A storage
+        // lineage is the identifier of the ancestry of one storage image. The production restore
+        // path creates a fresh target. The birth publication of that fresh target already
+        // generates a random storage identity and a random storage lineage. The call below is
+        // therefore a no-operation for the production restore path, because the target already
+        // carries the restore-in-progress lifecycle state. The call serves an in-place restore
+        // into an already active storage, which only a test performs today.
         beginLineageReplacement();
         var result = preprocessingIncrementalRestore();
         for (var ibuFilePair : tempIBUFiles) {
@@ -1707,6 +1912,12 @@ public class DiskStorage extends AbstractStorage {
         }
 
         postProcessIncrementalRestore(result.contextConfiguration);
+        // Track 24 restore order. The restore target reaches the active lifecycle state only
+        // after the validation of the restored content and after the durability barrier over
+        // that content. A failed validation therefore leaves the restore-in-progress state, and
+        // the destructive restart entry accepts that state.
+        validateRestoredContent();
+        barrierWhileCallerOwnsStateLock();
         activateBootstrapSnapshot("Cannot activate the restored storage lineage");
         dropStaleIndexLifecycles();
       } finally {
@@ -1723,6 +1934,21 @@ public class DiskStorage extends AbstractStorage {
     }
   }
 
+  /**
+   * Adopts a fresh storage lineage for an in-place restore into an already active storage.
+   *
+   * <p>A storage lineage is the identifier of the ancestry of one storage image. A restored image
+   * never shares its storage lineage with the backup source. An in-place restore therefore
+   * replaces the lineage of the target before the first content write.
+   *
+   * <p>This method performs no work for a target that already carries the restore-in-progress
+   * lifecycle state. The production restore path creates a fresh target. The birth publication of
+   * that fresh target already generated a random storage identity and a random storage lineage.
+   * That fresh target therefore needs no replacement.
+   *
+   * <p>The logical sequence floor needs no adoption either. A fresh target starts at the lowest
+   * floor, and no production reader of the durable floor exists today.
+   */
   void beginLineageReplacement() {
     try {
       var current = java.util.Objects.requireNonNull(bootstrapSnapshot, "bootstrapSnapshot");
@@ -1753,6 +1979,73 @@ public class DiskStorage extends AbstractStorage {
     configuration = null;
 
     return new IncrementalRestorePreprocessingResult(contextConfiguration, charset, locale);
+  }
+
+  /**
+   * Validates the restored content before the activation of this restore target.
+   *
+   * <p>The validation covers two durable values of the restored image. The first value is the
+   * storage layout version of the restored storage configuration. The storage layout version is
+   * the version of the on-disk storage layout. The second value is the genesis marker. The genesis
+   * marker is the durable property that records a finished genesis.
+   *
+   * <p>A failed validation leaves this target in the restore-in-progress lifecycle state, because
+   * the activation follows this method.
+   */
+  private void validateRestoredContent() throws IOException {
+    final var restoredConfiguration = (CollectionBasedStorageConfiguration) configuration;
+    final var restoredLayoutVersion =
+        atomicOperationsManager.calculateInsideAtomicOperation(restoredConfiguration::getVersion);
+    validateRestoredStorageLayoutVersion(name, restoredLayoutVersion);
+    validateRestoredGenesisMarker(
+        name, restoredConfiguration.getProperty(SharedContext.GENESIS_COMPLETED_PROPERTY));
+  }
+
+  /**
+   * Rejects a restored storage layout version that this build does not support.
+   *
+   * <p>A backup of an older or a newer build carries such a version. The refusal keeps the target
+   * in the restore-in-progress lifecycle state. A drop discards that target and reports success.
+   *
+   * <p>This check is defense in depth. The configuration load of the restore reads the same value
+   * earlier. That load reports the named inconsistent-metadata result for a disagreement. A real
+   * backup of another build therefore never reaches this check today. This check still guards the
+   * case of a configuration load that stops comparing that value.
+   */
+  static void validateRestoredStorageLayoutVersion(String storageName, int restoredLayoutVersion) {
+    if (restoredLayoutVersion != StorageConfiguration.CURRENT_VERSION) {
+      throw new StorageException(
+          storageName,
+          "The restore of database '"
+              + storageName
+              + "' failed. The backup content carries storage layout version "
+              + restoredLayoutVersion
+              + ". This build supports storage layout version "
+              + StorageConfiguration.CURRENT_VERSION
+              + " only. Drop database '"
+              + storageName
+              + "' to remove the unusable restore target.");
+    }
+  }
+
+  /**
+   * Rejects restored content without a set genesis marker.
+   *
+   * <p>The genesis marker is the durable property that records a finished genesis. A backup of an
+   * incomplete database carries no such marker. The refusal keeps the target in the
+   * restore-in-progress lifecycle state.
+   */
+  static void validateRestoredGenesisMarker(String storageName, String markerValue) {
+    if (!Boolean.parseBoolean(markerValue)) {
+      throw new StorageException(
+          storageName,
+          "The restore of database '"
+              + storageName
+              + "' failed. The backup content carries no genesis completion marker. The backup"
+              + " therefore holds an incomplete database. Drop database '"
+              + storageName
+              + "' to remove the unusable restore target.");
+    }
   }
 
   private void postProcessIncrementalRestore(ContextConfiguration contextConfiguration)

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -59,6 +59,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.CommitSerializationExcep
 import com.jetbrains.youtrackdb.internal.core.exception.ConcurrentCreateException;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.IndexEngineReplacedException;
 import com.jetbrains.youtrackdb.internal.core.exception.InternalErrorException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidDatabaseNameException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
@@ -4489,7 +4490,7 @@ public abstract class AbstractStorage
     indexLifecycleRegistry.remove(descriptorIdentity);
   }
 
-  public IndexEngineReference getIndexEngineReference(int externalIndexId) {
+  @Nullable public IndexEngineReference getIndexEngineReference(int externalIndexId) {
     if (isCommitWindowActive()) {
       return getIndexEngineReferenceWithStateLock(externalIndexId);
     }
@@ -4502,7 +4503,7 @@ public abstract class AbstractStorage
     }
   }
 
-  private IndexEngineReference getIndexEngineReferenceWithStateLock(int externalIndexId) {
+  @Nullable private IndexEngineReference getIndexEngineReferenceWithStateLock(int externalIndexId) {
     final var internalIndexId = extractInternalId(externalIndexId);
     try {
       checkIndexId(internalIndexId);
@@ -4510,45 +4511,54 @@ public abstract class AbstractStorage
       throw new IllegalStateException("Cannot resolve an unregistered index engine", e);
     }
 
-    final var reference = indexEngines.get(internalIndexId).getEngineReference();
-    if (reference == null) {
-      throw new IllegalStateException("Local index engine has no process-local reference");
-    }
-    return reference;
+    return indexEngines.get(internalIndexId).getEngineReference();
   }
 
   /**
    * Binds a local engine to its durable descriptor after that descriptor obtains or loads its RID.
+   * The expected reference must be identical or precede the live generation at the same slot.
    */
-  public IndexEngineReference bindIndexEngineToDescriptor(
-      int externalIndexId, RID descriptorIdentity, IndexEngineReference expectedReference) {
+  @Nullable public IndexEngineReference attachIndexEngineOwner(
+      int externalIndexId, RID descriptorIdentity,
+      @Nullable IndexEngineReference carrierReference) {
     if (isCommitWindowActive()) {
-      return bindIndexEngineToDescriptorWithStateLock(
-          externalIndexId, descriptorIdentity, expectedReference);
+      return attachIndexEngineOwnerWithStateLock(
+          externalIndexId, descriptorIdentity, carrierReference);
     }
 
     stateLock.readLock().lock();
     try {
-      return bindIndexEngineToDescriptorWithStateLock(
-          externalIndexId, descriptorIdentity, expectedReference);
+      return attachIndexEngineOwnerWithStateLock(
+          externalIndexId, descriptorIdentity, carrierReference);
     } finally {
       stateLock.readLock().unlock();
     }
   }
 
-  private IndexEngineReference bindIndexEngineToDescriptorWithStateLock(
-      int externalIndexId, RID descriptorIdentity, IndexEngineReference expectedReference) {
-    final var reference = getIndexEngineReferenceWithStateLock(externalIndexId);
-    if (reference.slot() != expectedReference.slot()
-        || reference.apiVersion() != expectedReference.apiVersion()
-        || reference.generation() != expectedReference.generation()) {
+  @Nullable private IndexEngineReference attachIndexEngineOwnerWithStateLock(
+      int externalIndexId, RID descriptorIdentity,
+      @Nullable IndexEngineReference carrierReference) {
+    final var liveReference = getIndexEngineReferenceWithStateLock(externalIndexId);
+    if (liveReference == null) {
+      if (carrierReference != null) {
+        throw new IllegalStateException("Index engine lost its process-local reference");
+      }
+      return null;
+    }
+    if (carrierReference == null) {
+      throw new IllegalStateException("Index engine unexpectedly gained a process-local reference");
+    }
+    if (liveReference != carrierReference
+        && (liveReference.slot() != carrierReference.slot()
+            || liveReference.generation() <= carrierReference.generation())) {
       throw new IllegalStateException(
-          "Index engine reference changed from generation " + expectedReference.generation()
-              + " to " + reference.generation() + " for slot " + reference.slot());
+          "Index engine reference changed non-monotonically from generation "
+              + carrierReference.generation() + " to " + liveReference.generation()
+              + " for slot " + liveReference.slot());
     }
 
-    reference.bindOwner(descriptorIdentity);
-    return reference;
+    liveReference.bindOwner(descriptorIdentity);
+    return liveReference;
   }
 
   /**
@@ -4556,7 +4566,7 @@ public abstract class AbstractStorage
    *
    * <p>The commit-window branch avoids reacquiring the non-reentrant storage state lock.
    */
-  public int resolveIndexEngineByOwner(final RID descriptorIdentity) {
+  public ResolvedIndexEngine resolveIndexEngineByOwner(final RID descriptorIdentity) {
     try {
       if (isCommitWindowActive()) {
         return resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
@@ -4583,7 +4593,8 @@ public abstract class AbstractStorage
    * @throws StaleIndexEngineException when no registered engine has the requested owner
    * @throws StorageException when registry ownership is ambiguous
    */
-  public int resolveIndexEngineByOwnerWithStateLock(final RID descriptorIdentity) {
+  public ResolvedIndexEngine resolveIndexEngineByOwnerWithStateLock(
+      final RID descriptorIdentity) {
     if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
       throw new IllegalStateException(
           "Index engine owner resolution requires the storage state lock or an active commit"
@@ -4622,7 +4633,14 @@ public abstract class AbstractStorage
           "Cannot resolve index engine for descriptor " + descriptorIdentity
               + ": no registered engine has that owner");
     }
-    return resolvedIdentifier;
+    final var internalIdentifier = extractInternalId(resolvedIdentifier);
+    return new ResolvedIndexEngine(
+        resolvedIdentifier, indexEngines.get(internalIdentifier).getEngineReference());
+  }
+
+  /** One coherent result from an owner scan. */
+  public record ResolvedIndexEngine(
+      int engineIdentifier, @Nullable IndexEngineReference engineReference) {
   }
 
   public int loadIndexEngine(final String name) {
@@ -5260,16 +5278,22 @@ public abstract class AbstractStorage
 
   public BaseIndexEngine getIndexEngine(final int indexId)
       throws InvalidIndexEngineIdException {
+    return getIndexEngine(indexId, getIndexEngineReference(indexId));
+  }
+
+  public BaseIndexEngine getIndexEngine(
+      final int indexId, @Nullable final IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
     try {
       // A schema-carrying commit already holds stateLock.writeLock(). The active commit window
       // proves that ownership and avoids a non-reentrant read-lock acquisition.
       if (isCommitWindowActive()) {
-        return getIndexEngineWithStateLock(indexId);
+        return getIndexEngineWithStateLock(indexId, expectedReference);
       }
 
       stateLock.readLock().lock();
       try {
-        return getIndexEngineWithStateLock(indexId);
+        return getIndexEngineWithStateLock(indexId, expectedReference);
       } finally {
         stateLock.readLock().unlock();
       }
@@ -5290,6 +5314,12 @@ public abstract class AbstractStorage
    */
   public BaseIndexEngine getIndexEngineWithStateLock(final int indexId)
       throws InvalidIndexEngineIdException {
+    return getIndexEngineWithStateLock(indexId, getIndexEngineReferenceWithStateLock(indexId));
+  }
+
+  public BaseIndexEngine getIndexEngineWithStateLock(
+      final int indexId, @Nullable final IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
     if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
       throw new IllegalStateException(
           "Index engine resolution requires the storage state lock or an active commit window");
@@ -5297,9 +5327,18 @@ public abstract class AbstractStorage
 
     checkOpennessAndMigration();
     final var internalId = extractInternalId(indexId);
-    checkIndexId(internalId);
+    return engineForDereference(internalId, expectedReference);
+  }
 
+  private BaseIndexEngine engineForDereference(
+      final int internalId, @Nullable final IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
+    checkIndexId(internalId);
     final var engine = indexEngines.get(internalId);
+    if (engine.getEngineReference() != expectedReference) {
+      throw new IndexEngineReplacedException(
+          "Engine at slot " + internalId + " no longer matches the index handle");
+    }
     assert internalId == engine.getId();
     return engine;
   }
@@ -8408,8 +8447,14 @@ public abstract class AbstractStorage
     final var iAdditionalArgs =
         new Object[] {System.identityHashCode(exception), getURL(),
             YouTrackDBConstants.getVersion()};
-    LogManager.instance()
-        .error(this, "Exception `%08X` in storage `%s` : %s", exception, iAdditionalArgs);
+    if (exception instanceof IndexEngineReplacedException) {
+      LogManager.instance()
+          .debug(this, "Index engine replacement `%08X` in storage `%s`: %s", logger, exception,
+              iAdditionalArgs);
+    } else {
+      LogManager.instance()
+          .error(this, "Exception `%08X` in storage `%s` : %s", exception, iAdditionalArgs);
+    }
     return exception;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4732,6 +4732,14 @@ public abstract class AbstractStorage
             + " the index.");
   }
 
+  /** Test-only failure seam fired immediately before non-commit-window engine construction. */
+  private volatile Runnable indexEngineCreationTestHook;
+
+  /** Installs a test-only failure seam for public engine creation and rebuild replacement. */
+  public void setIndexEngineCreationTestHook(final Runnable hook) {
+    indexEngineCreationTestHook = hook;
+  }
+
   public int addIndexEngine(
       final IndexMetadata indexMetadata,
       final Map<String, String> engineProperties) {
@@ -4802,6 +4810,10 @@ public abstract class AbstractStorage
                       cfgEncryptionKey,
                       engineProperties);
 
+              final var creationHook = indexEngineCreationTestHook;
+              if (creationHook != null) {
+                creationHook.run();
+              }
               final var engine = doAddIndexEngine(atomicOperation, engineData);
 
               publishIndexEngine(engineData.getIndexId(), engine);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3887,6 +3887,7 @@ public abstract class AbstractStorage
 
     discardIndexDeltas(atomicOperation, internalIndexId);
     doDeleteIndexEngine(atomicOperation, engine);
+    detachHistogramManager(engine);
     indexEngines.set(internalIndexId, null);
     indexEngineNameMap.remove(engine.getName());
     return new DroppedIndexEngine(internalIndexId, capturedData, copiedOwnerDescriptorIdentity);
@@ -3919,6 +3920,7 @@ public abstract class AbstractStorage
       if (engine == null) {
         continue;
       }
+      detachHistogramManager(engine);
       indexEngines.set(internalId, null);
       indexEngineNameMap.remove(engine.getName());
       revertCreatedIndexEngineStructure(engine);
@@ -4379,12 +4381,8 @@ public abstract class AbstractStorage
     for (var entry : holder.getDeltas().int2ObjectEntrySet()) {
       int engineId = entry.getIntKey();
       var delta = entry.getValue();
-      // Engine may have been dropped concurrently — the commit is already
-      // durable, so the delta for a removed engine is stale and safe to skip.
-      // Safety: indexEngines is a plain ArrayList; concurrent structural
-      // modification is prevented by the stateLock read lock held on the
-      // commit path and the atomic operation serialization for index
-      // creation/deletion.
+      // Engine replacement cannot race this lookup. The index tree component lock remains held
+      // through Hook B, which applies these deltas after the durable commit.
       if (engineId >= 0 && engineId < indexEngines.size()) {
         var engine = indexEngines.get(engineId);
         if (engine instanceof BTreeIndexEngine btreeEngine) {
@@ -4410,6 +4408,7 @@ public abstract class AbstractStorage
    * Removes transaction-local work keyed by a slot whose engine lifetime has ended. Commit-window
    * drops run after ordinary index writes, while creates run before replacement population. Thus,
    * the removed work can only belong to the old owner. Work for the replacement accumulates later.
+   * Holders attached to sibling atomic operations remain untouched.
    */
   private static void discardIndexDeltas(
       final AtomicOperation atomicOperation, final int engineId) {
@@ -4452,12 +4451,8 @@ public abstract class AbstractStorage
     for (var entry : holder.getDeltas().entrySet()) {
       var engineId = entry.getKey();
       var delta = entry.getValue();
-      // Engine may have been dropped concurrently — the commit is already
-      // durable, so the delta for a removed engine is stale and safe to skip.
-      // Safety: indexEngines is a plain ArrayList; concurrent structural
-      // modification is prevented by the stateLock read lock held on the
-      // commit path and the atomic operation serialization for index
-      // creation/deletion.
+      // Engine replacement cannot race this lookup. The index tree component lock remains held
+      // through Hook B, which applies these deltas after the durable commit.
       if (engineId < indexEngines.size()) {
         var engine = indexEngines.get(engineId);
         if (engine instanceof BTreeIndexEngine btreeEngine) {
@@ -4720,6 +4715,7 @@ public abstract class AbstractStorage
                         indexMetadata.getName());
                 final var engine = indexEngineNameMap.remove(indexMetadata.getName());
                 if (engine != null) {
+                  detachHistogramManager(engine);
                   indexEngines.set(engine.getId(), null);
 
                   engine.delete(atomicOperation);
@@ -4841,6 +4837,15 @@ public abstract class AbstractStorage
    * StorageCollection)}. The public append path uses {@code id == indexEngines.size()};
    * the commit-local allocator may reuse a hole at {@code id < indexEngines.size()}.
    */
+  private static void detachHistogramManager(final BaseIndexEngine engine) {
+    if (engine instanceof BTreeIndexEngine btreeEngine) {
+      final var manager = btreeEngine.getHistogramManager();
+      if (manager != null) {
+        manager.detach();
+      }
+    }
+  }
+
   private void setIndexEngine(final int id, final BaseIndexEngine engine) {
     if (indexEngines.size() <= id) {
       while (indexEngines.size() < id) {
@@ -5074,6 +5079,7 @@ public abstract class AbstractStorage
         // successfully. If the atomic operation rolls back, the maps remain
         // consistent so that addIndexEngine()'s "OLD INDEX FILE" recovery
         // branch can find and clean up the stale engine.
+        detachHistogramManager(engine);
         indexEngines.set(internalIndexId, null);
         indexEngineNameMap.remove(engine.getName());
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3864,8 +3864,13 @@ public abstract class AbstractStorage
       final int externalIndexId, @Nullable IndexEngineReference expectedReference,
       final AtomicOperation atomicOperation)
       throws IOException, InvalidIndexEngineIdException {
-    validateIndexEngineReference(externalIndexId, expectedReference);
-    return deleteIndexEngineInCommitWindow(externalIndexId, atomicOperation);
+    assert isCommitWindowActive()
+        : "commit-window primitive called outside the commit window";
+    final var internalIndexId = extractInternalId(externalIndexId);
+    checkOpennessAndMigration();
+    makeStorageDirty();
+    return deleteIndexEngineInCommitWindow(
+        internalIndexId, engineForDereference(internalIndexId, expectedReference), atomicOperation);
   }
 
   public DroppedIndexEngine deleteIndexEngineInCommitWindow(
@@ -3876,10 +3881,14 @@ public abstract class AbstractStorage
             + " held)";
     final var internalIndexId = extractInternalId(externalIndexId);
     checkOpennessAndMigration();
-    checkIndexId(internalIndexId);
     makeStorageDirty();
+    return deleteIndexEngineInCommitWindow(
+        internalIndexId, engineByIdentifier(internalIndexId), atomicOperation);
+  }
 
-    final var engine = indexEngines.get(internalIndexId);
+  private DroppedIndexEngine deleteIndexEngineInCommitWindow(
+      final int internalIndexId, final BaseIndexEngine engine,
+      final AtomicOperation atomicOperation) throws IOException {
     assert internalIndexId == engine.getId();
 
     // Capture the durable engine data before the delete removes the config entry it reads. The
@@ -4290,10 +4299,15 @@ public abstract class AbstractStorage
       var index = changes.getIndex();
       try {
         if (changes.cleared) {
-          final var expectedReference =
-              index instanceof IndexAbstract handle ? handle.getEngineReference() : null;
-          validateIndexEngineReference(index.getIndexId(), expectedReference);
-          doClearIndex(atomicOperation, index.getIndexId());
+          if (index instanceof IndexAbstract handle) {
+            final var snapshot = handle.engineSnapshot();
+            final var internalIndexId = extractInternalId(snapshot.engineIdentifier());
+            doClearIndex(
+                atomicOperation, internalIndexId,
+                engineForDereference(internalIndexId, snapshot.engineReference()));
+          } else {
+            doClearIndex(atomicOperation, extractInternalId(index.getIndexId()));
+          }
         }
 
         for (final var changesPerKey : changes.changesPerKey.values()) {
@@ -4301,9 +4315,16 @@ public abstract class AbstractStorage
         }
 
         applyTxChanges(db, changes.nullKeyChanges, index);
-      } catch (final InvalidIndexEngineIdException e) {
-        throw BaseException.wrapException(new StorageException(name, "Error during index commit"),
-            e, name);
+      } catch (final IndexEngineReplacedException exception) {
+        final var stale = new StaleIndexEngineException(
+            name, "Index engine changed during index commit");
+        stale.initCause(exception);
+        throw stale;
+      } catch (final InvalidIndexEngineIdException exception) {
+        final var stale = new StaleIndexEngineException(
+            name, "Index engine became unavailable during index commit");
+        stale.initCause(exception);
+        throw stale;
       }
     }
   }
@@ -5096,8 +5117,33 @@ public abstract class AbstractStorage
   public void deleteIndexEngine(
       int indexId, @Nullable IndexEngineReference expectedReference)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    deleteIndexEngine(indexId);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.writeLock().lock();
+      try {
+        checkOpennessAndMigration();
+        final var engine = engineForDereference(internalIndexId, expectedReference);
+        makeStorageDirty();
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> doDeleteIndexEngine(atomicOperation, engine));
+        detachHistogramManager(engine);
+        indexEngines.set(internalIndexId, null);
+        indexEngineNameMap.remove(engine.getName());
+      } catch (final IOException exception) {
+        throw BaseException.wrapException(
+            new StorageException(name, "Error on index deletion"), exception, name);
+      } finally {
+        stateLock.writeLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
+    }
   }
 
   public void deleteIndexEngine(int indexId)
@@ -5162,12 +5208,6 @@ public abstract class AbstractStorage
         .deleteIndexEngine(atomicOperation, engine.getName());
   }
 
-  private void validateIndexEngineReference(
-      int externalIndexId, @Nullable IndexEngineReference expectedReference)
-      throws InvalidIndexEngineIdException {
-    engineForDereference(extractInternalId(externalIndexId), expectedReference);
-  }
-
   private void checkIndexId(final int indexId) throws InvalidIndexEngineIdException {
     if (indexId < 0 || indexId >= indexEngines.size() || indexEngines.get(indexId) == null) {
       throw new InvalidIndexEngineIdException(
@@ -5179,8 +5219,18 @@ public abstract class AbstractStorage
       final int indexId, @Nullable IndexEngineReference expectedReference,
       final Object key, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    return removeKeyFromIndex(indexId, key, atomicOperation);
+    try {
+      return removeKeyFromIndexInternal(
+          atomicOperation, extractInternalId(indexId), expectedReference, key);
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
+    }
   }
 
   public boolean removeKeyFromIndex(final int indexId, final Object key,
@@ -5203,10 +5253,21 @@ public abstract class AbstractStorage
   private boolean removeKeyFromIndexInternal(
       final AtomicOperation atomicOperation, final int indexId, final Object key)
       throws InvalidIndexEngineIdException {
-    try {
-      checkIndexId(indexId);
+    return removeKeyFromIndexInternal(
+        atomicOperation, engineByIdentifier(indexId), key);
+  }
 
-      final var engine = indexEngines.get(indexId);
+  private boolean removeKeyFromIndexInternal(
+      final AtomicOperation atomicOperation, final int indexId,
+      @Nullable IndexEngineReference expectedReference, final Object key)
+      throws InvalidIndexEngineIdException {
+    return removeKeyFromIndexInternal(
+        atomicOperation, engineForDereference(indexId, expectedReference), key);
+  }
+
+  private boolean removeKeyFromIndexInternal(
+      final AtomicOperation atomicOperation, final BaseIndexEngine engine, final Object key) {
+    try {
       if (engine.getEngineAPIVersion() == IndexEngine.VERSION) {
         return ((IndexEngine) engine).remove(this, atomicOperation, key);
       } else {
@@ -5230,12 +5291,29 @@ public abstract class AbstractStorage
   public void clearIndex(
       final int indexId, @Nullable IndexEngineReference expectedReference) {
     try {
-      getIndexEngine(indexId, expectedReference);
-    } catch (InvalidIndexEngineIdException exception) {
-      throw new StaleIndexEngineException(
-          name, "Index engine changed before clear: " + exception.getMessage());
+      final var internalIndexId = extractInternalId(indexId);
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        makeStorageDirty();
+        final var engine = engineForDereference(internalIndexId, expectedReference);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> doClearIndex(atomicOperation, internalIndexId, engine));
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      final var stale = new StaleIndexEngineException(
+          name, "Index engine changed before clear");
+      stale.initCause(exception);
+      throw stale;
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
     }
-    clearIndex(indexId);
   }
 
   public void clearIndex(final int indexId) {
@@ -5265,12 +5343,13 @@ public abstract class AbstractStorage
   private void doClearIndex(final AtomicOperation atomicOperation,
       final int indexId)
       throws InvalidIndexEngineIdException {
+    doClearIndex(atomicOperation, indexId, engineByIdentifier(indexId));
+  }
+
+  private void doClearIndex(
+      final AtomicOperation atomicOperation, final int indexId, final BaseIndexEngine engine) {
     try {
-      checkIndexId(indexId);
-
-      final var engine = indexEngines.get(indexId);
       assert indexId == engine.getId();
-
       engine.clear(this, atomicOperation);
     } catch (final IOException e) {
       throw BaseException.wrapException(
@@ -5282,8 +5361,30 @@ public abstract class AbstractStorage
   public Stream<RID> getIndexValues(
       int indexId, final Object key, AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    return getIndexValues(
-        indexId, getIndexEngineReference(indexId), key, atomicOperation);
+    final var engineAPIVersion = extractEngineAPIVersion(indexId);
+    if (engineAPIVersion != 1) {
+      throw new IllegalStateException(
+          "Unsupported version of index engine API. Required 1 but found " + engineAPIVersion);
+    }
+
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return ((V1IndexEngine) engineByIdentifier(internalIndexId)).get(key, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RID> getIndexValues(
@@ -5330,7 +5431,26 @@ public abstract class AbstractStorage
 
   public BaseIndexEngine getIndexEngine(final int indexId)
       throws InvalidIndexEngineIdException {
-    return getIndexEngine(indexId, getIndexEngineReference(indexId));
+    try {
+      if (isCommitWindowActive()) {
+        return getIndexEngineWithStateLock(indexId);
+      }
+
+      stateLock.readLock().lock();
+      try {
+        return getIndexEngineWithStateLock(indexId);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public BaseIndexEngine getIndexEngine(
@@ -5366,7 +5486,13 @@ public abstract class AbstractStorage
    */
   public BaseIndexEngine getIndexEngineWithStateLock(final int indexId)
       throws InvalidIndexEngineIdException {
-    return getIndexEngineWithStateLock(indexId, getIndexEngineReferenceWithStateLock(indexId));
+    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
+      throw new IllegalStateException(
+          "Index engine resolution requires the storage state lock or an active commit window");
+    }
+
+    checkOpennessAndMigration();
+    return engineByIdentifier(extractInternalId(indexId));
   }
 
   public BaseIndexEngine getIndexEngineWithStateLock(
@@ -5382,11 +5508,18 @@ public abstract class AbstractStorage
     return engineForDereference(internalId, expectedReference);
   }
 
-  private BaseIndexEngine engineForDereference(
-      final int internalId, @Nullable final IndexEngineReference expectedReference)
+  private BaseIndexEngine engineByIdentifier(final int internalId)
       throws InvalidIndexEngineIdException {
     checkIndexId(internalId);
     final var engine = indexEngines.get(internalId);
+    assert internalId == engine.getId();
+    return engine;
+  }
+
+  private BaseIndexEngine engineForDereference(
+      final int internalId, @Nullable final IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
+    final var engine = engineByIdentifier(internalId);
     if (engine.getEngineReference() != expectedReference) {
       throw new IndexEngineReplacedException(
           "Engine at slot " + internalId + " no longer matches the index handle");
@@ -5467,8 +5600,36 @@ public abstract class AbstractStorage
       final boolean readOperation, int indexId,
       @Nullable IndexEngineReference expectedReference, final IndexEngineCallback<T> callback)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    callIndexEngine(readOperation, indexId, callback);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      if (isCommitWindowActive()) {
+        checkOpennessAndMigration();
+        if (readOperation) {
+          makeStorageDirty();
+        }
+        callback.callEngine(engineForDereference(internalIndexId, expectedReference));
+        return;
+      }
+
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        if (readOperation) {
+          makeStorageDirty();
+        }
+        callback.callEngine(engineForDereference(internalIndexId, expectedReference));
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public <T> void callIndexEngine(
@@ -5527,8 +5688,25 @@ public abstract class AbstractStorage
       int indexId, @Nullable IndexEngineReference expectedReference,
       final Object key, final RID value, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    putRidIndexEntry(indexId, key, value, atomicOperation);
+    final var engineAPIVersion = extractEngineAPIVersion(indexId);
+    final var internalIndexId = extractInternalId(indexId);
+    if (engineAPIVersion != 1) {
+      throw new IllegalStateException(
+          "Unsupported version of index engine API. Required 1 but found " + engineAPIVersion);
+    }
+
+    try {
+      final var engine = engineForDereference(internalIndexId, expectedReference);
+      ((V1IndexEngine) engine).put(atomicOperation, key, value);
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
+    }
   }
 
   public void putRidIndexEntry(int indexId, final Object key, final RID value,
@@ -5571,8 +5749,25 @@ public abstract class AbstractStorage
       int indexId, @Nullable IndexEngineReference expectedReference,
       final Object key, final RID value, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    return removeRidIndexEntry(indexId, key, value, atomicOperation);
+    final var engineAPIVersion = extractEngineAPIVersion(indexId);
+    final var internalIndexId = extractInternalId(indexId);
+    if (engineAPIVersion != 1) {
+      throw new IllegalStateException(
+          "Unsupported version of index engine API. Required 1 but found " + engineAPIVersion);
+    }
+
+    try {
+      final var engine = engineForDereference(internalIndexId, expectedReference);
+      return ((MultiValueIndexEngine) engine).remove(atomicOperation, key, value);
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
+    }
   }
 
   public boolean removeRidIndexEntry(int indexId, final Object key, final RID value,
@@ -5632,8 +5827,20 @@ public abstract class AbstractStorage
       final IndexEngineValidator<Object, RID> validator,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    validateIndexEngineReference(indexId, expectedReference);
-    return validatedPutIndexValue(indexId, key, value, validator, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      return doValidatedPutIndexValue(
+          atomicOperation, internalIndexId,
+          engineForDereference(internalIndexId, expectedReference), key, value, validator);
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable);
+    }
   }
 
   @SuppressWarnings("UnusedReturnValue")
@@ -5665,10 +5872,18 @@ public abstract class AbstractStorage
       final RID value,
       final IndexEngineValidator<Object, RID> validator)
       throws InvalidIndexEngineIdException {
-    try {
-      checkIndexId(indexId);
+    return doValidatedPutIndexValue(
+        atomicOperation, indexId, engineByIdentifier(indexId), key, value, validator);
+  }
 
-      final var engine = indexEngines.get(indexId);
+  private boolean doValidatedPutIndexValue(
+      AtomicOperation atomicOperation,
+      final int indexId,
+      final BaseIndexEngine engine,
+      final Object key,
+      final RID value,
+      final IndexEngineValidator<Object, RID> validator) {
+    try {
       assert indexId == engine.getId();
 
       if (engine instanceof IndexEngine indexEngine) {
@@ -5696,10 +5911,27 @@ public abstract class AbstractStorage
       final Object rangeTo, final boolean toInclusive, final boolean ascSortOrder,
       final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return iterateIndexEntriesBetween(
-        indexId, rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder, transformer,
-        atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        final var engine = engineForDereference(internalIndexId, expectedReference);
+        return engine.iterateEntriesBetween(
+            rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder, transformer,
+            atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesBetween(
@@ -5758,9 +5990,26 @@ public abstract class AbstractStorage
       final Object fromKey, final boolean isInclusive, final boolean ascSortOrder,
       final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return iterateIndexEntriesMajor(
-        indexId, fromKey, isInclusive, ascSortOrder, transformer, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return engineForDereference(internalIndexId, expectedReference)
+            .iterateEntriesMajor(
+                fromKey, isInclusive, ascSortOrder, transformer, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesMajor(
@@ -5815,9 +6064,26 @@ public abstract class AbstractStorage
       final Object toKey, final boolean isInclusive, final boolean ascSortOrder,
       final IndexEngineValuesTransformer transformer, AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return iterateIndexEntriesMinor(
-        indexId, toKey, isInclusive, ascSortOrder, transformer, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return engineForDereference(internalIndexId, expectedReference)
+            .iterateEntriesMinor(
+                toKey, isInclusive, ascSortOrder, transformer, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesMinor(
@@ -5871,8 +6137,24 @@ public abstract class AbstractStorage
       final IndexEngineValuesTransformer valuesTransformer,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return getIndexStream(indexId, valuesTransformer, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        return engineForDereference(internalIndexId, expectedReference)
+            .stream(valuesTransformer, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RawPair<Object, RID>> getIndexStream(
@@ -5916,8 +6198,25 @@ public abstract class AbstractStorage
       final IndexEngineValuesTransformer valuesTransformer,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return getIndexDescStream(indexId, valuesTransformer, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return engineForDereference(internalIndexId, expectedReference)
+            .descStream(valuesTransformer, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<RawPair<Object, RID>> getIndexDescStream(
@@ -5962,8 +6261,24 @@ public abstract class AbstractStorage
       int indexId, @Nullable IndexEngineReference expectedReference,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return getIndexKeyStream(indexId, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return engineForDereference(internalIndexId, expectedReference).keyStream(atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public Stream<Object> getIndexKeyStream(int indexId, @Nonnull AtomicOperation atomicOperation)
@@ -6004,8 +6319,25 @@ public abstract class AbstractStorage
       int indexId, @Nullable IndexEngineReference expectedReference,
       final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    getIndexEngine(indexId, expectedReference);
-    return getIndexSize(indexId, transformer, atomicOperation);
+    final var internalIndexId = extractInternalId(indexId);
+    try {
+      stateLock.readLock().lock();
+      try {
+        checkOpennessAndMigration();
+        return engineForDereference(internalIndexId, expectedReference)
+            .size(this, transformer, atomicOperation);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final InvalidIndexEngineIdException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
   }
 
   public long getIndexSize(int indexId, final IndexEngineValuesTransformer transformer,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -64,6 +64,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.InvalidDatabaseNameExcep
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidInstanceIdException;
 import com.jetbrains.youtrackdb.internal.core.exception.ModificationOperationProhibitedException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageDoesNotExistException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageExistsException;
@@ -4501,6 +4502,86 @@ public abstract class AbstractStorage
 
     reference.bindOwner(descriptorIdentity);
     return reference;
+  }
+
+  /**
+   * Resolves the packed identifier of the engine owned by a durable index descriptor.
+   *
+   * <p>The commit-window branch avoids reacquiring the non-reentrant storage state lock.
+   */
+  public int resolveIndexEngineByOwner(final RID descriptorIdentity) {
+    try {
+      if (isCommitWindowActive()) {
+        return resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
+      }
+
+      stateLock.readLock().lock();
+      try {
+        return resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (final StaleIndexEngineException exception) {
+      // Preserve the HighLevelException marker used to keep the storage outside the error state.
+      throw exception;
+    } catch (final RuntimeException exception) {
+      throw logAndPrepareForRethrow(exception);
+    } catch (final Error error) {
+      throw logAndPrepareForRethrow(error, false);
+    } catch (final Throwable throwable) {
+      throw logAndPrepareForRethrow(throwable, false);
+    }
+  }
+
+  /**
+   * Resolves an engine by descriptor owner while the caller retains the storage state lock.
+   *
+   * @throws StaleIndexEngineException when no registered engine has the requested owner
+   * @throws StorageException when registry ownership is ambiguous or a local engine has no
+   *     process-local reference
+   */
+  public int resolveIndexEngineByOwnerWithStateLock(final RID descriptorIdentity) {
+    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
+      throw new IllegalStateException(
+          "Index engine owner resolution requires the storage state lock or an active commit"
+              + " window");
+    }
+
+    checkOpennessAndMigration();
+    int resolvedIdentifier = -1;
+    for (var slot = 0; slot < indexEngines.size(); slot++) {
+      final var engine = indexEngines.get(slot);
+      if (engine == null) {
+        continue;
+      }
+
+      final var reference = engine.getEngineReference();
+      if (reference == null) {
+        throw new StorageException(
+            name,
+            "Registered local index engine in slot " + slot
+                + " has no process-local reference while resolving descriptor "
+                + descriptorIdentity);
+      }
+
+      if (descriptorIdentity.equals(reference.ownerDescriptorIdentity())) {
+        if (resolvedIdentifier >= 0) {
+          throw new StorageException(
+              name,
+              "Multiple registered index engines are owned by descriptor "
+                  + descriptorIdentity);
+        }
+        resolvedIdentifier = generateIndexId(slot, engine);
+      }
+    }
+
+    if (resolvedIdentifier < 0) {
+      throw new StaleIndexEngineException(
+          name,
+          "Cannot resolve index engine for descriptor " + descriptorIdentity
+              + ": no registered engine has that owner");
+    }
+    return resolvedIdentifier;
   }
 
   public int loadIndexEngine(final String name) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4864,7 +4864,7 @@ public abstract class AbstractStorage
         | internalId;
   }
 
-  public static int extractInternalId(final int externalId) {
+  private static int extractInternalId(final int externalId) {
     if (externalId < 0) {
       throw new IllegalStateException("Index id has to be positive");
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -81,6 +81,7 @@ import com.jetbrains.youtrackdb.internal.core.index.IndexesSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.HistogramSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValidator;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexHistogramManager;
@@ -90,6 +91,8 @@ import com.jetbrains.youtrackdb.internal.core.index.engine.V1IndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeMultiValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleRegistry;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaShared;
@@ -324,6 +327,8 @@ public abstract class AbstractStorage
 
   private final Map<String, BaseIndexEngine> indexEngineNameMap = new HashMap<>();
   private final List<BaseIndexEngine> indexEngines = new ArrayList<>();
+  private final IndexLifecycleRegistry indexLifecycleRegistry = new IndexLifecycleRegistry();
+  private long indexEngineGeneration;
   private final AtomicOperationIdGen idGen = new AtomicOperationIdGen();
 
   /**
@@ -4412,6 +4417,58 @@ public abstract class AbstractStorage
         }
       }
     }
+  }
+
+  /** Allocates process-local identity when a local engine object is constructed. */
+  public synchronized IndexEngineReference allocateIndexEngineReference(int slot, int apiVersion) {
+    if (indexEngineGeneration == Long.MAX_VALUE) {
+      throw new StorageException(name, "Index engine generation space is exhausted");
+    }
+
+    return new IndexEngineReference(slot, apiVersion, ++indexEngineGeneration);
+  }
+
+  /** Returns the stable lifecycle carrier for a durable index descriptor. */
+  public IndexLifecycleCell getOrCreateIndexLifecycle(RID descriptorIdentity) {
+    return indexLifecycleRegistry.getOrCreate(descriptorIdentity);
+  }
+
+  /**
+   * Binds a local engine to its durable descriptor after that descriptor obtains or loads its RID.
+   */
+  public IndexEngineReference bindIndexEngineToDescriptor(
+      int externalIndexId, RID descriptorIdentity) {
+    try {
+      if (isCommitWindowActive()) {
+        return bindIndexEngineToDescriptorWithStateLock(externalIndexId, descriptorIdentity);
+      }
+
+      stateLock.readLock().lock();
+      try {
+        return bindIndexEngineToDescriptorWithStateLock(externalIndexId, descriptorIdentity);
+      } finally {
+        stateLock.readLock().unlock();
+      }
+    } catch (RuntimeException e) {
+      throw logAndPrepareForRethrow(e);
+    }
+  }
+
+  private IndexEngineReference bindIndexEngineToDescriptorWithStateLock(
+      int externalIndexId, RID descriptorIdentity) {
+    final var internalIndexId = extractInternalId(externalIndexId);
+    try {
+      checkIndexId(internalIndexId);
+    } catch (InvalidIndexEngineIdException e) {
+      throw new IllegalStateException("Cannot bind an unregistered index engine", e);
+    }
+
+    final var reference = indexEngines.get(internalIndexId).getEngineReference();
+    if (reference == null) {
+      throw new IllegalStateException("Local index engine has no process-local reference");
+    }
+    reference.bindOwner(descriptorIdentity);
+    return reference;
   }
 
   public int loadIndexEngine(final String name) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -74,6 +74,7 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
 import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.IndexDefinition;
 import com.jetbrains.youtrackdb.internal.core.index.IndexException;
 import com.jetbrains.youtrackdb.internal.core.index.IndexManagerEmbedded;
@@ -3860,6 +3861,14 @@ public abstract class AbstractStorage
    * @return the captured dropped engine (slot + durable data) for the failure-path reconstruction.
    */
   public DroppedIndexEngine deleteIndexEngineInCommitWindow(
+      final int externalIndexId, @Nullable IndexEngineReference expectedReference,
+      final AtomicOperation atomicOperation)
+      throws IOException, InvalidIndexEngineIdException {
+    validateIndexEngineReference(externalIndexId, expectedReference);
+    return deleteIndexEngineInCommitWindow(externalIndexId, atomicOperation);
+  }
+
+  public DroppedIndexEngine deleteIndexEngineInCommitWindow(
       final int externalIndexId, final AtomicOperation atomicOperation)
       throws IOException, InvalidIndexEngineIdException {
     assert isCommitWindowActive()
@@ -4281,6 +4290,9 @@ public abstract class AbstractStorage
       var index = changes.getIndex();
       try {
         if (changes.cleared) {
+          final var expectedReference =
+              index instanceof IndexAbstract handle ? handle.getEngineReference() : null;
+          validateIndexEngineReference(index.getIndexId(), expectedReference);
           doClearIndex(atomicOperation, index.getIndexId());
         }
 
@@ -5081,6 +5093,13 @@ public abstract class AbstractStorage
     return keySerializer;
   }
 
+  public void deleteIndexEngine(
+      int indexId, @Nullable IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    deleteIndexEngine(indexId);
+  }
+
   public void deleteIndexEngine(int indexId)
       throws InvalidIndexEngineIdException {
     final var internalIndexId = extractInternalId(indexId);
@@ -5143,11 +5162,25 @@ public abstract class AbstractStorage
         .deleteIndexEngine(atomicOperation, engine.getName());
   }
 
+  private void validateIndexEngineReference(
+      int externalIndexId, @Nullable IndexEngineReference expectedReference)
+      throws InvalidIndexEngineIdException {
+    engineForDereference(extractInternalId(externalIndexId), expectedReference);
+  }
+
   private void checkIndexId(final int indexId) throws InvalidIndexEngineIdException {
     if (indexId < 0 || indexId >= indexEngines.size() || indexEngines.get(indexId) == null) {
       throw new InvalidIndexEngineIdException(
           "Engine with id " + indexId + " is not registered inside of storage");
     }
+  }
+
+  public boolean removeKeyFromIndex(
+      final int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object key, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    return removeKeyFromIndex(indexId, key, atomicOperation);
   }
 
   public boolean removeKeyFromIndex(final int indexId, final Object key,
@@ -5194,6 +5227,16 @@ public abstract class AbstractStorage
     }
   }
 
+  public void clearIndex(
+      final int indexId, @Nullable IndexEngineReference expectedReference) {
+    try {
+      getIndexEngine(indexId, expectedReference);
+    } catch (InvalidIndexEngineIdException exception) {
+      throw new IllegalStateException(exception);
+    }
+    clearIndex(indexId);
+  }
+
   public void clearIndex(final int indexId) {
     try {
       final var internalIndexId = extractInternalId(indexId);
@@ -5235,7 +5278,16 @@ public abstract class AbstractStorage
     }
   }
 
-  public Stream<RID> getIndexValues(int indexId, final Object key, AtomicOperation atomicOperation)
+  public Stream<RID> getIndexValues(
+      int indexId, final Object key, AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    return getIndexValues(
+        indexId, getIndexEngineReference(indexId), key, atomicOperation);
+  }
+
+  public Stream<RID> getIndexValues(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object key, AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
     final var engineAPIVersion = extractEngineAPIVersion(indexId);
     if (engineAPIVersion != 1) {
@@ -5250,7 +5302,7 @@ public abstract class AbstractStorage
       try {
         checkOpennessAndMigration();
 
-        return doGetIndexValues(indexId, key, atomicOperation);
+        return doGetIndexValues(indexId, expectedReference, key, atomicOperation);
       } finally {
         stateLock.readLock().unlock();
       }
@@ -5265,12 +5317,11 @@ public abstract class AbstractStorage
     }
   }
 
-  private Stream<RID> doGetIndexValues(final int indexId, final Object key,
-      AtomicOperation atomicOperation)
+  private Stream<RID> doGetIndexValues(
+      final int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object key, AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
-    checkIndexId(indexId);
-
-    final var engine = indexEngines.get(indexId);
+    final var engine = engineForDereference(indexId, expectedReference);
     assert indexId == engine.getId();
 
     return ((V1IndexEngine) engine).get(key, atomicOperation);
@@ -5412,6 +5463,14 @@ public abstract class AbstractStorage
   }
 
   public <T> void callIndexEngine(
+      final boolean readOperation, int indexId,
+      @Nullable IndexEngineReference expectedReference, final IndexEngineCallback<T> callback)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    callIndexEngine(readOperation, indexId, callback);
+  }
+
+  public <T> void callIndexEngine(
       final boolean readOperation, int indexId, final IndexEngineCallback<T> callback)
       throws InvalidIndexEngineIdException {
     indexId = extractInternalId(indexId);
@@ -5463,6 +5522,14 @@ public abstract class AbstractStorage
     callback.callEngine(engine);
   }
 
+  public void putRidIndexEntry(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object key, final RID value, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    putRidIndexEntry(indexId, key, value, atomicOperation);
+  }
+
   public void putRidIndexEntry(int indexId, final Object key, final RID value,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
@@ -5497,6 +5564,14 @@ public abstract class AbstractStorage
     assert engine.getId() == indexId;
 
     ((V1IndexEngine) engine).put(atomicOperation, key, value);
+  }
+
+  public boolean removeRidIndexEntry(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object key, final RID value, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    return removeRidIndexEntry(indexId, key, value, atomicOperation);
   }
 
   public boolean removeRidIndexEntry(int indexId, final Object key, final RID value,
@@ -5547,6 +5622,19 @@ public abstract class AbstractStorage
    *     in-place or the validator rejected the operation (IGNORE).
    * @see IndexEngineValidator#validate(Object, Object, Object)
    */
+  @SuppressWarnings("UnusedReturnValue")
+  public boolean validatedPutIndexValue(
+      final int indexId,
+      @Nullable IndexEngineReference expectedReference,
+      final Object key,
+      final RID value,
+      final IndexEngineValidator<Object, RID> validator,
+      @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    validateIndexEngineReference(indexId, expectedReference);
+    return validatedPutIndexValue(indexId, key, value, validator, atomicOperation);
+  }
+
   @SuppressWarnings("UnusedReturnValue")
   public boolean validatedPutIndexValue(
       final int indexId,
@@ -5602,6 +5690,18 @@ public abstract class AbstractStorage
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesBetween(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object rangeFrom, final boolean fromInclusive,
+      final Object rangeTo, final boolean toInclusive, final boolean ascSortOrder,
+      final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return iterateIndexEntriesBetween(
+        indexId, rangeFrom, fromInclusive, rangeTo, toInclusive, ascSortOrder, transformer,
+        atomicOperation);
+  }
+
+  public Stream<RawPair<Object, RID>> iterateIndexEntriesBetween(
       int indexId,
       final Object rangeFrom,
       final boolean fromInclusive,
@@ -5653,6 +5753,16 @@ public abstract class AbstractStorage
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesMajor(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object fromKey, final boolean isInclusive, final boolean ascSortOrder,
+      final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return iterateIndexEntriesMajor(
+        indexId, fromKey, isInclusive, ascSortOrder, transformer, atomicOperation);
+  }
+
+  public Stream<RawPair<Object, RID>> iterateIndexEntriesMajor(
       int indexId,
       final Object fromKey,
       final boolean isInclusive,
@@ -5697,6 +5807,16 @@ public abstract class AbstractStorage
 
     return engine.iterateEntriesMajor(fromKey, isInclusive, ascSortOrder, transformer,
         atomicOperation);
+  }
+
+  public Stream<RawPair<Object, RID>> iterateIndexEntriesMinor(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final Object toKey, final boolean isInclusive, final boolean ascSortOrder,
+      final IndexEngineValuesTransformer transformer, AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return iterateIndexEntriesMinor(
+        indexId, toKey, isInclusive, ascSortOrder, transformer, atomicOperation);
   }
 
   public Stream<RawPair<Object, RID>> iterateIndexEntriesMinor(
@@ -5746,6 +5866,15 @@ public abstract class AbstractStorage
   }
 
   public Stream<RawPair<Object, RID>> getIndexStream(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final IndexEngineValuesTransformer valuesTransformer,
+      @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return getIndexStream(indexId, valuesTransformer, atomicOperation);
+  }
+
+  public Stream<RawPair<Object, RID>> getIndexStream(
       int indexId, final IndexEngineValuesTransformer valuesTransformer,
       @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
@@ -5779,6 +5908,15 @@ public abstract class AbstractStorage
     assert indexId == engine.getId();
 
     return engine.stream(valuesTransformer, atomicOperation);
+  }
+
+  public Stream<RawPair<Object, RID>> getIndexDescStream(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final IndexEngineValuesTransformer valuesTransformer,
+      @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return getIndexDescStream(indexId, valuesTransformer, atomicOperation);
   }
 
   public Stream<RawPair<Object, RID>> getIndexDescStream(
@@ -5819,6 +5957,14 @@ public abstract class AbstractStorage
     return engine.descStream(valuesTransformer, atomicOperation);
   }
 
+  public Stream<Object> getIndexKeyStream(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return getIndexKeyStream(indexId, atomicOperation);
+  }
+
   public Stream<Object> getIndexKeyStream(int indexId, @Nonnull AtomicOperation atomicOperation)
       throws InvalidIndexEngineIdException {
     indexId = extractInternalId(indexId);
@@ -5851,6 +5997,14 @@ public abstract class AbstractStorage
     assert indexId == engine.getId();
 
     return engine.keyStream(atomicOperation);
+  }
+
+  public long getIndexSize(
+      int indexId, @Nullable IndexEngineReference expectedReference,
+      final IndexEngineValuesTransformer transformer, @Nonnull AtomicOperation atomicOperation)
+      throws InvalidIndexEngineIdException {
+    getIndexEngine(indexId, expectedReference);
+    return getIndexSize(indexId, transformer, atomicOperation);
   }
 
   public long getIndexSize(int indexId, final IndexEngineValuesTransformer transformer,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4381,8 +4381,9 @@ public abstract class AbstractStorage
     for (var entry : holder.getDeltas().int2ObjectEntrySet()) {
       int engineId = entry.getIntKey();
       var delta = entry.getValue();
-      // Engine replacement cannot race this lookup. The index tree component lock remains held
-      // through Hook B, which applies these deltas after the durable commit.
+      // indexEngines is a plain ArrayList. Ordinary transaction commits retain the state read lock
+      // and index tree component lock through Hook B. The rebuild tail reaches Hook B after
+      // releasing both locks. That pre-existing unlocked lookup is deferred to YTDB-1268.
       if (engineId >= 0 && engineId < indexEngines.size()) {
         var engine = indexEngines.get(engineId);
         if (engine instanceof BTreeIndexEngine btreeEngine) {
@@ -4451,8 +4452,9 @@ public abstract class AbstractStorage
     for (var entry : holder.getDeltas().entrySet()) {
       var engineId = entry.getKey();
       var delta = entry.getValue();
-      // Engine replacement cannot race this lookup. The index tree component lock remains held
-      // through Hook B, which applies these deltas after the durable commit.
+      // indexEngines is a plain ArrayList. Ordinary transaction commits retain the state read lock
+      // and index tree component lock through Hook B. The rebuild tail reaches Hook B after
+      // releasing both locks. That pre-existing unlocked lookup is deferred to YTDB-1268.
       if (engineId < indexEngines.size()) {
         var engine = indexEngines.get(engineId);
         if (engine instanceof BTreeIndexEngine btreeEngine) {
@@ -4832,10 +4834,8 @@ public abstract class AbstractStorage
   }
 
   /**
-   * Sets {@code indexEngines.get(id) == engine}, growing the list with null padding when
-   * {@code id} is at or past the current size, mirroring {@link #setCollection(int,
-   * StorageCollection)}. The public append path uses {@code id == indexEngines.size()};
-   * the commit-local allocator may reuse a hole at {@code id < indexEngines.size()}.
+   * Detaches histogram publication from an engine that is leaving the registry. This must run
+   * before its slot is released, so removal linearizes before a replacement publishes there.
    */
   private static void detachHistogramManager(final BaseIndexEngine engine) {
     if (engine instanceof BTreeIndexEngine btreeEngine) {
@@ -4846,6 +4846,12 @@ public abstract class AbstractStorage
     }
   }
 
+  /**
+   * Sets {@code indexEngines.get(id) == engine}, growing the list with null padding when
+   * {@code id} is at or past the current size, mirroring {@link #setCollection(int,
+   * StorageCollection)}. The public append path uses {@code id == indexEngines.size()};
+   * the commit-local allocator may reuse a hole at {@code id < indexEngines.size()}.
+   */
   private void setIndexEngine(final int id, final BaseIndexEngine engine) {
     if (indexEngines.size() <= id) {
       while (indexEngines.size() < id) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4301,6 +4301,10 @@ public abstract class AbstractStorage
         if (changes.cleared) {
           if (index instanceof IndexAbstract handle) {
             final var snapshot = handle.engineSnapshot();
+            if (snapshot.engineIdentifier() < 0) {
+              throw new StaleIndexEngineException(
+                  name, "Index engine became unavailable before index clear");
+            }
             final var internalIndexId = extractInternalId(snapshot.engineIdentifier());
             doClearIndex(
                 atomicOperation, internalIndexId,
@@ -4549,7 +4553,7 @@ public abstract class AbstractStorage
 
   /**
    * Binds a local engine to its durable descriptor after that descriptor obtains or loads its RID.
-   * The expected reference must be identical or precede the live generation at the same slot.
+   * A differing reference is accepted only for a newer engine already bound to the same owner.
    */
   @Nullable public IndexEngineReference attachIndexEngineOwner(
       int externalIndexId, RID descriptorIdentity,
@@ -4581,13 +4585,17 @@ public abstract class AbstractStorage
     if (carrierReference == null) {
       throw new IllegalStateException("Index engine unexpectedly gained a process-local reference");
     }
-    if (liveReference != carrierReference
-        && (liveReference.slot() != carrierReference.slot()
-            || liveReference.generation() <= carrierReference.generation())) {
-      throw new IllegalStateException(
-          "Index engine reference changed non-monotonically from generation "
-              + carrierReference.generation() + " to " + liveReference.generation()
-              + " for slot " + liveReference.slot());
+    if (liveReference != carrierReference) {
+      final var liveOwner = liveReference.ownerDescriptorIdentity();
+      final var isOwnedMonotonicReplacement =
+          liveReference.slot() == carrierReference.slot()
+              && liveReference.generation() > carrierReference.generation()
+              && descriptorIdentity.equals(liveOwner);
+      if (!isOwnedMonotonicReplacement) {
+        throw new IllegalStateException(
+            "Index engine reference changed from generation " + carrierReference.generation()
+                + " to " + liveReference.generation() + " for slot " + liveReference.slot());
+      }
     }
 
     liveReference.bindOwner(descriptorIdentity);
@@ -4601,7 +4609,7 @@ public abstract class AbstractStorage
    */
   public ResolvedIndexEngine resolveIndexEngineByOwner(final RID descriptorIdentity) {
     try {
-      if (isCommitWindowActive()) {
+      if (isCommitWindowActive() || stateLock.isReadLockedByCurrentThread()) {
         return resolveIndexEngineByOwnerWithStateLock(descriptorIdentity);
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3797,6 +3797,7 @@ public abstract class AbstractStorage
     final var generatedId = nextFreeIndexEngineId();
     assert generatedId >= indexEngines.size() || indexEngines.get(generatedId) == null
         : "commit-local index-engine allocator returned an occupied slot " + generatedId;
+    discardIndexDeltas(atomicOperation, generatedId);
     // Unlike the reusable slot id above, the file base id is never reused: allocated from the
     // monotonic high-water mark inside this commit's atomic operation (the floor write reverts
     // with a failed commit; the mark itself burns the value).
@@ -3884,6 +3885,7 @@ public abstract class AbstractStorage
     final var capturedData =
         configuration.getIndexEngine(engine.getName(), internalIndexId, atomicOperation);
 
+    discardIndexDeltas(atomicOperation, internalIndexId);
     doDeleteIndexEngine(atomicOperation, engine);
     indexEngines.set(internalIndexId, null);
     indexEngineNameMap.remove(engine.getName());
@@ -4405,9 +4407,26 @@ public abstract class AbstractStorage
   }
 
   /**
-   * Applies histogram deltas accumulated during the transaction to the
-   * in-memory CHM cache. Called after {@code endTxCommit()} succeeds so
-   * that the cache always reflects committed state only.
+   * Removes transaction-local work keyed by a slot whose engine lifetime has ended. Commit-window
+   * drops run after ordinary index writes, while creates run before replacement population. Thus,
+   * the removed work can only belong to the old owner. Work for the replacement accumulates later.
+   */
+  private static void discardIndexDeltas(
+      final AtomicOperation atomicOperation, final int engineId) {
+    final var countDeltas = atomicOperation.getIndexCountDeltas();
+    if (countDeltas != null) {
+      countDeltas.discard(engineId);
+    }
+
+    final var histogramDeltas = atomicOperation.getHistogramDeltas();
+    if (histogramDeltas != null) {
+      histogramDeltas.discard(engineId);
+    }
+  }
+
+  /**
+   * Applies histogram deltas accumulated during the transaction to the in-memory CHM cache. Called
+   * after {@code endTxCommit()} succeeds so that the cache always reflects committed state only.
    */
   public void applyHistogramDeltas(AtomicOperation atomicOperation) {
     var holder = atomicOperation.getHistogramDeltas();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4568,8 +4568,7 @@ public abstract class AbstractStorage
    * Resolves an engine by descriptor owner while the caller retains the storage state lock.
    *
    * @throws StaleIndexEngineException when no registered engine has the requested owner
-   * @throws StorageException when registry ownership is ambiguous or a local engine has no
-   *     process-local reference
+   * @throws StorageException when registry ownership is ambiguous
    */
   public int resolveIndexEngineByOwnerWithStateLock(final RID descriptorIdentity) {
     if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
@@ -4588,11 +4587,9 @@ public abstract class AbstractStorage
 
       final var reference = engine.getEngineReference();
       if (reference == null) {
-        throw new StorageException(
-            name,
-            "Registered local index engine in slot " + slot
-                + " has no process-local reference while resolving descriptor "
-                + descriptorIdentity);
+        // An engine without a reference cannot be owned by any descriptor. Skipping it cannot hide
+        // a possible owner-resolution target.
+        continue;
       }
 
       if (descriptorIdentity.equals(reference.ownerDescriptorIdentity())) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -5232,7 +5232,8 @@ public abstract class AbstractStorage
     try {
       getIndexEngine(indexId, expectedReference);
     } catch (InvalidIndexEngineIdException exception) {
-      throw new IllegalStateException(exception);
+      throw new StaleIndexEngineException(
+          name, "Index engine changed before clear: " + exception.getMessage());
     }
     clearIndex(indexId);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4552,9 +4552,6 @@ public abstract class AbstractStorage
       } finally {
         stateLock.readLock().unlock();
       }
-    } catch (final StaleIndexEngineException exception) {
-      // Preserve the HighLevelException marker used to keep the storage outside the error state.
-      throw exception;
     } catch (final RuntimeException exception) {
       throw logAndPrepareForRethrow(exception);
     } catch (final Error error) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3923,6 +3923,25 @@ public abstract class AbstractStorage
     }
   }
 
+  void bindOwnerAndPublishRestoredIndexEngine(
+      int indexId, BaseIndexEngine engine, @Nullable RID ownerDescriptorIdentity) {
+    if (ownerDescriptorIdentity != null) {
+      final var engineReference = engine.getEngineReference();
+      if (engineReference != null) {
+        engineReference.bindOwner(ownerDescriptorIdentity);
+      } else {
+        // Publish reference-less engines because preserving the surviving committed index is safer
+        // than turning optional process-local ownership metadata into a restore failure.
+        LogManager.instance().warn(
+            this,
+            "Restored index engine '" + engine.getName()
+                + "' exposes no process-local reference. Owner " + ownerDescriptorIdentity
+                + " was not bound");
+      }
+    }
+    publishIndexEngine(indexId, engine);
+  }
+
   /**
    * Restores the in-memory engine registry for every engine a failed schema-carry commit dropped, the
    * drop-side mirror of {@link #undoReconciledCollections}'s re-register arm. {@link
@@ -3984,10 +4003,8 @@ public abstract class AbstractStorage
               if (engine instanceof BTreeIndexEngine btreeEngine) {
                 wireHistogramManagerOnLoad(btreeEngine, engineData, atomicOperation);
               }
-              if (dropped.ownerDescriptorIdentity() != null) {
-                engine.getEngineReference().bindOwner(dropped.ownerDescriptorIdentity());
-              }
-              publishIndexEngine(engineData.getIndexId(), engine);
+              bindOwnerAndPublishRestoredIndexEngine(
+                  engineData.getIndexId(), engine, dropped.ownerDescriptorIdentity());
             });
       } catch (final IOException | RuntimeException | AssertionError e) {
         // Loud failure containment: the reconstruction runs while the primary commit exception is

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -2031,7 +2031,8 @@ public abstract class AbstractStorage
    * collection's approximate record count without taking {@code stateLock}, because the schema-carry
    * commit already holds {@code stateLock.writeLock()} and re-acquiring the non-reentrant read lock
    * would busy-spin. The commit-time index build uses it to enforce the v1 empty-source-collection
-   * bound. Mirrors the lock-free {@link #doGetIndexEngine} precondition: the caller MUST hold
+   * bound. Mirrors the lock-free {@link #getIndexEngineWithStateLock(int)} precondition: the caller
+   * MUST hold
    * {@code stateLock.writeLock()} with the commit window open, which supplies the exclusion and the
    * happens-before edge for the plain-list read.
    *
@@ -2058,7 +2059,8 @@ public abstract class AbstractStorage
    * count before it relies on the v1 empty-source-collection bound, closing the under-report hole
    * where a stale approximate zero would let the build skip committed rows. Exact but cheap on the
    * empty collection the caller has already pre-checked as approximately empty. Mirrors the lock-free
-   * {@link #doGetIndexEngine} precondition: the caller MUST hold {@code stateLock.writeLock()} with
+   * {@link #getIndexEngineWithStateLock(int)} precondition: the caller MUST hold
+   * {@code stateLock.writeLock()} with
    * the commit window open, which supplies the exclusion and the happens-before edge.
    *
    * @param collectionId    a real (>= 0) collection id.
@@ -5018,29 +5020,18 @@ public abstract class AbstractStorage
     return ((V1IndexEngine) engine).get(key, atomicOperation);
   }
 
-  public BaseIndexEngine getIndexEngine(int indexId) throws InvalidIndexEngineIdException {
-    indexId = extractInternalId(indexId);
-
+  public BaseIndexEngine getIndexEngine(final int indexId)
+      throws InvalidIndexEngineIdException {
     try {
-      checkIndexId(indexId);
-
-      // A schema-carrying commit reaches this resolver through the index-apply path
-      // (lockIndexes -> IndexAbstract.acquireAtomicExclusiveLock) while already holding
-      // stateLock.writeLock(). Re-acquiring the read lock there would busy-spin forever on the
-      // non-reentrant ScalableRWLock, so the commit window self-routes to the lock-free body, the
-      // same seam getPhysicalCollectionNameById and readRecordInternal use. The held write lock
-      // supplies the exclusion and the happens-before edge; the pure-read fast path keeps the lock.
+      // A schema-carrying commit already holds stateLock.writeLock(). The active commit window
+      // proves that ownership and avoids a non-reentrant read-lock acquisition.
       if (isCommitWindowActive()) {
-        checkOpennessAndMigration();
-        return doGetIndexEngine(indexId);
+        return getIndexEngineWithStateLock(indexId);
       }
 
       stateLock.readLock().lock();
       try {
-
-        checkOpennessAndMigration();
-
-        return doGetIndexEngine(indexId);
+        return getIndexEngineWithStateLock(indexId);
       } finally {
         stateLock.readLock().unlock();
       }
@@ -5056,28 +5047,18 @@ public abstract class AbstractStorage
   }
 
   /**
-   * Lock-free engine resolver for the commit window. Reads {@code indexEngines.get(id)}
-   * without taking {@code stateLock}, mirroring the lock-free {@link
-   * #doGetAndCheckCollection(int)} for collections. The schema-carrying commit already
-   * holds {@code stateLock.writeLock()} (the write-lock branch chosen at commit entry),
-   * so re-acquiring {@code stateLock.readLock()} through the public {@link
-   * #getIndexEngine(int)} would busy-spin forever on the non-reentrant {@code
-   * ScalableRWLock}. The commit-time index-apply path reaches this resolver instead.
-   *
-   * <p><b>Precondition the caller MUST satisfy:</b> this method does no in-method
-   * synchronization and reads the plain (non-{@code volatile}, non-concurrent) {@code
-   * indexEngines} list directly, so the caller MUST hold {@code stateLock} across the call:
-   * {@code writeLock()} for the commit window, {@code readLock()} for the public wrapper.
-   * That held lock is the only thing that excludes a concurrent registrar and
-   * supplies the happens-before edge making the registry read visibility-safe; off-lock
-   * use (or use under only the metadata write locks, not {@code stateLock}) is a data race
-   * on a plain {@code ArrayList} and is unsupported.
-   *
-   * @param internalId the already-extracted internal index id (not the external,
-   *                   API-version-tagged id).
+   * Resolves an engine without acquiring {@code stateLock}. The caller must already hold the
+   * state read lock, or run inside the commit window while holding the state write lock.
    */
-  private BaseIndexEngine doGetIndexEngine(final int internalId)
+  public BaseIndexEngine getIndexEngineWithStateLock(final int indexId)
       throws InvalidIndexEngineIdException {
+    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
+      throw new IllegalStateException(
+          "Index engine resolution requires the storage state lock or an active commit window");
+    }
+
+    checkOpennessAndMigration();
+    final var internalId = extractInternalId(indexId);
     checkIndexId(internalId);
 
     final var engine = indexEngines.get(internalId);
@@ -6819,6 +6800,68 @@ public abstract class AbstractStorage
       }
 
       LogManager.instance().info(this, "Storage data recover was completed");
+    }
+  }
+
+  /**
+   * Creates a record inside a caller-owned atomic operation. The caller owns the state-lock
+   * lifetime, while this method ensures the target collection is locked exclusively.
+   *
+   * @return the initial durable record version
+   */
+  public long createRecordInsideAtomicOperation(
+      final AtomicOperation atomicOperation,
+      final RecordIdInternal rid,
+      @Nonnull final byte[] content,
+      final byte recordType) {
+    checkCallerOwnsStateLock();
+    checkOpennessAndMigration();
+    if (!rid.isNew() || !(rid instanceof ChangeableRecordId)) {
+      throw new IllegalArgumentException(
+          "Record creation requires a new changeable record identifier: " + rid);
+    }
+
+    final var collection = doGetAndCheckCollection(rid.getCollectionId());
+    collection.acquireAtomicExclusiveLock(atomicOperation);
+    final var position =
+        doCreateRecord(
+            atomicOperation,
+            rid,
+            content,
+            atomicOperation.getCommitTs(),
+            recordType,
+            collection,
+            null);
+    return position.recordVersion;
+  }
+
+  /**
+   * Updates a record inside a caller-owned atomic operation and checks its durable version.
+   *
+   * @return the new durable record version
+   */
+  public long updateRecordInsideAtomicOperation(
+      final AtomicOperation atomicOperation,
+      final RecordIdInternal rid,
+      @Nonnull final byte[] content,
+      final long expectedVersion,
+      final byte recordType) {
+    checkCallerOwnsStateLock();
+    checkOpennessAndMigration();
+    if (!rid.isPersistent()) {
+      throw new IllegalArgumentException("Record update requires a persistent identifier: " + rid);
+    }
+
+    final var collection = doGetAndCheckCollection(rid.getCollectionId());
+    collection.acquireAtomicExclusiveLock(atomicOperation);
+    return doUpdateRecord(
+        atomicOperation, rid, true, content, expectedVersion, recordType, collection);
+  }
+
+  private void checkCallerOwnsStateLock() {
+    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
+      throw new IllegalStateException(
+          "Caller-owned record writes require the storage state lock or an active commit window");
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4416,18 +4416,13 @@ public abstract class AbstractStorage
 
   public int loadIndexEngine(final String name) {
     try {
+      if (isCommitWindowActive()) {
+        return loadIndexEngineWithStateLock(name);
+      }
+
       stateLock.readLock().lock();
       try {
-
-        checkOpennessAndMigration();
-
-        final var engine = indexEngineNameMap.get(name);
-        if (engine == null) {
-          return -1;
-        }
-        final var indexId = indexEngines.indexOf(engine);
-        assert indexId == engine.getId();
-        return generateIndexId(indexId, engine);
+        return loadIndexEngineWithStateLock(name);
       } finally {
         stateLock.readLock().unlock();
       }
@@ -4438,6 +4433,23 @@ public abstract class AbstractStorage
     } catch (final Throwable t) {
       throw logAndPrepareForRethrow(t, false);
     }
+  }
+
+  /** Resolves an engine identifier by name while the caller retains the storage state lock. */
+  public int loadIndexEngineWithStateLock(final String name) {
+    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
+      throw new IllegalStateException(
+          "Index engine reload requires the storage state lock or an active commit window");
+    }
+
+    checkOpennessAndMigration();
+    final var engine = indexEngineNameMap.get(name);
+    if (engine == null) {
+      return -1;
+    }
+    final var indexId = indexEngines.indexOf(engine);
+    assert indexId == engine.getId();
+    return generateIndexId(indexId, engine);
   }
 
   public int loadExternalIndexEngine(
@@ -6804,8 +6816,9 @@ public abstract class AbstractStorage
   }
 
   /**
-   * Creates a record inside a caller-owned atomic operation. The caller owns the state-lock
-   * lifetime, while this method ensures the target collection is locked exclusively.
+   * Creates a record inside a caller-owned atomic operation. One operation may use these record
+   * primitives for one collection only. Future multi-collection support must lock collections in
+   * ascending identifier order before mutation.
    *
    * @return the initial durable record version
    */
@@ -6813,7 +6826,7 @@ public abstract class AbstractStorage
       final AtomicOperation atomicOperation,
       final RecordIdInternal rid,
       @Nonnull final byte[] content,
-      final byte recordType) {
+      final byte recordType) throws IOException {
     checkCallerOwnsStateLock();
     checkOpennessAndMigration();
     if (!rid.isNew() || !(rid instanceof ChangeableRecordId)) {
@@ -6821,6 +6834,8 @@ public abstract class AbstractStorage
           "Record creation requires a new changeable record identifier: " + rid);
     }
 
+    atomicOperation.validateRecordCollectionLockOrder(rid.getCollectionId());
+    makeStorageDirty();
     final var collection = doGetAndCheckCollection(rid.getCollectionId());
     collection.acquireAtomicExclusiveLock(atomicOperation);
     final var position =
@@ -6836,7 +6851,9 @@ public abstract class AbstractStorage
   }
 
   /**
-   * Updates a record inside a caller-owned atomic operation and checks its durable version.
+   * Updates a record inside a caller-owned atomic operation and checks its durable version. One
+   * operation may use these record primitives for one collection only. Future multi-collection
+   * support must lock collections in ascending identifier order before mutation.
    *
    * @return the new durable record version
    */
@@ -6845,13 +6862,15 @@ public abstract class AbstractStorage
       final RecordIdInternal rid,
       @Nonnull final byte[] content,
       final long expectedVersion,
-      final byte recordType) {
+      final byte recordType) throws IOException {
     checkCallerOwnsStateLock();
     checkOpennessAndMigration();
     if (!rid.isPersistent()) {
       throw new IllegalArgumentException("Record update requires a persistent identifier: " + rid);
     }
 
+    atomicOperation.validateRecordCollectionLockOrder(rid.getCollectionId());
+    makeStorageDirty();
     final var collection = doGetAndCheckCollection(rid.getCollectionId());
     collection.acquireAtomicExclusiveLock(atomicOperation);
     return doUpdateRecord(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4433,40 +4433,72 @@ public abstract class AbstractStorage
     return indexLifecycleRegistry.getOrCreate(descriptorIdentity);
   }
 
-  /**
-   * Binds a local engine to its durable descriptor after that descriptor obtains or loads its RID.
-   */
-  public IndexEngineReference bindIndexEngineToDescriptor(
-      int externalIndexId, RID descriptorIdentity) {
-    try {
-      if (isCommitWindowActive()) {
-        return bindIndexEngineToDescriptorWithStateLock(externalIndexId, descriptorIdentity);
-      }
+  public IndexLifecycleCell getIndexLifecycle(RID descriptorIdentity) {
+    return indexLifecycleRegistry.get(descriptorIdentity);
+  }
 
-      stateLock.readLock().lock();
-      try {
-        return bindIndexEngineToDescriptorWithStateLock(externalIndexId, descriptorIdentity);
-      } finally {
-        stateLock.readLock().unlock();
-      }
-    } catch (RuntimeException e) {
-      throw logAndPrepareForRethrow(e);
+  public void removeIndexLifecycle(RID descriptorIdentity) {
+    indexLifecycleRegistry.remove(descriptorIdentity);
+  }
+
+  public IndexEngineReference getIndexEngineReference(int externalIndexId) {
+    if (isCommitWindowActive()) {
+      return getIndexEngineReferenceWithStateLock(externalIndexId);
+    }
+
+    stateLock.readLock().lock();
+    try {
+      return getIndexEngineReferenceWithStateLock(externalIndexId);
+    } finally {
+      stateLock.readLock().unlock();
     }
   }
 
-  private IndexEngineReference bindIndexEngineToDescriptorWithStateLock(
-      int externalIndexId, RID descriptorIdentity) {
+  private IndexEngineReference getIndexEngineReferenceWithStateLock(int externalIndexId) {
     final var internalIndexId = extractInternalId(externalIndexId);
     try {
       checkIndexId(internalIndexId);
     } catch (InvalidIndexEngineIdException e) {
-      throw new IllegalStateException("Cannot bind an unregistered index engine", e);
+      throw new IllegalStateException("Cannot resolve an unregistered index engine", e);
     }
 
     final var reference = indexEngines.get(internalIndexId).getEngineReference();
     if (reference == null) {
       throw new IllegalStateException("Local index engine has no process-local reference");
     }
+    return reference;
+  }
+
+  /**
+   * Binds a local engine to its durable descriptor after that descriptor obtains or loads its RID.
+   */
+  public IndexEngineReference bindIndexEngineToDescriptor(
+      int externalIndexId, RID descriptorIdentity, IndexEngineReference expectedReference) {
+    if (isCommitWindowActive()) {
+      return bindIndexEngineToDescriptorWithStateLock(
+          externalIndexId, descriptorIdentity, expectedReference);
+    }
+
+    stateLock.readLock().lock();
+    try {
+      return bindIndexEngineToDescriptorWithStateLock(
+          externalIndexId, descriptorIdentity, expectedReference);
+    } finally {
+      stateLock.readLock().unlock();
+    }
+  }
+
+  private IndexEngineReference bindIndexEngineToDescriptorWithStateLock(
+      int externalIndexId, RID descriptorIdentity, IndexEngineReference expectedReference) {
+    final var reference = getIndexEngineReferenceWithStateLock(externalIndexId);
+    if (reference.slot() != expectedReference.slot()
+        || reference.apiVersion() != expectedReference.apiVersion()
+        || reference.generation() != expectedReference.generation()) {
+      throw new IllegalStateException(
+          "Index engine reference changed from generation " + expectedReference.generation()
+              + " to " + reference.generation() + " for slot " + reference.slot());
+    }
+
     reference.bindOwner(descriptorIdentity);
     return reference;
   }
@@ -4832,7 +4864,7 @@ public abstract class AbstractStorage
         | internalId;
   }
 
-  private static int extractInternalId(final int externalId) {
+  public static int extractInternalId(final int externalId) {
     if (externalId < 0) {
       throw new IllegalStateException("Index id has to be positive");
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3828,7 +3828,10 @@ public abstract class AbstractStorage
    * path (the delete's own {@code IndexHistogramManager} teardown makes the live engine object
    * unusable, so the failure path never re-publishes the torn object).
    */
-  public record DroppedIndexEngine(int internalId, IndexEngineData data) {
+  public record DroppedIndexEngine(
+      int internalId,
+      IndexEngineData data,
+      @Nullable RID ownerDescriptorIdentity) {
 
   }
 
@@ -3869,14 +3872,22 @@ public abstract class AbstractStorage
     assert internalIndexId == engine.getId();
 
     // Capture the durable engine data before the delete removes the config entry it reads. The
-    // captured data (not the torn live engine) drives the failure-path reconstruction.
+    // captured data (not the torn live engine) drives the failure-path reconstruction. Copy the
+    // owner because commit apply can mutate its ChangeableRecordId in place after this capture.
+    final var ownerDescriptorIdentity = engine.getEngineReference() == null
+        ? null
+        : engine.getEngineReference().ownerDescriptorIdentity();
+    final var copiedOwnerDescriptorIdentity = ownerDescriptorIdentity == null
+        ? null
+        : new RecordId(ownerDescriptorIdentity.getCollectionId(),
+            ownerDescriptorIdentity.getCollectionPosition());
     final var capturedData =
         configuration.getIndexEngine(engine.getName(), internalIndexId, atomicOperation);
 
     doDeleteIndexEngine(atomicOperation, engine);
     indexEngines.set(internalIndexId, null);
     indexEngineNameMap.remove(engine.getName());
-    return new DroppedIndexEngine(internalIndexId, capturedData);
+    return new DroppedIndexEngine(internalIndexId, capturedData, copiedOwnerDescriptorIdentity);
   }
 
   /**
@@ -3972,6 +3983,9 @@ public abstract class AbstractStorage
               engine.load(engineData, atomicOperation);
               if (engine instanceof BTreeIndexEngine btreeEngine) {
                 wireHistogramManagerOnLoad(btreeEngine, engineData, atomicOperation);
+              }
+              if (dropped.ownerDescriptorIdentity() != null) {
+                engine.getEngineReference().bindOwner(dropped.ownerDescriptorIdentity());
               }
               publishIndexEngine(engineData.getIndexId(), engine);
             });

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -94,8 +94,10 @@ import com.jetbrains.youtrackdb.internal.core.index.engine.V1IndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeMultiValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildState;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleRegistry;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleSnapshot;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaShared;
@@ -123,6 +125,8 @@ import com.jetbrains.youtrackdb.internal.core.storage.collection.SnapshotKey;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.VisibilityKey;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.v2.PaginatedCollectionV2;
 import com.jetbrains.youtrackdb.internal.core.storage.config.CollectionBasedStorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsTable;
@@ -330,7 +334,8 @@ public abstract class AbstractStorage
 
   private final Map<String, BaseIndexEngine> indexEngineNameMap = new HashMap<>();
   private final List<BaseIndexEngine> indexEngines = new ArrayList<>();
-  private final IndexLifecycleRegistry indexLifecycleRegistry = new IndexLifecycleRegistry();
+  private final StorageIdentityHolder storageIdentityHolder;
+  private final IndexLifecycleRegistry indexLifecycleRegistry;
   private long indexEngineGeneration;
   private final AtomicOperationIdGen idGen = new AtomicOperationIdGen();
 
@@ -514,6 +519,15 @@ public abstract class AbstractStorage
   public AbstractStorage(
       final String name, final String filePath, final int id,
       YouTrackDBInternalEmbedded context) {
+    this(name, filePath, id, context, true);
+  }
+
+  protected AbstractStorage(
+      final String name,
+      final String filePath,
+      final int id,
+      YouTrackDBInternalEmbedded context,
+      boolean initializeVolatileIdentity) {
     this.context = context;
     this.name = checkName(name);
 
@@ -522,6 +536,11 @@ public abstract class AbstractStorage
     stateLock = new ScalableRWLock();
 
     this.id = id;
+
+    storageIdentityHolder = initializeVolatileIdentity
+        ? new StorageIdentityHolder(StorageIdentity.random(), StorageLineageIdentity.random())
+        : new StorageIdentityHolder();
+    indexLifecycleRegistry = new IndexLifecycleRegistry(storageIdentityHolder::lineageIdentity);
 
     int permits = GlobalConfiguration.QUERY_STATS_MAX_CONCURRENT_REBALANCES
         .getValueAsInteger();
@@ -824,6 +843,7 @@ public abstract class AbstractStorage
                 "Cannot open the storage '" + name + "' because it does not exist in path: " + url);
           }
 
+          readStorageIdentity();
           readIv();
 
           initWalAndDiskCache(contextConfiguration);
@@ -1477,6 +1497,7 @@ public abstract class AbstractStorage
           "Cannot create new storage '" + getURL() + "' because it already exists");
     }
 
+    prepareStorageBirth();
     uuid = UUID.randomUUID();
     initIv();
 
@@ -1545,6 +1566,10 @@ public abstract class AbstractStorage
             doAddCollection(atomicOperation, MetadataDefault.BLOB_COLLECTION_NAME_PREFIX + i);
           }
 
+          // Preserve established blob collection identifiers. Storage creation still completes
+          // before genesis creates security indexes, so the build state collection is ready.
+          doAddCollection(atomicOperation, MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+
           ((CollectionBasedStorageConfiguration) configuration)
               .setCreationVersion(atomicOperation, YouTrackDBConstants.getVersion());
           ((CollectionBasedStorageConfiguration) configuration)
@@ -1559,6 +1584,37 @@ public abstract class AbstractStorage
           clearStorageDirty();
           postCreateSteps();
         });
+
+    activateStorageBirth();
+  }
+
+  /** Reads durable identity before write-ahead log processing starts. */
+  protected void readStorageIdentity() {
+  }
+
+  /** Publishes durable birth before write-ahead log initialization starts. */
+  protected void prepareStorageBirth() {
+  }
+
+  /** Activates durable birth after shared storage creation finishes. */
+  protected void activateStorageBirth() {
+  }
+
+  protected final void updateStorageIdentity(
+      StorageIdentity storageIdentity, StorageLineageIdentity lineageIdentity) {
+    storageIdentityHolder.update(storageIdentity, lineageIdentity);
+  }
+
+  public final StorageIdentity getStorageIdentity() {
+    return storageIdentityHolder.storageIdentity();
+  }
+
+  public final StorageLineageIdentity getStorageLineageIdentity() {
+    return storageIdentityHolder.lineageIdentity();
+  }
+
+  protected final void dropStaleIndexLifecycles() {
+    indexLifecycleRegistry.dropStale();
   }
 
   protected void generateDatabaseInstanceId(AtomicOperation atomicOperation) {
@@ -4516,7 +4572,9 @@ public abstract class AbstractStorage
 
   /** Returns the stable lifecycle carrier for a durable index descriptor. */
   public IndexLifecycleCell getOrCreateIndexLifecycle(RID descriptorIdentity) {
-    return indexLifecycleRegistry.getOrCreate(descriptorIdentity);
+    var initial = IndexBuildState.initial(descriptorIdentity);
+    return indexLifecycleRegistry.getOrCreate(
+        descriptorIdentity, new IndexLifecycleSnapshot(initial, 0));
   }
 
   public IndexLifecycleCell getIndexLifecycle(RID descriptorIdentity) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -851,6 +851,9 @@ public abstract class AbstractStorage
                 "Cannot open the storage '" + name + "' because it does not exist in path: " + url);
           }
 
+          // This call is the single admission decision of storage open. Admission runs before
+          // write-ahead log initialization and before recovery, so a rejected image never reaches
+          // recovery. A write-ahead log records a change before that change reaches its final file.
           readStorageIdentity();
           readIv();
 
@@ -1500,7 +1503,7 @@ public abstract class AbstractStorage
           "Cannot create new storage '" + getURL() + "' because it is not closed");
     }
 
-    if (exists()) {
+    if (existsBeforeCreation()) {
       throw new StorageExistsException(name,
           "Cannot create new storage '" + getURL() + "' because it already exists");
     }
@@ -1593,7 +1596,156 @@ public abstract class AbstractStorage
           postCreateSteps();
         });
 
+    // Track 24 delays the publication of the active lifecycle state. Storage creation builds the
+    // storage files only. Genesis creates the initial schema, the index manager, the index
+    // statistics, and the default users after this method returns. The creation path calls
+    // completeStorageBirth after genesis, so a crash inside genesis leaves an inadmissible image.
+  }
+
+  /**
+   * Completes storage birth after genesis finished.
+   *
+   * <p>Genesis is the creation of the initial database metadata. Genesis creates the schema, the
+   * index manager, the index statistics, and the default users. Genesis completes inside the
+   * database session creation path of the embedded factory.
+   *
+   * <p>This method runs the durability barrier over every genesis artifact first. This method
+   * publishes the active lifecycle state afterwards. A crash before this method therefore leaves
+   * an image that storage admission rejects with the interrupted-birth reason.
+   */
+  public final void completeStorageBirth() {
+    final var observer = SCOPED_BIRTH_COMPLETION_OBSERVER.get();
+    if (observer != null) {
+      observer.afterGenesisBeforeBarrier(this);
+    }
+    barrierOverGenesisArtifacts();
+    if (observer != null) {
+      observer.afterBarrierBeforeActivation(this);
+    }
     activateStorageBirth();
+  }
+
+  /**
+   * Observes the two boundaries inside {@link #completeStorageBirth()}.
+   *
+   * <p>This interface is a test seam. A test uses this seam to build the durable image of a crash
+   * after genesis and before the durability barrier. A test also uses this seam to build the
+   * durable image of a crash after the durability barrier and before the activation. Production
+   * code installs no observer, so production code runs two null checks per creation.
+   */
+  interface BirthCompletionObserver {
+
+    /** Runs after genesis finished and before the durability barrier starts. */
+    void afterGenesisBeforeBarrier(AbstractStorage storage);
+
+    /** Runs after the durability barrier finished and before the activation starts. */
+    void afterBarrierBeforeActivation(AbstractStorage storage);
+  }
+
+  private static final ThreadLocal<BirthCompletionObserver> SCOPED_BIRTH_COMPLETION_OBSERVER =
+      new ThreadLocal<>();
+
+  /** Installs one birth completion observer on the current thread until the scope closes. */
+  static AutoCloseable useBirthCompletionObserverForCurrentThread(
+      final BirthCompletionObserver observer) {
+    final var previous = SCOPED_BIRTH_COMPLETION_OBSERVER.get();
+    SCOPED_BIRTH_COMPLETION_OBSERVER.set(Objects.requireNonNull(observer, "observer"));
+    return () -> {
+      if (previous == null) {
+        SCOPED_BIRTH_COMPLETION_OBSERVER.remove();
+      } else {
+        SCOPED_BIRTH_COMPLETION_OBSERVER.set(previous);
+      }
+    };
+  }
+
+  /**
+   * Forces every genesis artifact to durable media.
+   *
+   * <p>The default implementation performs no work. Memory storage keeps that default, because
+   * Track 24 changes disk storage admission only. Memory storage therefore pays no extra flush
+   * during creation.
+   */
+  protected void barrierOverGenesisArtifacts() {
+  }
+
+  /**
+   * Publishes the restore-in-progress lifecycle state of a fresh restore target.
+   *
+   * <p>Restore creates the restore target without genesis and without activation. Genesis is the
+   * creation of the initial database metadata. The restore path calls this method directly after
+   * the creation of the storage files, so a restore target never appears as an empty active
+   * database.
+   *
+   * <p>The default implementation performs no work, because Track 24 changes disk storage
+   * admission only. Memory storage supports no restore at all.
+   */
+  public void beginRestoreLifecycle() {
+  }
+
+  /**
+   * Forces every durable artifact of this storage to durable media.
+   *
+   * <p>This method runs the same two steps as the public synchronization entry point. The first
+   * step flushes dirty index histogram data. An index histogram is index statistics data that the
+   * index engine keeps in a separate file. The second step flushes every index engine, the
+   * write-ahead log, and the write cache.
+   *
+   * <p>This method takes no state lock, so the caller must already own the storage state lock. The
+   * state lock of this storage is not reentrant, so the public entry point would deadlock a caller
+   * that already owns the write lock.
+   *
+   * <p>This method fails closed. The public synchronization entry point skips every flush while
+   * the storage sits in the internal error state. That entry point also swallows a failure of one
+   * index histogram flush and a failure of one index engine flush. This method reports every such
+   * case to the caller instead. The caller therefore never publishes the active lifecycle state
+   * over content that never reached durable media.
+   */
+  protected final void barrierWhileCallerOwnsStateLock() {
+    requireNoErrorStateForBarrier();
+    flushDirtyHistograms(true);
+    doSynch(true);
+    // A flush can move this storage into the error state without throwing. One example is a page
+    // checksum failure under the read-only error mode. The second check therefore repeats.
+    requireNoErrorStateForBarrier();
+  }
+
+  /**
+   * Runs the durability barrier of this storage under the state read lock of this storage.
+   *
+   * <p>The creation path owns no state lock when the path completes storage birth, so the barrier
+   * of the creation path takes the read lock itself. The barrier fails closed, so a failed flush
+   * reaches the creation path and the creation path publishes no active lifecycle state.
+   */
+  protected final void barrierWithOwnStateLock() {
+    stateLock.readLock().lock();
+    try {
+      barrierWhileCallerOwnsStateLock();
+    } finally {
+      stateLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Fails the durability barrier when this storage sits in the internal error state.
+   *
+   * <p>A storage in the internal error state flushes nothing. A barrier over such a storage would
+   * therefore report success without any durable write. The barrier reports the error state to the
+   * caller instead, and the caller keeps the storage out of the active lifecycle state.
+   */
+  private void requireNoErrorStateForBarrier() {
+    final var storageError = error.get();
+    if (storageError == null) {
+      return;
+    }
+    throw BaseException.wrapException(
+        new StorageException(
+            name,
+            "The durability barrier of database '"
+                + name
+                + "' failed, because the storage reached an internal error state"),
+        storageError,
+        name);
   }
 
   /** Reads durable identity before write-ahead log processing starts. */
@@ -1604,7 +1756,11 @@ public abstract class AbstractStorage
   protected void prepareStorageBirth() {
   }
 
-  /** Activates durable birth after shared storage creation finishes. */
+  /**
+   * Activates durable birth after genesis finished and after the durability barrier completed.
+   *
+   * <p>Only {@link #completeStorageBirth()} calls this method on the creation path.
+   */
   protected void activateStorageBirth() {
   }
 
@@ -6645,10 +6801,10 @@ public abstract class AbstractStorage
         // Flush dirty histogram stats before freezing — see
         // flushDirtyHistograms() Javadoc for deadlock details.
         if (!isInError()) {
-          flushDirtyHistograms();
+          flushDirtyHistograms(false);
         }
 
-        doSynch();
+        doSynch(false);
       } finally {
         stateLock.readLock().unlock();
       }
@@ -6669,6 +6825,16 @@ public abstract class AbstractStorage
    * flush's {@code executeInsideAtomicOperation()} call.
    */
   private void doSynch() {
+    doSynch(false);
+  }
+
+  /**
+   * Runs the core synchronization logic, and optionally reports every flush failure.
+   *
+   * @param failOnFlushFailure true when a flush failure must reach the caller, which the
+   *                           durability barrier of storage birth requires
+   */
+  private void doSynch(final boolean failOnFlushFailure) {
     final var synchStartedAt = System.nanoTime();
     // A TRANSIENT self-quiesce: bounded by the flush body, so schema commits may park behind it
     // exactly like data commits. Note the legal nesting: freeze() (an OPERATOR freeze) calls this
@@ -6686,6 +6852,18 @@ public abstract class AbstractStorage
               indexEngine.flush();
             }
           } catch (final Throwable t) {
+            if (failOnFlushFailure) {
+              throw BaseException.wrapException(
+                  new StorageException(
+                      name,
+                      "The durability barrier of database '"
+                          + name
+                          + "' failed, because one index engine of class "
+                          + indexEngine.getClass().getSimpleName()
+                          + " could not flush its data"),
+                  t,
+                  name);
+            }
             LogManager.instance()
                 .error(
                     this,
@@ -6698,6 +6876,9 @@ public abstract class AbstractStorage
         flushAllData();
 
       } else {
+        if (failOnFlushFailure) {
+          requireNoErrorStateForBarrier();
+        }
         LogManager.instance()
             .error(
                 this,
@@ -7389,13 +7570,46 @@ public abstract class AbstractStorage
    * best-effort and must not block checkpoint or shutdown.
    */
   private void flushDirtyHistograms() {
+    flushDirtyHistograms(false);
+  }
+
+  /**
+   * Flushes dirty index histogram data, and optionally reports every flush failure.
+   *
+   * <p>An index histogram is index statistics data that the index engine keeps in a separate file.
+   * The write-ahead log never carries that data, so a swallowed failure loses that data forever.
+   * The durability barrier of storage birth therefore reports every such failure to the caller.
+   *
+   * <p>The strict path calls the strict flush variant of the index histogram manager. The
+   * best-effort variant logs an input and output failure and returns, so the strict path would
+   * otherwise never observe such a failure.
+   *
+   * @param failOnFlushFailure true when a flush failure must reach the caller
+   */
+  private void flushDirtyHistograms(final boolean failOnFlushFailure) {
     for (var engine : indexEngines) {
       if (engine instanceof BTreeIndexEngine btreeEngine) {
         var mgr = btreeEngine.getHistogramManager();
         if (mgr != null) {
           try {
-            mgr.flushIfDirty();
+            if (failOnFlushFailure) {
+              mgr.flushIfDirtyOrFail();
+            } else {
+              mgr.flushIfDirty();
+            }
           } catch (Exception e) {
+            if (failOnFlushFailure) {
+              throw BaseException.wrapException(
+                  new StorageException(
+                      name,
+                      "The durability barrier of database '"
+                          + name
+                          + "' failed, because the index statistics of index "
+                          + mgr.getName()
+                          + " could not reach durable media"),
+                  e,
+                  name);
+            }
             LogManager.instance().error(this,
                 "Failed to flush histogram stats for engine %d (%s)"
                     + " — histogram data may be stale after restart",
@@ -7517,6 +7731,16 @@ public abstract class AbstractStorage
   }
 
   protected void preCreateSteps() throws IOException {
+  }
+
+  /**
+   * Reports whether this image already holds content that a creation must not overwrite.
+   *
+   * <p>The default answer is the plain existence of this storage. A storage type that can hold
+   * one residue file without any content overrides this method.
+   */
+  protected boolean existsBeforeCreation() {
+    return exists();
   }
 
   protected abstract void initWalAndDiskCache(ContextConfiguration contextConfiguration)

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -2451,6 +2451,15 @@ public abstract class AbstractStorage
 
   @Override
   public final int getCollectionIdByName(final String collectionName) {
+    return getCollectionIdByName(collectionName, isCommitWindowActive());
+  }
+
+  /** Resolves a collection without reacquiring state protection already held by this thread. */
+  final int getCollectionIdByNameWithStateLock(final String collectionName) {
+    return getCollectionIdByName(collectionName, callerOwnsStateProtection());
+  }
+
+  private int getCollectionIdByName(final String collectionName, final boolean lockFree) {
     try {
       if (collectionName == null) {
         throw new IllegalArgumentException("Collection name is null");
@@ -2460,20 +2469,13 @@ public abstract class AbstractStorage
         throw new IllegalArgumentException("Collection name is empty");
       }
 
-      // The schema-carry commit reaches this through session.newInternalInstance() while
-      // serializing the tx-local schema (toStream allocates a fresh per-class record), still
-      // holding stateLock.writeLock(). Re-acquiring the read lock there busy-spins forever on the
-      // non-reentrant ScalableRWLock, so the commit window self-routes to the lock-free read. The
-      // held write lock supplies the exclusion and the visibility edge for collectionMap.
-      final boolean lockFree = isCommitWindowActive();
+      // Protected callers already have the exclusion and visibility edge for collectionMap.
+      // Other callers acquire read mode around the lookup.
       if (!lockFree) {
         stateLock.readLock().lock();
       }
       try {
-
         checkOpennessAndMigration();
-
-        // SEARCH IT BETWEEN PHYSICAL COLLECTIONS
 
         final var segment = collectionMap.get(collectionName.toLowerCase(Locale.ROOT));
         if (segment != null) {
@@ -4711,6 +4713,10 @@ public abstract class AbstractStorage
       RID descriptorIdentity,
       @Nullable RID existingLifecycleIdentity,
       AtomicOperation atomicOperation) {
+    if (!callerOwnsStateProtection()) {
+      throw new StorageStateContextException(
+          "Initial lifecycle creation requires the storage state lock or an active commit window");
+    }
     return indexBuildStateStore.createInitial(
         descriptorIdentity,
         existingLifecycleIdentity,
@@ -5829,6 +5835,13 @@ public abstract class AbstractStorage
     return commitWindowDepth.get()[0] > 0;
   }
 
+  /** Returns whether this thread owns any supported storage state protection. */
+  final boolean callerOwnsStateProtection() {
+    return stateLock.isReadLockedByCurrentThread()
+        || stateLock.isWriteLockedByCurrentThread()
+        || isCommitWindowActive();
+  }
+
   public <T> void callIndexEngine(
       final boolean readOperation, int indexId,
       @Nullable IndexEngineReference expectedReference, final IndexEngineCallback<T> callback)
@@ -6618,7 +6631,8 @@ public abstract class AbstractStorage
     if (error != null
         && !((error instanceof HighLevelException)
             || (error instanceof NeedRetryException)
-            || (error instanceof InternalErrorException))) {
+            || (error instanceof InternalErrorException)
+            || (error instanceof StorageStateContextException))) {
       setInError(error);
     }
   }
@@ -7822,6 +7836,7 @@ public abstract class AbstractStorage
       final RecordIdInternal rid,
       @Nonnull final byte[] content,
       final byte recordType) throws IOException {
+    checkCallerOwnsStateLock();
     checkOpennessAndMigration();
     if (!rid.isNew() || !(rid instanceof ChangeableRecordId)) {
       throw new IllegalArgumentException(
@@ -7889,8 +7904,8 @@ public abstract class AbstractStorage
   }
 
   private void checkCallerOwnsStateLock() {
-    if (!stateLock.isReadLockedByCurrentThread() && !isCommitWindowActive()) {
-      throw new IllegalStateException(
+    if (!callerOwnsStateProtection()) {
+      throw new StorageStateContextException(
           "Caller-owned record writes require the storage state lock or an active commit window");
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -95,6 +95,7 @@ import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeMultiValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildState;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildStateStore;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleRegistry;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleSnapshot;
@@ -336,6 +337,11 @@ public abstract class AbstractStorage
   private final List<BaseIndexEngine> indexEngines = new ArrayList<>();
   private final StorageIdentityHolder storageIdentityHolder;
   private final IndexLifecycleRegistry indexLifecycleRegistry;
+  private static final String TOP_LEVEL_INDEX_LIFECYCLES =
+      AbstractStorage.class.getName() + ".topLevelIndexLifecycles";
+
+  private final IndexBuildStateStorageBackend indexBuildStateStorageBackend;
+  private final IndexBuildStateStore indexBuildStateStore;
   private long indexEngineGeneration;
   private final AtomicOperationIdGen idGen = new AtomicOperationIdGen();
 
@@ -541,6 +547,8 @@ public abstract class AbstractStorage
         ? new StorageIdentityHolder(StorageIdentity.random(), StorageLineageIdentity.random())
         : new StorageIdentityHolder();
     indexLifecycleRegistry = new IndexLifecycleRegistry(storageIdentityHolder::lineageIdentity);
+    indexBuildStateStorageBackend = new IndexBuildStateStorageBackend(this);
+    indexBuildStateStore = new IndexBuildStateStore(indexBuildStateStorageBackend);
 
     int permits = GlobalConfiguration.QUERY_STATS_MAX_CONCURRENT_REBALANCES
         .getValueAsInteger();
@@ -2682,14 +2690,27 @@ public abstract class AbstractStorage
         }
 
         if (logger.isDebugEnabled()) {
+          // Whole entities can resolve links after the atomic operation has ended. Log only values
+          // that are already available on each committed record operation.
+          final var committedRecords =
+              result.stream()
+                  .map(
+                      operation -> "%s %s %s"
+                          .formatted(
+                              operation.getRecordId(),
+                              RecordOperation.getName(operation.type),
+                              operation.record == null
+                                  ? "<null>"
+                                  : "v.%d".formatted(operation.record.getVersion())))
+                  .toList();
           LogManager.instance()
               .debug(
                   this,
-                  "%d Committed transaction %d on database '%s' (result=%s)",
+                  "%d Committed transaction %d on database '%s' (records=%s)",
                   logger, Thread.currentThread().threadId(),
                   frontendTransaction.getId(),
                   session.getDatabaseName(),
-                  result);
+                  committedRecords);
         }
         return result;
       } finally {
@@ -2906,6 +2927,7 @@ public abstract class AbstractStorage
       // populate the engines after the record apply, publish into the shared index maps after
       // commitChanges. Null on a pure-data commit and on a schema-carry commit with no index delta.
       IndexManagerEmbedded.ReconciledIndexPlan indexPlan = null;
+      var topLevelIndexLifecycles = pendingTopLevelIndexLifecycles(frontendTransaction);
       startTxCommit(atomicOperation, schemaContext != null);
       try {
         if (schemaContext != null) {
@@ -3137,6 +3159,16 @@ public abstract class AbstractStorage
           }
         }
 
+        if (indexPlan != null) {
+          // Descriptor identities are persistent now. Create the lifecycle record and set the
+          // descriptor link before record serialization. Every write remains in this atomic unit.
+          schemaContext.indexManager()
+              .createReconciledIndexLifecycles(
+                  frontendTransaction, atomicOperation, indexPlan);
+        }
+        createTopLevelIndexLifecycles(
+            frontendTransaction, atomicOperation, topLevelIndexLifecycles);
+
         for (final var recordOperation : workingSet.recordOperations()) {
           commitEntry(
               frontendTransaction,
@@ -3272,6 +3304,7 @@ public abstract class AbstractStorage
             }
             throw e;
           }
+          publishTopLevelIndexLifecycles(topLevelIndexLifecycles);
           try {
             cleanupSnapshotIndex();
           } catch (final RuntimeException | AssertionError e) {
@@ -4570,11 +4603,133 @@ public abstract class AbstractStorage
     return new IndexEngineReference(slot, apiVersion, ++indexEngineGeneration);
   }
 
+  private static final class TopLevelIndexLifecycle {
+
+    private final RID descriptorIdentity;
+    private IndexBuildStateStore.CreatedLifecycleRecord created;
+
+    private TopLevelIndexLifecycle(RID descriptorIdentity) {
+      this.descriptorIdentity = descriptorIdentity;
+    }
+  }
+
+  /** Registers lifecycle creation for a top-level index descriptor in the current commit. */
+  public void registerTopLevelIndexLifecycle(
+      FrontendTransaction transaction, RID descriptorIdentity) {
+    var descriptor = transaction.loadEntity(descriptorIdentity);
+    if (descriptor.getLink(Index.LIFECYCLE_RECORD) != null) {
+      throw new IllegalStateException("Index descriptor already has a lifecycle record link");
+    }
+
+    var pending = pendingTopLevelIndexLifecycles(transaction);
+    if (pending.isEmpty()) {
+      pending = new ArrayList<>();
+      transaction.setCustomData(TOP_LEVEL_INDEX_LIFECYCLES, pending);
+    }
+    if (pending.stream()
+        .anyMatch(candidate -> candidate.descriptorIdentity.equals(descriptorIdentity))) {
+      throw new IllegalStateException("Index descriptor already awaits a lifecycle record");
+    }
+    pending.add(new TopLevelIndexLifecycle(descriptorIdentity));
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<TopLevelIndexLifecycle> pendingTopLevelIndexLifecycles(
+      FrontendTransaction transaction) {
+    var pending =
+        (List<TopLevelIndexLifecycle>) transaction.getCustomData(TOP_LEVEL_INDEX_LIFECYCLES);
+    return pending == null ? List.of() : pending;
+  }
+
+  private void createTopLevelIndexLifecycles(
+      FrontendTransaction transaction,
+      AtomicOperation atomicOperation,
+      List<TopLevelIndexLifecycle> pending) {
+    for (var lifecycle : pending) {
+      var descriptor = transaction.loadEntity(lifecycle.descriptorIdentity);
+      var existing = descriptor.getLink(Index.LIFECYCLE_RECORD);
+      lifecycle.created =
+          createInitialIndexLifecycle(
+              lifecycle.descriptorIdentity, existing, atomicOperation);
+      descriptor.setLink(Index.LIFECYCLE_RECORD, lifecycle.created.identity());
+    }
+  }
+
+  private void publishTopLevelIndexLifecycles(List<TopLevelIndexLifecycle> pending) {
+    for (var lifecycle : pending) {
+      publishInitialIndexLifecycle(
+          lifecycle.descriptorIdentity, lifecycle.created.snapshot());
+    }
+  }
+
+  /** Fails metadata loading when the lifecycle storage area is absent. */
+  public void validateIndexBuildStateCollection() {
+    indexBuildStateStorageBackend.validateBuildStateCollection();
+  }
+
+  /** Loads durable lifecycle state or publishes stable missing-state quarantine. */
+  public IndexLifecycleCell recoverIndexLifecycle(
+      RID descriptorIdentity, @Nullable RID lifecycleIdentity) {
+    final IndexLifecycleSnapshot recovered;
+    if (lifecycleIdentity == null) {
+      recovered = quarantineMissingLifecycle(
+          descriptorIdentity, "Index descriptor has no lifecycle record link");
+    } else {
+      IndexLifecycleSnapshot durable;
+      try {
+        durable = indexBuildStateStore.read(descriptorIdentity, lifecycleIdentity);
+      } catch (IndexBuildStateStore.MissingLinkedRecordException exception) {
+        durable = null;
+      }
+      if (durable == null) {
+        recovered = quarantineMissingLifecycle(
+            descriptorIdentity, "Linked index build state record is missing");
+      } else if (durable.buildState().ownerEpoch() != null) {
+        recovered =
+            new IndexLifecycleSnapshot(
+                durable.buildState().withoutProcessOwnership(), durable.recordVersion());
+      } else {
+        recovered = durable;
+      }
+    }
+    return indexLifecycleRegistry.recover(descriptorIdentity, recovered);
+  }
+
+  private static IndexLifecycleSnapshot quarantineMissingLifecycle(
+      RID descriptorIdentity, String diagnosticReason) {
+    return new IndexLifecycleSnapshot(
+        IndexBuildState.quarantineMissing(descriptorIdentity, diagnosticReason), 0);
+  }
+
+  /** Returns the durable lifecycle read and write path for local schema indexes. */
+  public IndexBuildStateStore getIndexBuildStateStore() {
+    return indexBuildStateStore;
+  }
+
+  /** Creates initial lifecycle state inside an enclosing index creation atomic unit. */
+  public IndexBuildStateStore.CreatedLifecycleRecord createInitialIndexLifecycle(
+      RID descriptorIdentity,
+      @Nullable RID existingLifecycleIdentity,
+      AtomicOperation atomicOperation) {
+    return indexBuildStateStore.createInitial(
+        descriptorIdentity,
+        existingLifecycleIdentity,
+        value -> indexBuildStateStorageBackend.createInsideAtomicOperation(atomicOperation, value));
+  }
+
+  /** Publishes a committed lifecycle snapshot into the storage-scoped registry. */
+  public IndexLifecycleCell publishInitialIndexLifecycle(
+      RID descriptorIdentity, IndexLifecycleSnapshot snapshot) {
+    return indexLifecycleRegistry.getOrCreate(descriptorIdentity, snapshot);
+  }
+
   /** Returns the stable lifecycle carrier for a durable index descriptor. */
   public IndexLifecycleCell getOrCreateIndexLifecycle(RID descriptorIdentity) {
-    var initial = IndexBuildState.initial(descriptorIdentity);
-    return indexLifecycleRegistry.getOrCreate(
-        descriptorIdentity, new IndexLifecycleSnapshot(initial, 0));
+    var cell = indexLifecycleRegistry.get(descriptorIdentity);
+    if (cell == null) {
+      throw new IllegalStateException("The index lifecycle snapshot is not loaded");
+    }
+    return cell;
   }
 
   public IndexLifecycleCell getIndexLifecycle(RID descriptorIdentity) {
@@ -7658,6 +7813,15 @@ public abstract class AbstractStorage
       @Nonnull final byte[] content,
       final byte recordType) throws IOException {
     checkCallerOwnsStateLock();
+    return createRecordInsideCommitAtomicOperation(atomicOperation, rid, content, recordType);
+  }
+
+  /** Creates a record while the commit caller holds the storage state lock. */
+  long createRecordInsideCommitAtomicOperation(
+      final AtomicOperation atomicOperation,
+      final RecordIdInternal rid,
+      @Nonnull final byte[] content,
+      final byte recordType) throws IOException {
     checkOpennessAndMigration();
     if (!rid.isNew() || !(rid instanceof ChangeableRecordId)) {
       throw new IllegalArgumentException(
@@ -7680,10 +7844,27 @@ public abstract class AbstractStorage
     return position.recordVersion;
   }
 
+  /** Deletes a record inside a caller-owned atomic operation. */
+  public void deleteRecordInsideAtomicOperation(
+      final AtomicOperation atomicOperation,
+      final RecordIdInternal rid,
+      final long expectedVersion) throws IOException {
+    checkCallerOwnsStateLock();
+    checkOpennessAndMigration();
+    if (!rid.isPersistent()) {
+      throw new IllegalArgumentException(
+          "Record deletion requires a persistent identifier: " + rid);
+    }
+
+    atomicOperation.validateRecordCollectionLockOrder(rid.getCollectionId());
+    makeStorageDirty();
+    final var collection = doGetAndCheckCollection(rid.getCollectionId());
+    collection.acquireAtomicExclusiveLock(atomicOperation);
+    doDeleteRecord(atomicOperation, rid, expectedVersion, collection);
+  }
+
   /**
-   * Updates a record inside a caller-owned atomic operation and checks its durable version. One
-   * operation may use these record primitives for one collection only. Future multi-collection
-   * support must lock collections in ascending identifier order before mutation.
+   * Updates a record inside a caller-owned atomic operation and checks its durable version.
    *
    * @return the new durable record version
    */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AtomicOperationIdGen.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AtomicOperationIdGen.java
@@ -2,16 +2,43 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+/** Generates logical operation identifiers without permitting rewind or numeric wraparound. */
 public final class AtomicOperationIdGen {
 
   private final AtomicLong idGen = new AtomicLong();
 
   public long nextId() {
-    return idGen.incrementAndGet();
+    while (true) {
+      final var current = idGen.get();
+      if (current == Long.MAX_VALUE) {
+        throw new IllegalStateException("Logical operation identifier space is exhausted");
+      }
+      if (idGen.compareAndSet(current, current + 1)) {
+        return current + 1;
+      }
+    }
   }
 
+  /** Advances the highest-issued identifier while rejecting a stale or negative floor. */
+  public void advanceToAtLeast(final long highestIssued) {
+    if (highestIssued < 0) {
+      throw new IllegalArgumentException("Logical operation identifier must not be negative");
+    }
+
+    while (true) {
+      final var current = idGen.get();
+      if (highestIssued < current) {
+        throw new IllegalStateException("Logical operation identifier cannot rewind");
+      }
+      if (highestIssued == current || idGen.compareAndSet(current, highestIssued)) {
+        return;
+      }
+    }
+  }
+
+  /** Retained for source compatibility and applies the same monotonic floor semantics. */
   public void setStartId(final long id) {
-    idGen.set(id);
+    advanceToAtLeast(id);
   }
 
   public long getLastId() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexBuildStateStorageBackend.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexBuildStateStorageBackend.java
@@ -1,0 +1,225 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
+import com.jetbrains.youtrackdb.internal.common.function.TxFunction;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
+import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildStateStore;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
+import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Stores index lifecycle values in the storage-owned build state collection. */
+final class IndexBuildStateStorageBackend implements IndexBuildStateStore.Backend {
+
+  private static final int MAX_FIELDS = 64;
+  private static final byte NULL_VALUE = 0;
+  private static final byte INTEGER_VALUE = 1;
+  private static final byte LONG_VALUE = 2;
+  private static final byte STRING_VALUE = 3;
+  private static final byte BOOLEAN_VALUE = 4;
+
+  private final AbstractStorage storage;
+
+  IndexBuildStateStorageBackend(AbstractStorage storage) {
+    this.storage = storage;
+  }
+
+  @Override
+  public synchronized Optional<IndexBuildStateStore.VersionedRecord> read(RID recordIdentity) {
+    verifyBuildStateIdentity(recordIdentity);
+    return runAtomic(
+        operation -> {
+          try {
+            var result = storage.readRecord(new RecordId(recordIdentity), operation).toRawBuffer();
+            return Optional.of(
+                new IndexBuildStateStore.VersionedRecord(
+                    decode(result.buffer()), result.recordVersion()));
+          } catch (RecordNotFoundException exception) {
+            return Optional.empty();
+          }
+        });
+  }
+
+  @Override
+  public synchronized IndexBuildStateStore.CreatedRecord create(Map<String, Object> value) {
+    return runAtomic(
+        operation -> {
+          var rid = new ChangeableRecordId(buildStateCollectionId(), RID.COLLECTION_POS_INVALID);
+          var content = encode(value);
+          storage.stateLock.readLock().lock();
+          try {
+            var version =
+                storage.createRecordInsideAtomicOperation(
+                    operation, rid, content, RecordBytes.RECORD_TYPE);
+            return new IndexBuildStateStore.CreatedRecord(
+                rid.copy(), new IndexBuildStateStore.VersionedRecord(value, version));
+          } finally {
+            storage.stateLock.readLock().unlock();
+          }
+        });
+  }
+
+  IndexBuildStateStore.CreatedRecord createInsideAtomicOperation(
+      com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation operation,
+      Map<String, Object> value) {
+    var rid = new ChangeableRecordId(buildStateCollectionId(), RID.COLLECTION_POS_INVALID);
+    try {
+      var version =
+          storage.createRecordInsideCommitAtomicOperation(
+              operation, rid, encode(value), RecordBytes.RECORD_TYPE);
+      return new IndexBuildStateStore.CreatedRecord(
+          rid.copy(), new IndexBuildStateStore.VersionedRecord(value, version));
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(storage.getName(), "Index build state creation failed"),
+          exception,
+          storage.getName());
+    }
+  }
+
+  @Override
+  public synchronized IndexBuildStateStore.VersionedRecord update(
+      RID recordIdentity, long expectedVersion, Map<String, Object> value) {
+    verifyBuildStateIdentity(recordIdentity);
+    return runAtomic(
+        operation -> {
+          storage.stateLock.readLock().lock();
+          try {
+            var version =
+                storage.updateRecordInsideAtomicOperation(
+                    operation,
+                    new RecordId(recordIdentity),
+                    encode(value),
+                    expectedVersion,
+                    RecordBytes.RECORD_TYPE);
+            return new IndexBuildStateStore.VersionedRecord(value, version);
+          } finally {
+            storage.stateLock.readLock().unlock();
+          }
+        });
+  }
+
+  @Override
+  public synchronized void delete(RID recordIdentity, long expectedVersion) {
+    verifyBuildStateIdentity(recordIdentity);
+    runAtomic(
+        operation -> {
+          storage.stateLock.readLock().lock();
+          try {
+            storage.deleteRecordInsideAtomicOperation(
+                operation, new RecordId(recordIdentity), expectedVersion);
+            return null;
+          } finally {
+            storage.stateLock.readLock().unlock();
+          }
+        });
+  }
+
+  private void verifyBuildStateIdentity(RID recordIdentity) {
+    if (recordIdentity.getCollectionId() != buildStateCollectionId()) {
+      throw new IllegalArgumentException(
+          "Lifecycle link does not point into the index build state collection");
+    }
+  }
+
+  void validateBuildStateCollection() {
+    buildStateCollectionId();
+  }
+
+  private int buildStateCollectionId() {
+    var collectionId =
+        storage.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    if (collectionId < 0) {
+      throw new IllegalStateException("The index build state collection is missing");
+    }
+    return collectionId;
+  }
+
+  private <T> T runAtomic(TxFunction<T> action) {
+    try {
+      return storage.getAtomicOperationsManager().calculateInsideAtomicOperation(action);
+    } catch (IOException exception) {
+      throw BaseException.wrapException(
+          new StorageException(storage.getName(), "Index build state storage operation failed"),
+          exception,
+          storage.getName());
+    }
+  }
+
+  private static byte[] encode(Map<String, Object> value) throws IOException {
+    var bytes = new ByteArrayOutputStream();
+    try (var output = new DataOutputStream(bytes)) {
+      output.writeInt(value.size());
+      for (var entry : value.entrySet()) {
+        output.writeUTF(entry.getKey());
+        writeValue(output, entry.getValue());
+      }
+    }
+    return bytes.toByteArray();
+  }
+
+  private static void writeValue(DataOutputStream output, Object value) throws IOException {
+    switch (value) {
+      case null -> output.writeByte(NULL_VALUE);
+      case Integer integer -> {
+        output.writeByte(INTEGER_VALUE);
+        output.writeInt(integer);
+      }
+      case Long longValue -> {
+        output.writeByte(LONG_VALUE);
+        output.writeLong(longValue);
+      }
+      case String string -> {
+        output.writeByte(STRING_VALUE);
+        output.writeUTF(string);
+      }
+      case Boolean booleanValue -> {
+        output.writeByte(BOOLEAN_VALUE);
+        output.writeBoolean(booleanValue);
+      }
+      default -> throw new IllegalArgumentException(
+          "Unsupported index build state value type " + value.getClass().getName());
+    }
+  }
+
+  private static Map<String, Object> decode(byte[] bytes) {
+    try (var input = new DataInputStream(new ByteArrayInputStream(bytes))) {
+      var size = input.readInt();
+      if (size < 0 || size > MAX_FIELDS) {
+        throw new IllegalStateException("Invalid index build state field count " + size);
+      }
+      var value = new LinkedHashMap<String, Object>();
+      for (var index = 0; index < size; index++) {
+        value.put(input.readUTF(), readValue(input));
+      }
+      if (input.available() != 0) {
+        throw new IllegalStateException("Index build state contains trailing bytes");
+      }
+      return value;
+    } catch (IOException exception) {
+      throw new IllegalStateException("Cannot decode index build state", exception);
+    }
+  }
+
+  private static Object readValue(DataInputStream input) throws IOException {
+    return switch (input.readByte()) {
+      case NULL_VALUE -> null;
+      case INTEGER_VALUE -> input.readInt();
+      case LONG_VALUE -> input.readLong();
+      case STRING_VALUE -> input.readUTF();
+      case BOOLEAN_VALUE -> input.readBoolean();
+      default -> throw new IllegalStateException("Invalid index build state value type");
+    };
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexBuildStateStorageBackend.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexBuildStateStorageBackend.java
@@ -31,6 +31,9 @@ final class IndexBuildStateStorageBackend implements IndexBuildStateStore.Backen
 
   private final AbstractStorage storage;
 
+  /** Test signal fired before atomic admission. Caller state protection depends on the path. */
+  private volatile Runnable beforeAtomicOperationTestHook;
+
   IndexBuildStateStorageBackend(AbstractStorage storage) {
     this.storage = storage;
   }
@@ -52,22 +55,26 @@ final class IndexBuildStateStorageBackend implements IndexBuildStateStore.Backen
   }
 
   @Override
-  public synchronized IndexBuildStateStore.CreatedRecord create(Map<String, Object> value) {
-    return runAtomic(
-        operation -> {
-          var rid = new ChangeableRecordId(buildStateCollectionId(), RID.COLLECTION_POS_INVALID);
-          var content = encode(value);
-          storage.stateLock.readLock().lock();
-          try {
-            var version =
-                storage.createRecordInsideAtomicOperation(
-                    operation, rid, content, RecordBytes.RECORD_TYPE);
-            return new IndexBuildStateStore.CreatedRecord(
-                rid.copy(), new IndexBuildStateStore.VersionedRecord(value, version));
-          } finally {
-            storage.stateLock.readLock().unlock();
-          }
-        });
+  public IndexBuildStateStore.CreatedRecord create(Map<String, Object> value) {
+    rejectProtectedStandaloneCaller(
+        "Standalone lifecycle creation cannot run with storage state protection. Use "
+            + "createInsideAtomicOperation instead");
+    synchronized (this) {
+      storage.stateLock.readLock().lock();
+      try {
+        var rid = new ChangeableRecordId(buildStateCollectionId(), RID.COLLECTION_POS_INVALID);
+        return runAtomic(
+            operation -> {
+              var version =
+                  storage.createRecordInsideAtomicOperation(
+                      operation, rid, encode(value), RecordBytes.RECORD_TYPE);
+              return new IndexBuildStateStore.CreatedRecord(
+                  rid.copy(), new IndexBuildStateStore.VersionedRecord(value, version));
+            });
+      } finally {
+        storage.stateLock.readLock().unlock();
+      }
+    }
   }
 
   IndexBuildStateStore.CreatedRecord createInsideAtomicOperation(
@@ -89,41 +96,54 @@ final class IndexBuildStateStorageBackend implements IndexBuildStateStore.Backen
   }
 
   @Override
-  public synchronized IndexBuildStateStore.VersionedRecord update(
-      RID recordIdentity, long expectedVersion, Map<String, Object> value) {
-    verifyBuildStateIdentity(recordIdentity);
-    return runAtomic(
-        operation -> {
-          storage.stateLock.readLock().lock();
-          try {
-            var version =
-                storage.updateRecordInsideAtomicOperation(
-                    operation,
-                    new RecordId(recordIdentity),
-                    encode(value),
-                    expectedVersion,
-                    RecordBytes.RECORD_TYPE);
-            return new IndexBuildStateStore.VersionedRecord(value, version);
-          } finally {
-            storage.stateLock.readLock().unlock();
-          }
-        });
+  public void checkStandaloneUpdateAllowed() {
+    rejectProtectedStandaloneCaller(
+        "Standalone lifecycle update cannot run with storage state protection");
   }
 
   @Override
-  public synchronized void delete(RID recordIdentity, long expectedVersion) {
-    verifyBuildStateIdentity(recordIdentity);
-    runAtomic(
-        operation -> {
-          storage.stateLock.readLock().lock();
-          try {
-            storage.deleteRecordInsideAtomicOperation(
-                operation, new RecordId(recordIdentity), expectedVersion);
-            return null;
-          } finally {
-            storage.stateLock.readLock().unlock();
-          }
-        });
+  public IndexBuildStateStore.VersionedRecord update(
+      RID recordIdentity, long expectedVersion, Map<String, Object> value) {
+    checkStandaloneUpdateAllowed();
+    synchronized (this) {
+      storage.stateLock.readLock().lock();
+      try {
+        verifyBuildStateIdentity(recordIdentity);
+        return runAtomic(
+            operation -> {
+              var version =
+                  storage.updateRecordInsideAtomicOperation(
+                      operation,
+                      new RecordId(recordIdentity),
+                      encode(value),
+                      expectedVersion,
+                      RecordBytes.RECORD_TYPE);
+              return new IndexBuildStateStore.VersionedRecord(value, version);
+            });
+      } finally {
+        storage.stateLock.readLock().unlock();
+      }
+    }
+  }
+
+  @Override
+  public void delete(RID recordIdentity, long expectedVersion) {
+    rejectProtectedStandaloneCaller(
+        "Standalone lifecycle deletion cannot run with storage state protection");
+    synchronized (this) {
+      storage.stateLock.readLock().lock();
+      try {
+        verifyBuildStateIdentity(recordIdentity);
+        runAtomic(
+            operation -> {
+              storage.deleteRecordInsideAtomicOperation(
+                  operation, new RecordId(recordIdentity), expectedVersion);
+              return null;
+            });
+      } finally {
+        storage.stateLock.readLock().unlock();
+      }
+    }
   }
 
   private void verifyBuildStateIdentity(RID recordIdentity) {
@@ -139,15 +159,31 @@ final class IndexBuildStateStorageBackend implements IndexBuildStateStore.Backen
 
   private int buildStateCollectionId() {
     var collectionId =
-        storage.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+        storage.getCollectionIdByNameWithStateLock(
+            MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
     if (collectionId < 0) {
       throw new IllegalStateException("The index build state collection is missing");
     }
     return collectionId;
   }
 
+  private void rejectProtectedStandaloneCaller(String message) {
+    if (storage.callerOwnsStateProtection()) {
+      throw new StorageStateContextException(message);
+    }
+  }
+
+  /** Installs the lock-order test signal. Production leaves this value unset. */
+  void setBeforeAtomicOperationTestHook(Runnable hook) {
+    beforeAtomicOperationTestHook = hook;
+  }
+
   private <T> T runAtomic(TxFunction<T> action) {
     try {
+      var testHook = beforeAtomicOperationTestHook;
+      if (testHook != null) {
+        testHook.run();
+      }
       return storage.getAtomicOperationsManager().calculateInsideAtomicOperation(action);
     } catch (IOException exception) {
       throw BaseException.wrapException(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageIdentityHolder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageIdentityHolder.java
@@ -1,0 +1,50 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Holds the current storage identity pair for one storage instance. */
+public final class StorageIdentityHolder {
+
+  private final AtomicReference<IdentityPair> current;
+
+  public StorageIdentityHolder() {
+    current = new AtomicReference<>();
+  }
+
+  public StorageIdentityHolder(
+      StorageIdentity storageIdentity, StorageLineageIdentity lineageIdentity) {
+    current = new AtomicReference<>(new IdentityPair(storageIdentity, lineageIdentity));
+  }
+
+  public StorageIdentity storageIdentity() {
+    return currentIdentity().storageIdentity();
+  }
+
+  public StorageLineageIdentity lineageIdentity() {
+    return currentIdentity().lineageIdentity();
+  }
+
+  public void update(StorageIdentity storageIdentity, StorageLineageIdentity lineageIdentity) {
+    current.set(new IdentityPair(storageIdentity, lineageIdentity));
+  }
+
+  private IdentityPair currentIdentity() {
+    var identity = current.get();
+    if (identity == null) {
+      throw new IllegalStateException("Storage identity is not initialized");
+    }
+    return identity;
+  }
+
+  private record IdentityPair(
+      StorageIdentity storageIdentity, StorageLineageIdentity lineageIdentity) {
+
+    private IdentityPair {
+      Objects.requireNonNull(storageIdentity, "storageIdentity");
+      Objects.requireNonNull(lineageIdentity, "lineageIdentity");
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageStateContextException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageStateContextException.java
@@ -1,0 +1,9 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+/** Indicates that the calling thread lacks the storage state protection required by an operation. */
+public final class StorageStateContextException extends IllegalStateException {
+
+  public StorageStateContextException(String message) {
+    super(message);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/FeatureFormatIdentity.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/FeatureFormatIdentity.java
@@ -1,0 +1,11 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+/** Identifies one disk-storage feature format independently of its bootstrap encoding. */
+public record FeatureFormatIdentity(int version) {
+
+  public FeatureFormatIdentity {
+    if (version <= 0) {
+      throw new IllegalArgumentException("Feature format version must be positive");
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/LineageFloorAdoption.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/LineageFloorAdoption.java
@@ -1,0 +1,13 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.util.Objects;
+
+/** Supplies the format and source identity context required to adopt a cross-lineage floor. */
+public record LineageFloorAdoption(
+    FeatureFormatIdentity format, LogicalSequenceFloor sourceFloor) {
+
+  public LineageFloorAdoption {
+    Objects.requireNonNull(format, "format");
+    Objects.requireNonNull(sourceFloor, "sourceFloor");
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/LogicalSequenceFloor.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/LogicalSequenceFloor.java
@@ -1,0 +1,21 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.util.Objects;
+
+/**
+ * The highest issued logical operation identifier, qualified by its storage and lineage.
+ * Identity qualification prevents a raw number from authorizing work in another lineage.
+ */
+public record LogicalSequenceFloor(
+    StorageIdentity storageIdentity,
+    StorageLineageIdentity lineageIdentity,
+    long highestIssued) {
+
+  public LogicalSequenceFloor {
+    Objects.requireNonNull(storageIdentity, "storageIdentity");
+    Objects.requireNonNull(lineageIdentity, "lineageIdentity");
+    if (highestIssued < 0) {
+      throw new IllegalArgumentException("Logical sequence floor must not be negative");
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageAdmissionException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageAdmissionException.java
@@ -1,0 +1,198 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Names one cause that rejects a storage image during admission.
+ *
+ * <p>Admission is the decision that accepts an existing storage image for use. Admission runs
+ * before write-ahead log initialization and before recovery. A write-ahead log records a change
+ * before that change reaches its final file.
+ *
+ * <p>This exception extends {@link IOException} on purpose. Every present caller of the bootstrap
+ * authority already catches {@link IOException} and wraps that failure into a storage exception.
+ * The narrower type therefore adds a named cause without breaking one present catch site.
+ */
+public class StorageAdmissionException extends IOException {
+
+  private final Reason reason;
+
+  public StorageAdmissionException(
+      final Reason reason, final Path storageDirectory, final String message) {
+    this(reason, storageDirectory, message, null);
+  }
+
+  public StorageAdmissionException(
+      final Reason reason,
+      final Path storageDirectory,
+      final String message,
+      final Throwable cause) {
+    super(composeMessage(reason, storageDirectory, message), cause);
+    this.reason = reason;
+  }
+
+  /** Returns the single named cause of this rejection. */
+  public Reason reason() {
+    return reason;
+  }
+
+  /**
+   * Builds the diagnostic message of one rejection.
+   *
+   * <p>This message carries the reason identifier and the storage path, because a developer and a
+   * log reader need both values. The operator-facing message of the caller states the cause in
+   * plain words through {@link Reason#description()}, so no caller repeats the identifier.
+   */
+  private static String composeMessage(
+      final Reason reason, final Path storageDirectory, final String message) {
+    Objects.requireNonNull(reason, "reason");
+    Objects.requireNonNull(message, "message");
+    return message
+        + " (admission reason: "
+        + reason.name()
+        + ", storage path: "
+        + storageDirectory
+        + ")";
+  }
+
+  /** Enumerates every cause that the authority decoder or the authority selection can report. */
+  public enum Reason {
+
+    /** The directory holds no bootstrap authority artifact at all. */
+    AUTHORITY_MISSING,
+
+    /**
+     * One authority copy failed its integrity check.
+     *
+     * <p>An integrity check covers the record size, a truncated read, a grown read, and the
+     * checksum. Selection tolerates a single damaged copy. A directory whose every copy fails the
+     * integrity check reports {@link #INTERRUPTED_BIRTH} under the residue precedence rule, and
+     * that verdict carries each damaged-copy failure as a suppressed exception.
+     */
+    AUTHORITY_DAMAGED,
+
+    /**
+     * One checksum-valid authority copy holds an impossible value.
+     *
+     * <p>An impossible value is a wrong record magic value or a non-positive generation. A
+     * generation is a counter inside the record, where a higher value means a newer record.
+     */
+    AUTHORITY_INVALID_CONTENT,
+
+    /** One authority path or the authority lock path is not a regular file. */
+    NON_REGULAR_AUTHORITY_FILE,
+
+    /** Two readable authority copies name different storage identities. */
+    FOREIGN_AUTHORITY_COPY,
+
+    /** Two readable authority copies hold conflicting content at the same generation. */
+    AUTHORITY_AMBIGUOUS,
+
+    /** Two consecutive generations describe an illegal lifecycle transition. */
+    AUTHORITY_ILLEGAL_TRANSITION,
+
+    /** The authority encoding version of the record is not supported by this build. */
+    UNSUPPORTED_ENCODING_VERSION,
+
+    /** The authority feature format version of the record is not supported by this build. */
+    UNSUPPORTED_FEATURE_FORMAT_VERSION,
+
+    /** The lifecycle state code of the record is not supported by this build. */
+    UNSUPPORTED_LIFECYCLE_STATE,
+
+    /**
+     * The storage layout version of the record is not supported by this build.
+     *
+     * <p>The storage layout version is the version of the on-disk storage layout. An image that an
+     * earlier commit of this branch created holds the empty value zero in that field, so that image
+     * also reports this reason.
+     */
+    UNSUPPORTED_STORAGE_LAYOUT_VERSION,
+
+    /**
+     * The image carries an interrupted storage birth.
+     *
+     * <p>This reason covers a readable record in the birth-in-progress lifecycle state. This reason
+     * also covers a directory that holds a bootstrap authority artifact without any readable
+     * record.
+     */
+    INTERRUPTED_BIRTH,
+
+    /** The image carries a readable record in the restore-in-progress lifecycle state. */
+    INTERRUPTED_RESTORE,
+
+    /**
+     * The destructive restore restart refuses the target because of the lifecycle state.
+     *
+     * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+     * restore. The restart accepts a readable record in the restore-in-progress lifecycle state
+     * only. The restart reports this reason for a readable record in the active lifecycle state,
+     * and the restart then changes no file.
+     */
+    RESTART_TARGET_NOT_RESTORE_IN_PROGRESS,
+
+    /** The destructive restore restart found the normal database lock busy. */
+    RESTART_TARGET_BUSY,
+
+    /** The logical sequence floor of the record is negative. */
+    INVALID_SEQUENCE_FLOOR,
+
+    /** A low-level input or output failure prevented the admission decision. */
+    AUTHORITY_IO_FAILURE;
+
+    /**
+     * Returns one plain sentence that an operator can read.
+     *
+     * <p>A bootstrap authority record is the durable record that names one storage identity, one
+     * storage lineage, and one lifecycle state. Every operator-facing message of a rejected
+     * admission uses the sentence of this method instead of the reason identifier.
+     */
+    public String description() {
+      return switch (this) {
+        case AUTHORITY_MISSING ->
+            "The directory holds no bootstrap authority record of a database.";
+        case AUTHORITY_DAMAGED ->
+            "One bootstrap authority record failed its integrity check.";
+        case AUTHORITY_INVALID_CONTENT ->
+            "One bootstrap authority record holds an impossible value.";
+        case NON_REGULAR_AUTHORITY_FILE ->
+            "One bootstrap authority file is no regular file.";
+        case FOREIGN_AUTHORITY_COPY ->
+            "Two bootstrap authority records name two different databases.";
+        case AUTHORITY_AMBIGUOUS ->
+            "Two bootstrap authority records of the same age hold different content.";
+        case AUTHORITY_ILLEGAL_TRANSITION ->
+            "Two bootstrap authority records describe an impossible lifecycle change.";
+        case UNSUPPORTED_ENCODING_VERSION ->
+            "The bootstrap authority record uses a record layout that this build cannot read.";
+        case UNSUPPORTED_FEATURE_FORMAT_VERSION ->
+            "The bootstrap authority record names a feature set that this build cannot serve.";
+        case UNSUPPORTED_LIFECYCLE_STATE ->
+            "The bootstrap authority record names a lifecycle state that this build cannot use.";
+        case UNSUPPORTED_STORAGE_LAYOUT_VERSION ->
+            "The image uses an on-disk storage layout that this build cannot read.";
+        case INTERRUPTED_BIRTH ->
+            "The database carries no complete bootstrap authority record. An interrupted creation"
+                + " produces this state. Damaged bootstrap authority records of a complete database"
+                + " produce the same state. Inspect the database directory before any deletion. A"
+                + " backup restores a complete database. A drop removes a database whose creation"
+                + " never finished.";
+        case INTERRUPTED_RESTORE ->
+            "The restore of the database never finished. Restart the restore, or drop the"
+                + " database.";
+        case RESTART_TARGET_NOT_RESTORE_IN_PROGRESS ->
+            "The database carries no interrupted restore, so the destructive restart refuses the"
+                + " database.";
+        case RESTART_TARGET_BUSY ->
+            "The interrupted restore target is busy, so the destructive restart refuses the"
+                + " database.";
+        case INVALID_SEQUENCE_FLOOR ->
+            "The bootstrap authority record holds a negative operation counter.";
+        case AUTHORITY_IO_FAILURE ->
+            "A read failure of the bootstrap authority files stopped the admission decision.";
+      };
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
@@ -1,0 +1,743 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import net.jpountz.xxhash.XXHash64;
+import net.jpountz.xxhash.XXHashFactory;
+
+/** Persists the redundant, format-neutral authority for a disk storage. */
+public final class StorageBootstrapMetadata {
+
+  static final String LOCK_FILE_NAME = "storage-bootstrap.bsml";
+  static final List<String> AUTHORITY_FILE_NAMES =
+      List.of(
+          "storage-bootstrap-0.bsm", "storage-bootstrap-1.bsm", "storage-bootstrap-2.bsm");
+
+  private static final long MAGIC = 0x5954444242534D31L;
+  private static final int ENCODING_VERSION = 1;
+  private static final int RECORD_SIZE = 80;
+  private static final int CHECKSUM_OFFSET = RECORD_SIZE - Long.BYTES;
+  private static final long XX_HASH_SEED = 0x648B7A2195D3L;
+  private static final int LINEAGE_GENERATION_ATTEMPTS = 3;
+  private static final XXHash64 XX_HASH_64 = XXHashFactory.fastestInstance().hash64();
+  private static final Object PROCESS_LOCKS_MONITOR = new Object();
+  private static final Map<Path, ProcessLock> PROCESS_LOCKS = new HashMap<>();
+
+  private final Path directory;
+  private final List<Path> authorityPaths;
+  private final List<Path> temporaryPaths;
+  private final Path lockPath;
+  private final FeatureFormatIdentity expectedFormat;
+  private final MoveStrategy moveStrategy;
+  private final PublicationWarning publicationWarning;
+  private final CandidateCleanup candidateCleanup;
+
+  private Snapshot liveBirth;
+  private Snapshot locallyConfirmed;
+
+  public StorageBootstrapMetadata(
+      final Path storageDirectory, final FeatureFormatIdentity expectedFormat) throws IOException {
+    this(storageDirectory, expectedFormat, FileUtils::durableAtomicMove);
+  }
+
+  StorageBootstrapMetadata(
+      final Path storageDirectory,
+      final FeatureFormatIdentity expectedFormat,
+      final MoveStrategy moveStrategy)
+      throws IOException {
+    this(
+        storageDirectory,
+        expectedFormat,
+        moveStrategy,
+        StorageBootstrapMetadata::warnAboutFailedPublication,
+        Files::deleteIfExists);
+  }
+
+  StorageBootstrapMetadata(
+      final Path storageDirectory,
+      final FeatureFormatIdentity expectedFormat,
+      final MoveStrategy moveStrategy,
+      final PublicationWarning publicationWarning,
+      final CandidateCleanup candidateCleanup)
+      throws IOException {
+    this.directory = Objects.requireNonNull(storageDirectory, "storageDirectory").toRealPath();
+    this.expectedFormat = Objects.requireNonNull(expectedFormat, "expectedFormat");
+    this.moveStrategy = Objects.requireNonNull(moveStrategy, "moveStrategy");
+    this.publicationWarning = Objects.requireNonNull(publicationWarning, "publicationWarning");
+    this.candidateCleanup = Objects.requireNonNull(candidateCleanup, "candidateCleanup");
+    this.authorityPaths =
+        AUTHORITY_FILE_NAMES.stream().map(directory::resolve).toList();
+    this.temporaryPaths =
+        authorityPaths.stream().map(path -> path.resolveSibling(path.getFileName() + ".tmp"))
+            .toList();
+    this.lockPath = directory.resolve(LOCK_FILE_NAME);
+  }
+
+  /** Establishes the first durable birth authority and returns its live-creation token. */
+  public Snapshot createBirth(
+      final StorageIdentity storageIdentity, final StorageLineageIdentity lineageIdentity)
+      throws IOException {
+    Objects.requireNonNull(storageIdentity, "storageIdentity");
+    Objects.requireNonNull(lineageIdentity, "lineageIdentity");
+
+    return withAuthorityLock(
+        () -> {
+          if (anyPublicationResourceExists()) {
+            throw new IOException("Bootstrap authority or publication residue already exists");
+          }
+
+          final var floor = new LogicalSequenceFloor(storageIdentity, lineageIdentity, 0);
+          final var birth = new Snapshot(expectedFormat, 1, State.BIRTH_IN_PROGRESS, floor);
+          publishTo(birth, authorityPaths.get(0), temporaryPaths.get(0));
+          liveBirth = birth;
+          locallyConfirmed = birth;
+          return birth;
+        });
+  }
+
+  /** Reads and confirms the newest unambiguous legal authority. */
+  public Snapshot readRequired() throws IOException {
+    return withAuthorityLock(this::readAndConfirmLocked);
+  }
+
+  /** Reads authority for Open and rejects an interrupted birth before WAL processing can start. */
+  public Snapshot readActiveRequired() throws IOException {
+    return withAuthorityLock(
+        () -> {
+          final var selected = selectLocked();
+          if (selected.snapshot().state() == State.BIRTH_IN_PROGRESS) {
+            throw new IOException("Interrupted storage birth must be removed before Open");
+          }
+          return confirmSelectedLocked(selected).snapshot();
+        });
+  }
+
+  /** Advances the current lineage floor. A stale identity or lower floor is rejected. */
+  public Snapshot advanceFloor(final Snapshot expected, final LogicalSequenceFloor requested)
+      throws IOException {
+    Objects.requireNonNull(requested, "requested");
+
+    return withAuthorityLock(
+        () -> {
+          final var current = verifyExpected(expected);
+          requireLiveBirthWhenPending(expected);
+          verifyCurrentIdentity(current, requested);
+          if (requested.highestIssued() < current.sequenceFloor().highestIssued()) {
+            throw new IllegalStateException("Logical sequence floor cannot rewind");
+          }
+          if (requested.highestIssued() == current.sequenceFloor().highestIssued()) {
+            // Preserve the identity-bearing token after verifyExpected decoded its durable copy.
+            return current.state() == State.BIRTH_IN_PROGRESS ? liveBirth : current;
+          }
+
+          final var next = current.withFloor(requested, nextGeneration(current.generation()));
+          publish(next);
+          if (current.state() == State.BIRTH_IN_PROGRESS) {
+            liveBirth = next;
+          }
+          return next;
+        });
+  }
+
+  /** Activates a validated pending image without changing its identity or sequence floor. */
+  public Snapshot activate(final Snapshot expected) throws IOException {
+    return withAuthorityLock(
+        () -> {
+          final var current = verifyExpected(expected);
+          requireLiveBirthWhenPending(expected);
+          if (current.state() != State.BIRTH_IN_PROGRESS
+              && current.state() != State.RESTORE_IN_PROGRESS) {
+            throw new IllegalStateException("Only a pending image can become active");
+          }
+
+          final var next =
+              new Snapshot(
+                  current.format(),
+                  nextGeneration(current.generation()),
+                  State.ACTIVE,
+                  current.sequenceFloor());
+          publish(next);
+          if (current.state() == State.BIRTH_IN_PROGRESS) {
+            liveBirth = null;
+          }
+          return next;
+        });
+  }
+
+  /**
+   * Starts replacement under a fresh target lineage while retaining the target high-water.
+   *
+   * @param expected the previously observed authority snapshot
+   * @param adoption the source format and sequence floor to adopt
+   * @return the restore-in-progress authority snapshot carrying the generated target lineage
+   */
+  public Snapshot beginLineageReplacement(
+      final Snapshot expected, final LineageFloorAdoption adoption) throws IOException {
+    Objects.requireNonNull(adoption, "adoption");
+
+    return withAuthorityLock(
+        () -> {
+          final var current = verifyExpected(expected);
+          if (current.state() != State.ACTIVE) {
+            throw new IllegalStateException("Lineage replacement requires active storage");
+          }
+          if (!current.format().equals(adoption.format())) {
+            throw new IllegalStateException("Cannot adopt a floor from another feature format");
+          }
+          final var sourceFloor = adoption.sourceFloor();
+          final var newLineage =
+              generateFreshLineage(
+                  StorageLineageIdentity::random,
+                  current.lineageIdentity(),
+                  sourceFloor.lineageIdentity());
+
+          final var retainedFloor =
+              Math.max(current.sequenceFloor().highestIssued(), sourceFloor.highestIssued());
+          final var targetFloor =
+              new LogicalSequenceFloor(current.storageIdentity(), newLineage, retainedFloor);
+          final var next =
+              new Snapshot(
+                  current.format(),
+                  nextGeneration(current.generation()),
+                  State.RESTORE_IN_PROGRESS,
+                  targetFloor);
+          publish(next);
+          return next;
+        });
+  }
+
+  static StorageLineageIdentity generateFreshLineage(
+      final Supplier<StorageLineageIdentity> candidateSource,
+      final StorageLineageIdentity currentLineage,
+      final StorageLineageIdentity sourceLineage) {
+    Objects.requireNonNull(candidateSource, "candidateSource");
+    Objects.requireNonNull(currentLineage, "currentLineage");
+    Objects.requireNonNull(sourceLineage, "sourceLineage");
+
+    // A replacement must not retain either prior lineage. This check is defensive because the
+    // production candidates are random. Bounded retries preserve the rule if collisions occur.
+    for (var attempt = 0; attempt < LINEAGE_GENERATION_ATTEMPTS; attempt++) {
+      final var generated =
+          Objects.requireNonNull(candidateSource.get(), "candidateSource returned null");
+      if (!generated.equals(currentLineage) && !generated.equals(sourceLineage)) {
+        return generated;
+      }
+    }
+    throw new IllegalStateException(
+        "Unable to generate a fresh target lineage because all "
+            + LINEAGE_GENERATION_ATTEMPTS
+            + " candidates collided with the current or source lineage identity");
+  }
+
+  private <T> T withAuthorityLock(final IOOperation<T> operation) throws IOException {
+    final var processLock = acquireProcessLock();
+    processLock.lock.lock();
+    try {
+      prepareLockResource();
+      try (var lockChannel =
+          FileChannel.open(lockPath, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS);
+          FileLock ignored = lockChannel.lock()) {
+        return operation.execute();
+      }
+    } finally {
+      processLock.lock.unlock();
+      releaseProcessLock(processLock);
+    }
+  }
+
+  private ProcessLock acquireProcessLock() {
+    synchronized (PROCESS_LOCKS_MONITOR) {
+      final var lock = PROCESS_LOCKS.computeIfAbsent(directory, ignored -> new ProcessLock());
+      lock.users++;
+      return lock;
+    }
+  }
+
+  private void releaseProcessLock(final ProcessLock lock) {
+    synchronized (PROCESS_LOCKS_MONITOR) {
+      lock.users--;
+      if (lock.users == 0) {
+        PROCESS_LOCKS.remove(directory, lock);
+      }
+    }
+  }
+
+  private void prepareLockResource() throws IOException {
+    if (!Files.exists(lockPath, LinkOption.NOFOLLOW_LINKS)) {
+      try {
+        Files.createFile(lockPath);
+      } catch (java.nio.file.FileAlreadyExistsException ignored) {
+        // A cooperating process can establish the shared lock file first.
+      }
+    }
+    final var attributes =
+        Files.readAttributes(lockPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+    if (!attributes.isRegularFile()) {
+      throw new IOException("Bootstrap publication lock is not a regular file");
+    }
+  }
+
+  private Snapshot verifyExpected(final Snapshot expected) throws IOException {
+    Objects.requireNonNull(expected, "expected");
+    final var current = readAndConfirmLocked();
+    if (!current.equals(expected)) {
+      throw new IllegalStateException("Bootstrap authority changed since it was observed");
+    }
+    return current;
+  }
+
+  private void requireLiveBirthWhenPending(final Snapshot expected) {
+    // Use the caller's record for identity. A decoded record would reject every creator.
+    if (expected.state() == State.BIRTH_IN_PROGRESS && expected != liveBirth) {
+      throw new IllegalStateException("An interrupted storage birth cannot continue");
+    }
+  }
+
+  private Snapshot readAndConfirmLocked() throws IOException {
+    final var selected = selectLocked();
+    if (selected.snapshot().state() == State.BIRTH_IN_PROGRESS
+        || selected.snapshot().equals(locallyConfirmed)) {
+      return selected.snapshot();
+    }
+    return confirmSelectedLocked(selected).snapshot();
+  }
+
+  private RecordAt confirmSelectedLocked(final RecordAt selected) throws IOException {
+    final var records = readValidRecordsLocked();
+    final var target = chooseTarget(records, selected);
+    publishTo(selected.snapshot(), target, temporaryPath(target));
+    locallyConfirmed = selected.snapshot();
+    return new RecordAt(target, selected.snapshot());
+  }
+
+  private RecordAt selectLocked() throws IOException {
+    rejectTemporaryResidue();
+    final var records = readValidRecordsLocked();
+    if (records.isEmpty()) {
+      throw new IOException("Bootstrap authority does not exist or has no valid record");
+    }
+
+    final var first = records.get(0).snapshot();
+    for (var record : records) {
+      final var snapshot = record.snapshot();
+      // Unsupported formats fail during decoding. This branch rejects conflicting storage identity.
+      if (!snapshot.storageIdentity().equals(first.storageIdentity())) {
+        throw new IOException("Bootstrap authority records are ambiguous");
+      }
+    }
+
+    final Map<Long, Snapshot> generations = new HashMap<>();
+    for (var record : records) {
+      final var prior = generations.putIfAbsent(record.snapshot().generation(), record.snapshot());
+      if (prior != null && !prior.equals(record.snapshot())) {
+        throw new IOException("Bootstrap authority generation is ambiguous");
+      }
+    }
+    final var ordered = generations.values().stream()
+        .sorted(Comparator.comparingLong(Snapshot::generation))
+        .toList();
+    for (var i = 1; i < ordered.size(); i++) {
+      final var prior = ordered.get(i - 1);
+      final var next = ordered.get(i);
+      if (next.generation() == prior.generation() + 1 && !isLegalSuccessor(prior, next)) {
+        throw new IOException("Bootstrap authority contains an illegal state transition");
+      }
+    }
+
+    final var newest = ordered.get(ordered.size() - 1);
+    return records.stream()
+        .filter(record -> record.snapshot().equals(newest))
+        .min(Comparator.comparingInt(record -> authorityPaths.indexOf(record.path())))
+        .orElseThrow();
+  }
+
+  private List<RecordAt> readValidRecordsLocked() throws IOException {
+    final var records = new ArrayList<RecordAt>();
+    for (var path : authorityPaths) {
+      if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        continue;
+      }
+      final var attributes =
+          Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isRegularFile()) {
+        throw new IOException("Bootstrap authority is not a regular file: " + path);
+      }
+      try {
+        records.add(new RecordAt(path, readRecord(path, attributes)));
+      } catch (DamagedRecordException ignored) {
+        // A size or checksum failure proves damage. The slot is not authority and can be reused.
+      }
+    }
+    return records;
+  }
+
+  private Snapshot readRecord(final Path path, final BasicFileAttributes attributes)
+      throws IOException {
+    if (attributes.size() != RECORD_SIZE) {
+      throw new DamagedRecordException("Invalid bootstrap authority size: " + attributes.size());
+    }
+
+    final byte[] bytes = new byte[RECORD_SIZE];
+    try (var channel = FileChannel.open(path, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS)) {
+      final var record = ByteBuffer.wrap(bytes);
+      while (record.hasRemaining()) {
+        if (channel.read(record) < 0) {
+          throw new DamagedRecordException("Bootstrap authority was truncated while it was read");
+        }
+      }
+      if (channel.read(ByteBuffer.allocate(1)) >= 0) {
+        throw new DamagedRecordException("Bootstrap authority grew while it was read");
+      }
+    }
+
+    final var expectedChecksum =
+        ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getLong(CHECKSUM_OFFSET);
+    if (XX_HASH_64.hash(bytes, 0, CHECKSUM_OFFSET, XX_HASH_SEED) != expectedChecksum) {
+      throw new DamagedRecordException("Bootstrap authority checksum mismatch");
+    }
+
+    try {
+      return decode(bytes);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Bootstrap authority contains an invalid value", e);
+    }
+  }
+
+  private Snapshot decode(final byte[] bytes) throws IOException {
+    final var buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
+    final var magic = buffer.getLong();
+    if (magic != MAGIC) {
+      throw new IOException("Invalid bootstrap authority magic: " + magic);
+    }
+    final var encodingVersion = buffer.getInt();
+    if (encodingVersion != ENCODING_VERSION) {
+      throw new IOException("Unsupported bootstrap encoding version: " + encodingVersion);
+    }
+    final var formatVersion = buffer.getInt();
+    if (formatVersion != expectedFormat.version()) {
+      // A checksum-valid foreign format came from software this reader does not understand.
+      throw new UnsupportedRecordException(
+          "Unsupported feature format version: " + formatVersion);
+    }
+    final var format = new FeatureFormatIdentity(formatVersion);
+    final var generation = buffer.getLong();
+    final var state = State.fromCode(buffer.getInt());
+    final var reserved = buffer.getInt();
+    if (reserved != 0) {
+      throw new IOException("Invalid bootstrap authority reserved field: " + reserved);
+    }
+    final var storageIdentity = new StorageIdentity(readUuid(buffer));
+    final var lineageIdentity = new StorageLineageIdentity(readUuid(buffer));
+    final var highestIssued = buffer.getLong();
+    if (generation <= 0) {
+      throw new IOException("Invalid bootstrap authority generation: " + generation);
+    }
+    if (highestIssued < 0) {
+      throw new IOException("Invalid bootstrap authority highest issued value: " + highestIssued);
+    }
+    final var floor = new LogicalSequenceFloor(storageIdentity, lineageIdentity, highestIssued);
+    return new Snapshot(format, generation, state, floor);
+  }
+
+  private void publish(final Snapshot snapshot) throws IOException {
+    final var records = readValidRecordsLocked();
+    final var selected = selectFromKnownRecords(records);
+    final var target = chooseTarget(records, selected);
+    publishTo(snapshot, target, temporaryPath(target));
+    locallyConfirmed = snapshot;
+  }
+
+  private RecordAt selectFromKnownRecords(final List<RecordAt> records) throws IOException {
+    final var maxGeneration = records.stream()
+        .mapToLong(record -> record.snapshot().generation())
+        .max()
+        .orElseThrow(() -> new IOException("No authority remains for publication"));
+    return records.stream()
+        .filter(record -> record.snapshot().generation() == maxGeneration)
+        .min(Comparator.comparingInt(record -> authorityPaths.indexOf(record.path())))
+        .orElseThrow();
+  }
+
+  private Path chooseTarget(final List<RecordAt> records, final RecordAt selected)
+      throws IOException {
+    for (var path : authorityPaths) {
+      if (!path.equals(selected.path()) && !Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        return path;
+      }
+    }
+
+    final var verifiedPaths = records.stream().map(RecordAt::path).toList();
+    for (var path : authorityPaths) {
+      if (!path.equals(selected.path()) && !verifiedPaths.contains(path)) {
+        // Overwriting a damaged slot destroys no verified authority.
+        return path;
+      }
+    }
+
+    final var candidates = records.stream()
+        .filter(record -> !record.path().equals(selected.path()))
+        .sorted(Comparator.comparingLong(record -> record.snapshot().generation()))
+        .toList();
+    for (var candidate : candidates) {
+      final var survivors = records.stream()
+          .filter(record -> !record.path().equals(candidate.path()))
+          .count();
+      if (survivors >= 2) {
+        return candidate.path();
+      }
+    }
+    throw new IOException("Publication would overwrite the last verified authority records");
+  }
+
+  private void publishTo(final Snapshot snapshot, final Path target, final Path temporary)
+      throws IOException {
+    if (Files.exists(temporary, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IOException("Temporary bootstrap publication already exists: " + temporary);
+    }
+    final var buffer = encode(snapshot);
+    var candidateCreated = false;
+    try {
+      try (var channel =
+          FileChannel.open(temporary, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+        candidateCreated = true;
+        while (buffer.hasRemaining()) {
+          channel.write(buffer);
+        }
+      }
+      moveStrategy.move(temporary, target, this);
+    } catch (IOException | RuntimeException | Error publicationError) {
+      if (candidateCreated) {
+        // Unchecked publication failures also belong to this call and must not leave owned residue.
+        cleanupFailedPublication(temporary, publicationError);
+      }
+      throw publicationError;
+    }
+  }
+
+  private void cleanupFailedPublication(final Path temporary, final Throwable publicationError) {
+    // Cleanup is best-effort and can never become the primary publication failure.
+    try {
+      try {
+        publicationWarning.warn(this, directory, temporary, publicationError);
+      } catch (Throwable ignored) {
+        // A diagnostic failure must not prevent candidate removal.
+      }
+
+      try {
+        candidateCleanup.remove(temporary);
+      } catch (Throwable cleanupError) {
+        if (publicationError != cleanupError) {
+          publicationError.addSuppressed(cleanupError);
+        }
+      }
+    } catch (Throwable ignored) {
+      // Removal and suppression are diagnostic cleanup, so neither can replace the original error.
+    }
+  }
+
+  private static void warnAboutFailedPublication(
+      final Object requester,
+      final Path directory,
+      final Path temporary,
+      final Throwable publicationError) {
+    // This seam only enables failure testing. Production retains the existing logger and message.
+    LogManager.instance()
+        .warn(
+            requester,
+            "Bootstrap publication failed in directory %s using candidate %s: %s",
+            publicationError,
+            directory,
+            temporary,
+            publicationError);
+  }
+
+  private void rejectTemporaryResidue() throws IOException {
+    for (var path : temporaryPaths) {
+      if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        throw new IOException("Interrupted bootstrap publication left a temporary file");
+      }
+    }
+  }
+
+  private boolean anyPublicationResourceExists() {
+    return authorityPaths.stream().anyMatch(path -> Files.exists(path, LinkOption.NOFOLLOW_LINKS))
+        || temporaryPaths.stream().anyMatch(path -> Files.exists(path, LinkOption.NOFOLLOW_LINKS));
+  }
+
+  private Path temporaryPath(final Path authorityPath) {
+    return temporaryPaths.get(authorityPaths.indexOf(authorityPath));
+  }
+
+  private static boolean isLegalSuccessor(final Snapshot prior, final Snapshot next) {
+    if (!prior.storageIdentity().equals(next.storageIdentity())
+        || next.sequenceFloor().highestIssued() < prior.sequenceFloor().highestIssued()) {
+      return false;
+    }
+    if (prior.lineageIdentity().equals(next.lineageIdentity())) {
+      return prior.state() == next.state()
+          || (prior.state() != State.ACTIVE && next.state() == State.ACTIVE);
+    }
+    return prior.state() == State.ACTIVE && next.state() == State.RESTORE_IN_PROGRESS;
+  }
+
+  private static ByteBuffer encode(final Snapshot snapshot) {
+    final var buffer = ByteBuffer.allocate(RECORD_SIZE).order(ByteOrder.BIG_ENDIAN);
+    buffer.putLong(MAGIC);
+    buffer.putInt(ENCODING_VERSION);
+    buffer.putInt(snapshot.format().version());
+    buffer.putLong(snapshot.generation());
+    buffer.putInt(snapshot.state().code);
+    buffer.putInt(0);
+    writeUuid(buffer, snapshot.storageIdentity().value());
+    writeUuid(buffer, snapshot.lineageIdentity().value());
+    buffer.putLong(snapshot.sequenceFloor().highestIssued());
+    final var bytes = buffer.array();
+    buffer.putLong(XX_HASH_64.hash(bytes, 0, CHECKSUM_OFFSET, XX_HASH_SEED));
+    buffer.flip();
+    return buffer;
+  }
+
+  private static long nextGeneration(final long generation) {
+    if (generation == Long.MAX_VALUE) {
+      throw new IllegalStateException("Bootstrap authority generation is exhausted");
+    }
+    return generation + 1;
+  }
+
+  private static void verifyCurrentIdentity(
+      final Snapshot current, final LogicalSequenceFloor requested) {
+    if (!current.storageIdentity().equals(requested.storageIdentity())
+        || !current.lineageIdentity().equals(requested.lineageIdentity())) {
+      throw new IllegalStateException("Logical sequence floor belongs to another identity");
+    }
+  }
+
+  private static UUID readUuid(final ByteBuffer buffer) {
+    return new UUID(buffer.getLong(), buffer.getLong());
+  }
+
+  private static void writeUuid(final ByteBuffer buffer, final UUID value) {
+    buffer.putLong(value.getMostSignificantBits());
+    buffer.putLong(value.getLeastSignificantBits());
+  }
+
+  static int processLockCountForTests() {
+    synchronized (PROCESS_LOCKS_MONITOR) {
+      return PROCESS_LOCKS.size();
+    }
+  }
+
+  private static final class ProcessLock {
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private int users;
+  }
+
+  private record RecordAt(Path path, Snapshot snapshot) {
+  }
+
+  private static final class DamagedRecordException extends IOException {
+
+    private DamagedRecordException(final String message) {
+      super(message);
+    }
+  }
+
+  private static final class UnsupportedRecordException extends IOException {
+
+    private UnsupportedRecordException(final String message) {
+      super(message);
+    }
+  }
+
+  @FunctionalInterface
+  private interface IOOperation<T> {
+
+    T execute() throws IOException;
+  }
+
+  @FunctionalInterface
+  interface MoveStrategy {
+
+    void move(Path source, Path target, Object requester) throws IOException;
+  }
+
+  @FunctionalInterface
+  interface PublicationWarning {
+
+    void warn(Object requester, Path directory, Path candidate, Throwable publicationError);
+  }
+
+  @FunctionalInterface
+  interface CandidateCleanup {
+
+    void remove(Path candidate) throws IOException;
+  }
+
+  public enum State {
+    BIRTH_IN_PROGRESS(1), ACTIVE(2), RESTORE_IN_PROGRESS(3);
+
+    private final int code;
+
+    State(final int code) {
+      this.code = code;
+    }
+
+    private static State fromCode(final int code) throws IOException {
+      for (var state : values()) {
+        if (state.code == code) {
+          return state;
+        }
+      }
+      // A checksum-valid unknown state came from software this reader does not understand.
+      throw new UnsupportedRecordException("Unsupported bootstrap state: " + code);
+    }
+  }
+
+  public record Snapshot(
+      FeatureFormatIdentity format,
+      long generation,
+      State state,
+      LogicalSequenceFloor sequenceFloor) {
+
+    public Snapshot {
+      Objects.requireNonNull(format, "format");
+      Objects.requireNonNull(state, "state");
+      Objects.requireNonNull(sequenceFloor, "sequenceFloor");
+      if (generation <= 0) {
+        throw new IllegalArgumentException("Bootstrap generation must be positive");
+      }
+    }
+
+    public StorageIdentity storageIdentity() {
+      return sequenceFloor.storageIdentity();
+    }
+
+    public StorageLineageIdentity lineageIdentity() {
+      return sequenceFloor.lineageIdentity();
+    }
+
+    private Snapshot withFloor(final LogicalSequenceFloor floor, final long nextGeneration) {
+      return new Snapshot(format, nextGeneration, state, floor);
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
@@ -41,6 +41,7 @@ public final class StorageBootstrapMetadata {
   private static final XXHash64 XX_HASH_64 = XXHashFactory.fastestInstance().hash64();
   private static final Object PROCESS_LOCKS_MONITOR = new Object();
   private static final Map<Path, ProcessLock> PROCESS_LOCKS = new HashMap<>();
+  private static final ThreadLocal<MoveStrategy> SCOPED_MOVE_STRATEGY = new ThreadLocal<>();
 
   private final Path directory;
   private final List<Path> authorityPaths;
@@ -56,7 +57,25 @@ public final class StorageBootstrapMetadata {
 
   public StorageBootstrapMetadata(
       final Path storageDirectory, final FeatureFormatIdentity expectedFormat) throws IOException {
-    this(storageDirectory, expectedFormat, FileUtils::durableAtomicMove);
+    this(
+        storageDirectory,
+        expectedFormat,
+        SCOPED_MOVE_STRATEGY.get() == null
+            ? FileUtils::durableAtomicMove
+            : SCOPED_MOVE_STRATEGY.get());
+  }
+
+  /** Overrides new metadata moves on the current thread until the returned scope closes. */
+  static AutoCloseable useMoveStrategyForCurrentThread(final MoveStrategy moveStrategy) {
+    final var previous = SCOPED_MOVE_STRATEGY.get();
+    SCOPED_MOVE_STRATEGY.set(Objects.requireNonNull(moveStrategy, "moveStrategy"));
+    return () -> {
+      if (previous == null) {
+        SCOPED_MOVE_STRATEGY.remove();
+      } else {
+        SCOPED_MOVE_STRATEGY.set(previous);
+      }
+    };
   }
 
   StorageBootstrapMetadata(
@@ -119,13 +138,16 @@ public final class StorageBootstrapMetadata {
     return withAuthorityLock(this::readAndConfirmLocked);
   }
 
-  /** Reads authority for Open and rejects an interrupted birth before WAL processing can start. */
+  /** Reads authority for Open and rejects interrupted work before WAL processing can start. */
   public Snapshot readActiveRequired() throws IOException {
     return withAuthorityLock(
         () -> {
           final var selected = selectLocked();
           if (selected.snapshot().state() == State.BIRTH_IN_PROGRESS) {
             throw new IOException("Interrupted storage birth must be removed before Open");
+          }
+          if (selected.snapshot().state() == State.RESTORE_IN_PROGRESS) {
+            throw new IOException("Interrupted storage restore must be retried before Open");
           }
           return confirmSelectedLocked(selected).snapshot();
         });
@@ -197,11 +219,14 @@ public final class StorageBootstrapMetadata {
     return withAuthorityLock(
         () -> {
           final var current = verifyExpected(expected);
-          if (current.state() != State.ACTIVE) {
-            throw new IllegalStateException("Lineage replacement requires active storage");
-          }
           if (!current.format().equals(adoption.format())) {
             throw new IllegalStateException("Cannot adopt a floor from another feature format");
+          }
+          if (current.state() == State.RESTORE_IN_PROGRESS) {
+            return current;
+          }
+          if (current.state() != State.ACTIVE) {
+            throw new IllegalStateException("Lineage replacement requires active storage");
           }
           final var sourceFloor = adoption.sourceFloor();
           final var newLineage =
@@ -330,8 +355,8 @@ public final class StorageBootstrapMetadata {
   }
 
   private RecordAt selectLocked() throws IOException {
-    rejectTemporaryResidue();
     final var records = readValidRecordsLocked();
+    recoverTemporaryResidueLocked(records);
     if (records.isEmpty()) {
       throw new IOException("Bootstrap authority does not exist or has no valid record");
     }
@@ -570,11 +595,15 @@ public final class StorageBootstrapMetadata {
             publicationError);
   }
 
-  private void rejectTemporaryResidue() throws IOException {
+  private void recoverTemporaryResidueLocked(final List<RecordAt> records) throws IOException {
     for (var path : temporaryPaths) {
-      if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+      if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        continue;
+      }
+      if (records.isEmpty()) {
         throw new IOException("Interrupted bootstrap publication left a temporary file");
       }
+      Files.delete(path);
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadata.java
@@ -2,13 +2,17 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
 
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import com.jetbrains.youtrackdb.internal.core.config.StorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException.Reason;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -28,6 +32,7 @@ import net.jpountz.xxhash.XXHashFactory;
 public final class StorageBootstrapMetadata {
 
   static final String LOCK_FILE_NAME = "storage-bootstrap.bsml";
+  static final String NORMAL_DATABASE_LOCK_FILE_NAME = "dirty.fl";
   static final List<String> AUTHORITY_FILE_NAMES =
       List.of(
           "storage-bootstrap-0.bsm", "storage-bootstrap-1.bsm", "storage-bootstrap-2.bsm");
@@ -35,6 +40,16 @@ public final class StorageBootstrapMetadata {
   private static final long MAGIC = 0x5954444242534D31L;
   private static final int ENCODING_VERSION = 1;
   private static final int RECORD_SIZE = 80;
+
+  /**
+   * Names the single storage layout version that this build supports.
+   *
+   * <p>The storage layout version is the version of the on-disk storage layout. The record carries
+   * that version in the field that carried no meaning before. The record size therefore stays at
+   * {@link #RECORD_SIZE} bytes, and every field offset stays unchanged.
+   */
+  static final int SUPPORTED_STORAGE_LAYOUT_VERSION = StorageConfiguration.CURRENT_VERSION;
+
   private static final int CHECKSUM_OFFSET = RECORD_SIZE - Long.BYTES;
   private static final long XX_HASH_SEED = 0x648B7A2195D3L;
   private static final int LINEAGE_GENERATION_ATTEMPTS = 3;
@@ -54,6 +69,16 @@ public final class StorageBootstrapMetadata {
 
   private Snapshot liveBirth;
   private Snapshot locallyConfirmed;
+
+  /**
+   * Records whether the authority lock file existed before the current locked operation.
+   *
+   * <p>A locked operation that establishes new authority creates the lock file when the lock file
+   * is absent. The residue precedence rule must not treat that fresh lock file as birth residue.
+   * The field therefore keeps the observation that the lock acquisition made before the lock
+   * acquisition created the file.
+   */
+  private boolean lockFileExistedBeforeOperation;
 
   public StorageBootstrapMetadata(
       final Path storageDirectory, final FeatureFormatIdentity expectedFormat) throws IOException {
@@ -135,22 +160,77 @@ public final class StorageBootstrapMetadata {
 
   /** Reads and confirms the newest unambiguous legal authority. */
   public Snapshot readRequired() throws IOException {
-    return withAuthorityLock(this::readAndConfirmLocked);
+    return withAuthorityLock(false, this::readAndConfirmLocked);
   }
 
-  /** Reads authority for Open and rejects interrupted work before WAL processing can start. */
-  public Snapshot readActiveRequired() throws IOException {
-    return withAuthorityLock(
-        () -> {
-          final var selected = selectLocked();
-          if (selected.snapshot().state() == State.BIRTH_IN_PROGRESS) {
-            throw new IOException("Interrupted storage birth must be removed before Open");
-          }
-          if (selected.snapshot().state() == State.RESTORE_IN_PROGRESS) {
-            throw new IOException("Interrupted storage restore must be retried before Open");
-          }
-          return confirmSelectedLocked(selected).snapshot();
-        });
+  /**
+   * Decides admission of this storage image and returns the accepted authority snapshot.
+   *
+   * <p>This method is the single admission decision of storage open. Storage open calls this method
+   * before write-ahead log initialization and before recovery. A write-ahead log records a change
+   * before that change reaches its final file. Admission accepts only one unambiguous selected
+   * snapshot. The accepted snapshot carries the active lifecycle state, a supported authority
+   * encoding version, a supported authority feature format version, a supported storage layout
+   * version, and a non-negative logical sequence floor. The decoder validates every version rule
+   * and the floor rule, so this method repeats no check.
+   *
+   * <p>Repair runs only after acceptance. Repair removes each unfinished record candidate, then
+   * reselects the publication target, and then confirms the selected snapshot. A repair failure is
+   * logged and never fails the open.
+   *
+   * @throws StorageAdmissionException when one named cause rejects this storage image
+   */
+  public Snapshot readActiveRequired() throws StorageAdmissionException {
+    try {
+      return withAuthorityLock(
+          false,
+          () -> {
+            final var admitted = admitLocked();
+            repairAfterAdmissionLocked(admitted);
+            return admitted.snapshot();
+          });
+    } catch (StorageAdmissionException admissionRejection) {
+      throw admissionRejection;
+    } catch (IOException inputOutputFailure) {
+      // Every remaining low-level input and output failure carries one named admission reason.
+      throw new StorageAdmissionException(
+          Reason.AUTHORITY_IO_FAILURE,
+          directory,
+          "The bootstrap authority read failed before the admission decision",
+          inputOutputFailure);
+    }
+  }
+
+  /** Decides admission without any repair write. The caller already holds the authority lock. */
+  private RecordAt admitLocked() throws IOException {
+    final var selected = selectLocked(false);
+    final var state = selected.snapshot().state();
+    if (state == State.BIRTH_IN_PROGRESS) {
+      throw admissionFailure(
+          Reason.INTERRUPTED_BIRTH, "Interrupted storage birth must be removed before Open");
+    }
+    if (state == State.RESTORE_IN_PROGRESS) {
+      throw admissionFailure(
+          Reason.INTERRUPTED_RESTORE, "Interrupted storage restore must be retried before Open");
+    }
+    return selected;
+  }
+
+  /** Repairs the authority set after acceptance. A repair failure never fails the open. */
+  private void repairAfterAdmissionLocked(final RecordAt admitted) {
+    try {
+      removeCandidateResidueLocked();
+      confirmSelectedLocked(admitted);
+    } catch (IOException | RuntimeException repairFailure) {
+      LogManager.instance()
+          .warn(
+              this,
+              "Bootstrap authority repair failed in directory %s after admission accepted the"
+                  + " storage image: %s",
+              repairFailure,
+              directory,
+              repairFailure);
+    }
   }
 
   /** Advances the current lineage floor. A stale identity or lower floor is rejected. */
@@ -206,7 +286,263 @@ public final class StorageBootstrapMetadata {
   }
 
   /**
+   * Publishes the restore-in-progress lifecycle state directly from the birth-in-progress state.
+   *
+   * <p>A restore target must never appear as an empty active database. Restore therefore creates
+   * the target without genesis and without activation. Genesis is the creation of the initial
+   * database metadata. This method publishes the restore-in-progress lifecycle state of that fresh
+   * target, and this method keeps the storage identity, the storage lineage, and the logical
+   * sequence floor of the birth record.
+   *
+   * @param expected the birth snapshot that the creation of this target published
+   * @return the restore-in-progress snapshot of this target
+   */
+  public Snapshot beginRestoreFromBirth(final Snapshot expected) throws IOException {
+    return withAuthorityLock(
+        () -> {
+          final var current = verifyExpected(expected);
+          requireLiveBirthWhenPending(expected);
+          if (current.state() == State.RESTORE_IN_PROGRESS) {
+            // The transition is repeat safe. A retried restore of the same target therefore
+            // publishes no second record and keeps the generation of the first publication.
+            return current;
+          }
+          if (current.state() != State.BIRTH_IN_PROGRESS) {
+            throw new IllegalStateException(
+                "A restore target publishes the restore-in-progress state from the"
+                    + " birth-in-progress state only");
+          }
+
+          final var next =
+              new Snapshot(
+                  current.format(),
+                  nextGeneration(current.generation()),
+                  State.RESTORE_IN_PROGRESS,
+                  current.sequenceFloor());
+          publish(next);
+          // The birth ended with this publication, so no later call may continue that birth.
+          liveBirth = null;
+          return next;
+        });
+  }
+
+  /**
+   * Accepts an interrupted restore target and deletes that target inside one exclusive unit.
+   *
+   * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+   * restore. The acceptance check and the deletion run under the authority lock, so two concurrent
+   * restarts never destroy a healthy restored database.
+   *
+   * <p>Before deletion, the restart attempts the existing normal database lock without waiting.
+   * A busy lock refuses the restart before mutation. The probe never creates or replaces the lock
+   * file, and an acquired lock remains held through content deletion. A missing lock file is valid
+   * crash residue, so deletion proceeds without creating one.
+   *
+   * <p>The deletion follows one fixed order. The deletion removes every content file first, then
+   * removes each unfinished record candidate, and then removes the authority copies. The authority
+   * lock file stays in place forever, because an unlink of that file would split the exclusive
+   * unit across two file objects. Every crash point of that order therefore leaves a target that a
+   * later restart still accepts.
+   *
+   * <p>The authority copies leave in one further order. The copy that carries the newest record
+   * leaves last. A crash inside the copy loop therefore keeps the newest record on disk, and that
+   * newest record still carries the restore-in-progress lifecycle state. The safety of every crash
+   * point of the copy loop follows from that order alone, and the safety needs no assumption about
+   * the slot of any copy.
+   *
+   * @param contentDeletion removes every file of the target that is not a bootstrap artifact
+   * @throws StorageAdmissionException when this target is no interrupted restore target
+   */
+  public void deleteInterruptedRestoreTarget(final ContentDeletion contentDeletion)
+      throws IOException {
+    deleteInterruptedRestoreTarget(contentDeletion, Files::deleteIfExists);
+  }
+
+  /**
+   * Deletes one interrupted restore target and unlinks each authority copy through one seam.
+   *
+   * <p>A test replaces the seam of the authority copies and stops the deletion inside the copy
+   * loop. The test then inspects the copies that the stopped deletion left behind.
+   *
+   * @param contentDeletion removes every file of the target that is not a bootstrap artifact
+   * @param authorityCopyDeletion unlinks one authority copy of the target
+   * @throws StorageAdmissionException when this target is no interrupted restore target
+   */
+  void deleteInterruptedRestoreTarget(
+      final ContentDeletion contentDeletion, final AuthorityCopyDeletion authorityCopyDeletion)
+      throws IOException {
+    Objects.requireNonNull(contentDeletion, "contentDeletion");
+    Objects.requireNonNull(authorityCopyDeletion, "authorityCopyDeletion");
+
+    withAuthorityLock(
+        false,
+        () -> {
+          requireRestoreTargetLocked();
+          // The order of the copies comes from the records of the untouched target.
+          final var orderedCopies = authorityCopyDeletionOrderLocked();
+          deleteContentUnderNormalDatabaseLock(contentDeletion);
+          removeCandidateResidueLocked();
+          for (var path : orderedCopies) {
+            authorityCopyDeletion.deleteAuthorityCopy(path);
+          }
+          liveBirth = null;
+          locallyConfirmed = null;
+          return null;
+        });
+  }
+
+  /**
+   * Deletes content while holding the existing normal database lock when that file remains.
+   *
+   * <p>The authority lock is already held. The normal lock attempt must not wait because restore
+   * activation takes these locks in the opposite order. Opening without {@code CREATE} preserves
+   * the accepted lock-file-only crash residue. A missing normal lock file also means an earlier
+   * restart already deleted that content file, so deletion remains repeatable.
+   */
+  private void deleteContentUnderNormalDatabaseLock(final ContentDeletion contentDeletion)
+      throws IOException {
+    final var normalLockPath = directory.resolve(NORMAL_DATABASE_LOCK_FILE_NAME);
+    final FileChannel normalLockChannel;
+    try {
+      normalLockChannel =
+          FileChannel.open(
+              normalLockPath,
+              StandardOpenOption.READ,
+              StandardOpenOption.WRITE,
+              LinkOption.NOFOLLOW_LINKS);
+    } catch (NoSuchFileException missingNormalLock) {
+      contentDeletion.deleteEveryContentFile(directory);
+      return;
+    }
+
+    try (normalLockChannel) {
+      final FileLock normalLock;
+      try {
+        normalLock = normalLockChannel.tryLock();
+      } catch (OverlappingFileLockException overlappingLock) {
+        throw normalDatabaseLockBusy(overlappingLock);
+      }
+      if (normalLock == null) {
+        throw normalDatabaseLockBusy(null);
+      }
+      try (normalLock) {
+        contentDeletion.deleteEveryContentFile(directory);
+      }
+    }
+  }
+
+  private StorageAdmissionException normalDatabaseLockBusy(final Throwable cause) {
+    return new StorageAdmissionException(
+        Reason.RESTART_TARGET_BUSY,
+        directory,
+        "The destructive restore restart refuses a target whose normal database lock is busy",
+        cause);
+  }
+
+  /**
+   * Orders the authority copies of one deletion, and puts the newest record last.
+   *
+   * <p>A generation is a counter inside the bootstrap authority record, and a higher value means a
+   * newer record. A copy without any readable record carries no accepting evidence, so such a copy
+   * leaves first. Two copies of the same generation keep the order of the file names.
+   *
+   * @return every authority path of this image, ordered by generation, lowest generation first
+   */
+  private List<Path> authorityCopyDeletionOrderLocked() throws IOException {
+    final Map<Path, Long> generationByPath = new HashMap<>();
+    for (var record : readValidRecordsLocked()) {
+      generationByPath.put(record.path(), record.snapshot().generation());
+    }
+    // Every readable generation is positive, so the value zero marks a copy without a record.
+    return authorityPaths.stream()
+        .sorted(Comparator.comparingLong(path -> generationByPath.getOrDefault(path, 0L)))
+        .toList();
+  }
+
+  /**
+   * Checks that this image is a valid destructive restart target and changes no durable content.
+   *
+   * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+   * restore. The caller runs this check before the caller discards any in-memory state of the
+   * named database. A refused restart therefore keeps every file and every live session of a
+   * healthy database.
+   *
+   * <p>This check is not the acceptance decision of the restart. The deletion repeats the same
+   * check inside its own exclusive unit, so the acceptance and the deletion stay one exclusive
+   * unit.
+   *
+   * @throws StorageAdmissionException when this image is no interrupted restore target
+   */
+  public void requireInterruptedRestoreTarget() throws IOException {
+    withAuthorityLock(
+        false,
+        () -> {
+          requireRestoreTargetLocked();
+          return null;
+        });
+  }
+
+  /**
+   * Checks that this target belongs to a destructive restore restart.
+   *
+   * <p>The check accepts positive evidence of an interrupted restore only. The first accepted
+   * shape is a readable authority record in the restore-in-progress lifecycle state. The second
+   * accepted shape is one directory whose only entry is the authority lock file.
+   *
+   * <p>Two events produce that second shape. The deletion of an earlier restart produces the
+   * second shape, because the deletion removes every content file first and every authority copy
+   * afterwards. An interrupted storage birth also produces the second shape, because the birth
+   * creates the authority lock file before the birth writes the first record. The check therefore
+   * cannot name the event that produced the second shape.
+   *
+   * <p>The check accepts the second shape for both events on purpose. The second shape holds no
+   * content file at all, so the restart destroys no data of any database. The restart then restores
+   * the named backup into that directory.
+   *
+   * <p>The check rejects every other case with one named admission reason and leaves every file in
+   * place. A directory without any bootstrap authority artifact is never a valid restart target. A
+   * directory that still holds content files without a readable authority record is never a valid
+   * restart target either, because such a directory can hold a database of an earlier format.
+   */
+  private void requireRestoreTargetLocked() throws IOException {
+    final RecordAt selected;
+    try {
+      selected = selectLocked(false);
+    } catch (StorageAdmissionException rejection) {
+      if (rejection.reason() == Reason.INTERRUPTED_BIRTH && holdsOnlyTheAuthorityLockFile()) {
+        // A crash in the tail of an earlier restart deletion produces this shape. An interrupted
+        // storage birth produces the same shape. The shape holds no content file, so the restart
+        // accepts the shape for both events.
+        return;
+      }
+      throw rejection;
+    }
+
+    final var state = selected.snapshot().state();
+    if (state == State.RESTORE_IN_PROGRESS) {
+      return;
+    }
+    if (state == State.BIRTH_IN_PROGRESS) {
+      throw admissionFailure(
+          Reason.INTERRUPTED_BIRTH,
+          "The destructive restore restart refuses an interrupted storage birth, which a drop"
+              + " removes");
+    }
+    throw admissionFailure(
+        Reason.RESTART_TARGET_NOT_RESTORE_IN_PROGRESS,
+        "The destructive restore restart accepts the restore-in-progress lifecycle state only,"
+            + " and the current lifecycle state is "
+            + state);
+  }
+
+  /**
    * Starts replacement under a fresh target lineage while retaining the target high-water.
+   *
+   * <p>A target that already carries the restore-in-progress lifecycle state keeps its lineage.
+   * The production restore path creates a fresh target. The birth publication of that fresh target
+   * already generated a random storage lineage. That fresh target therefore needs no replacement.
+   * The lifecycle transition table also allows no second restore-in-progress publication under a
+   * new lineage, because the design allows exactly one new transition.
    *
    * @param expected the previously observed authority snapshot
    * @param adoption the source format and sequence floor to adopt
@@ -223,6 +559,7 @@ public final class StorageBootstrapMetadata {
             throw new IllegalStateException("Cannot adopt a floor from another feature format");
           }
           if (current.state() == State.RESTORE_IN_PROGRESS) {
+            // The target already carries a fresh lineage from its own birth publication.
             return current;
           }
           if (current.state() != State.ACTIVE) {
@@ -273,11 +610,71 @@ public final class StorageBootstrapMetadata {
             + " candidates collided with the current or source lineage identity");
   }
 
+  /**
+   * Reports whether the authority lock file is the only entry of this storage directory.
+   *
+   * <p>The deletion of a destructive restart removes every content file, then every unfinished
+   * record candidate, and then every authority copy. The deletion keeps the authority lock file.
+   * A directory whose only entry is that lock file therefore comes either from a crash in the tail
+   * of an earlier restart deletion or from an interrupted storage birth. A storage birth creates
+   * the authority lock file before the birth writes the first record, so both events produce this
+   * one shape. The shape holds no content file under either event.
+   *
+   * <p>The method also requires that the lock file existed before the current locked operation, so
+   * a lock file of the current operation never proves anything.
+   */
+  private boolean holdsOnlyTheAuthorityLockFile() throws IOException {
+    if (!lockFileExistedBeforeOperation) {
+      return false;
+    }
+    return holdsOnlyTheAuthorityLockFile(directory);
+  }
+
+  /**
+   * Reports whether the authority lock file is the only entry of the given storage directory.
+   *
+   * <p>The deletion of a destructive restart removes every content file, then every unfinished
+   * record candidate, and then every authority copy. The deletion keeps the authority lock file.
+   * A directory of that shape therefore holds no storage content at all.
+   */
+  public static boolean holdsOnlyTheAuthorityLockFile(final Path storageDirectory)
+      throws IOException {
+    Objects.requireNonNull(storageDirectory, "storageDirectory");
+    if (!Files.isDirectory(storageDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      return false;
+    }
+    try (var entries = Files.list(storageDirectory)) {
+      var names = entries.map(entry -> entry.getFileName().toString()).toList();
+      return names.size() == 1 && names.get(0).equals(LOCK_FILE_NAME);
+    }
+  }
+
   private <T> T withAuthorityLock(final IOOperation<T> operation) throws IOException {
+    return withAuthorityLock(true, operation);
+  }
+
+  /**
+   * Runs one operation inside the exclusive unit over the authority copies.
+   *
+   * <p>The exclusive unit uses the authority lock file. A lock acquisition that establishes new
+   * authority creates that lock file when the lock file is absent. Every other operation creates
+   * no lock file in a directory without any bootstrap authority artifact. A created lock file
+   * would otherwise turn such a directory into birth residue, and the reported admission reason of
+   * one unchanged image would then differ between two repeated opens.
+   *
+   * @param establishesAuthority true when the operation may create the first authority artifact
+   * @throws StorageAdmissionException with the missing-record reason when the directory holds no
+   *     bootstrap authority artifact and the operation establishes no authority
+   */
+  private <T> T withAuthorityLock(
+      final boolean establishesAuthority, final IOOperation<T> operation) throws IOException {
     final var processLock = acquireProcessLock();
     processLock.lock.lock();
     try {
-      prepareLockResource();
+      if (!prepareLockResource(establishesAuthority)) {
+        // The directory holds no bootstrap authority artifact, so the operation guards nothing.
+        throw missingAuthorityFailure();
+      }
       try (var lockChannel =
           FileChannel.open(lockPath, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS);
           FileLock ignored = lockChannel.lock()) {
@@ -306,8 +703,19 @@ public final class StorageBootstrapMetadata {
     }
   }
 
-  private void prepareLockResource() throws IOException {
-    if (!Files.exists(lockPath, LinkOption.NOFOLLOW_LINKS)) {
+  /**
+   * Prepares the authority lock file of one exclusive unit.
+   *
+   * @param establishesAuthority true when the caller may create the first authority artifact
+   * @return false when the directory holds no bootstrap authority artifact and the caller
+   *     establishes no authority
+   */
+  private boolean prepareLockResource(final boolean establishesAuthority) throws IOException {
+    lockFileExistedBeforeOperation = Files.exists(lockPath, LinkOption.NOFOLLOW_LINKS);
+    if (!lockFileExistedBeforeOperation) {
+      if (!establishesAuthority && !anyPublicationResourceExists()) {
+        return false;
+      }
       try {
         Files.createFile(lockPath);
       } catch (java.nio.file.FileAlreadyExistsException ignored) {
@@ -317,8 +725,10 @@ public final class StorageBootstrapMetadata {
     final var attributes =
         Files.readAttributes(lockPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
     if (!attributes.isRegularFile()) {
-      throw new IOException("Bootstrap publication lock is not a regular file");
+      throw admissionFailure(
+          Reason.NON_REGULAR_AUTHORITY_FILE, "Bootstrap publication lock is not a regular file");
     }
+    return true;
   }
 
   private Snapshot verifyExpected(final Snapshot expected) throws IOException {
@@ -338,7 +748,8 @@ public final class StorageBootstrapMetadata {
   }
 
   private Snapshot readAndConfirmLocked() throws IOException {
-    final var selected = selectLocked();
+    // Every publication path keeps the historical order and removes candidate residue first.
+    final var selected = selectLocked(true);
     if (selected.snapshot().state() == State.BIRTH_IN_PROGRESS
         || selected.snapshot().equals(locallyConfirmed)) {
       return selected.snapshot();
@@ -354,11 +765,19 @@ public final class StorageBootstrapMetadata {
     return new RecordAt(target, selected.snapshot());
   }
 
-  private RecordAt selectLocked() throws IOException {
-    final var records = readValidRecordsLocked();
-    recoverTemporaryResidueLocked(records);
+  /**
+   * Selects the newest unambiguous legal record.
+   *
+   * @param removeCandidateResidue removes each unfinished record candidate before the selection
+   */
+  private RecordAt selectLocked(final boolean removeCandidateResidue) throws IOException {
+    final var damagedCopies = new ArrayList<StorageAdmissionException>();
+    final var records = readValidRecordsLocked(damagedCopies);
     if (records.isEmpty()) {
-      throw new IOException("Bootstrap authority does not exist or has no valid record");
+      throw residueVerdictLocked(damagedCopies);
+    }
+    if (removeCandidateResidue) {
+      removeCandidateResidueLocked();
     }
 
     final var first = records.get(0).snapshot();
@@ -366,7 +785,9 @@ public final class StorageBootstrapMetadata {
       final var snapshot = record.snapshot();
       // Unsupported formats fail during decoding. This branch rejects conflicting storage identity.
       if (!snapshot.storageIdentity().equals(first.storageIdentity())) {
-        throw new IOException("Bootstrap authority records are ambiguous");
+        throw admissionFailure(
+            Reason.FOREIGN_AUTHORITY_COPY,
+            "Bootstrap authority copies name different storage identities");
       }
     }
 
@@ -374,7 +795,8 @@ public final class StorageBootstrapMetadata {
     for (var record : records) {
       final var prior = generations.putIfAbsent(record.snapshot().generation(), record.snapshot());
       if (prior != null && !prior.equals(record.snapshot())) {
-        throw new IOException("Bootstrap authority generation is ambiguous");
+        throw admissionFailure(
+            Reason.AUTHORITY_AMBIGUOUS, "Bootstrap authority generation is ambiguous");
       }
     }
     final var ordered = generations.values().stream()
@@ -384,7 +806,9 @@ public final class StorageBootstrapMetadata {
       final var prior = ordered.get(i - 1);
       final var next = ordered.get(i);
       if (next.generation() == prior.generation() + 1 && !isLegalSuccessor(prior, next)) {
-        throw new IOException("Bootstrap authority contains an illegal state transition");
+        throw admissionFailure(
+            Reason.AUTHORITY_ILLEGAL_TRANSITION,
+            "Bootstrap authority contains an illegal state transition");
       }
     }
 
@@ -396,6 +820,16 @@ public final class StorageBootstrapMetadata {
   }
 
   private List<RecordAt> readValidRecordsLocked() throws IOException {
+    return readValidRecordsLocked(new ArrayList<>());
+  }
+
+  /**
+   * Reads each readable authority copy.
+   *
+   * @param damagedCopies collects one failure per copy that failed its integrity check
+   */
+  private List<RecordAt> readValidRecordsLocked(
+      final List<StorageAdmissionException> damagedCopies) throws IOException {
     final var records = new ArrayList<RecordAt>();
     for (var path : authorityPaths) {
       if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
@@ -404,15 +838,58 @@ public final class StorageBootstrapMetadata {
       final var attributes =
           Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
       if (!attributes.isRegularFile()) {
-        throw new IOException("Bootstrap authority is not a regular file: " + path);
+        throw admissionFailure(
+            Reason.NON_REGULAR_AUTHORITY_FILE,
+            "Bootstrap authority is not a regular file: " + path);
       }
       try {
         records.add(new RecordAt(path, readRecord(path, attributes)));
-      } catch (DamagedRecordException ignored) {
+      } catch (DamagedRecordException damaged) {
         // A size or checksum failure proves damage. The slot is not authority and can be reused.
+        damagedCopies.add(damaged);
       }
     }
     return records;
+  }
+
+  /**
+   * Applies the single residue precedence rule for a directory without any readable record.
+   *
+   * <p>A directory that holds any bootstrap authority artifact reports an interrupted birth. A
+   * bootstrap authority artifact is an authority copy, the authority lock file, or an unfinished
+   * record candidate. A directory without any such artifact reports a missing record. This method
+   * is the only place that decides between those two reasons.
+   */
+  private StorageAdmissionException residueVerdictLocked(
+      final List<StorageAdmissionException> damagedCopies) {
+    final StorageAdmissionException verdict;
+    if (anyBootstrapArtifactExistsLocked()) {
+      verdict =
+          admissionFailure(
+              Reason.INTERRUPTED_BIRTH,
+              "Bootstrap authority residue without a readable record proves an interrupted storage"
+                  + " birth");
+    } else {
+      verdict = missingAuthorityFailure();
+    }
+    for (var damaged : damagedCopies) {
+      verdict.addSuppressed(damaged);
+    }
+    return verdict;
+  }
+
+  /** Reports the single admission failure of a directory without any bootstrap artifact. */
+  private StorageAdmissionException missingAuthorityFailure() {
+    return admissionFailure(
+        Reason.AUTHORITY_MISSING, "Bootstrap authority does not exist in this directory");
+  }
+
+  private boolean anyBootstrapArtifactExistsLocked() {
+    return lockFileExistedBeforeOperation || anyPublicationResourceExists();
+  }
+
+  private StorageAdmissionException admissionFailure(final Reason reason, final String message) {
+    return new StorageAdmissionException(reason, directory, message);
   }
 
   private Snapshot readRecord(final Path path, final BasicFileAttributes attributes)
@@ -443,7 +920,11 @@ public final class StorageBootstrapMetadata {
     try {
       return decode(bytes);
     } catch (IllegalArgumentException e) {
-      throw new IOException("Bootstrap authority contains an invalid value", e);
+      throw new StorageAdmissionException(
+          Reason.AUTHORITY_INVALID_CONTENT,
+          directory,
+          "Bootstrap authority contains an invalid value",
+          e);
     }
   }
 
@@ -451,33 +932,48 @@ public final class StorageBootstrapMetadata {
     final var buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
     final var magic = buffer.getLong();
     if (magic != MAGIC) {
-      throw new IOException("Invalid bootstrap authority magic: " + magic);
+      throw admissionFailure(
+          Reason.AUTHORITY_INVALID_CONTENT, "Invalid bootstrap authority magic: " + magic);
     }
     final var encodingVersion = buffer.getInt();
     if (encodingVersion != ENCODING_VERSION) {
-      throw new IOException("Unsupported bootstrap encoding version: " + encodingVersion);
+      throw admissionFailure(
+          Reason.UNSUPPORTED_ENCODING_VERSION,
+          "Unsupported bootstrap encoding version: " + encodingVersion);
     }
     final var formatVersion = buffer.getInt();
     if (formatVersion != expectedFormat.version()) {
       // A checksum-valid foreign format came from software this reader does not understand.
-      throw new UnsupportedRecordException(
+      throw admissionFailure(
+          Reason.UNSUPPORTED_FEATURE_FORMAT_VERSION,
           "Unsupported feature format version: " + formatVersion);
     }
     final var format = new FeatureFormatIdentity(formatVersion);
     final var generation = buffer.getLong();
-    final var state = State.fromCode(buffer.getInt());
-    final var reserved = buffer.getInt();
-    if (reserved != 0) {
-      throw new IOException("Invalid bootstrap authority reserved field: " + reserved);
+    final var state = State.fromCode(buffer.getInt(), directory);
+    final var storageLayoutVersion = buffer.getInt();
+    if (storageLayoutVersion != SUPPORTED_STORAGE_LAYOUT_VERSION) {
+      // The empty value zero comes from an earlier commit of this branch and is also unsupported.
+      throw admissionFailure(
+          Reason.UNSUPPORTED_STORAGE_LAYOUT_VERSION,
+          "Unsupported storage layout version: "
+              + storageLayoutVersion
+              + ", supported storage layout version: "
+              + SUPPORTED_STORAGE_LAYOUT_VERSION);
     }
     final var storageIdentity = new StorageIdentity(readUuid(buffer));
     final var lineageIdentity = new StorageLineageIdentity(readUuid(buffer));
     final var highestIssued = buffer.getLong();
     if (generation <= 0) {
-      throw new IOException("Invalid bootstrap authority generation: " + generation);
+      throw admissionFailure(
+          Reason.AUTHORITY_INVALID_CONTENT,
+          "Invalid bootstrap authority generation: " + generation);
     }
     if (highestIssued < 0) {
-      throw new IOException("Invalid bootstrap authority highest issued value: " + highestIssued);
+      // The non-negative rule is the only floor rule that a durable record can break.
+      throw admissionFailure(
+          Reason.INVALID_SEQUENCE_FLOOR,
+          "Invalid bootstrap authority highest issued value: " + highestIssued);
     }
     final var floor = new LogicalSequenceFloor(storageIdentity, lineageIdentity, highestIssued);
     return new Snapshot(format, generation, state, floor);
@@ -595,16 +1091,27 @@ public final class StorageBootstrapMetadata {
             publicationError);
   }
 
-  private void recoverTemporaryResidueLocked(final List<RecordAt> records) throws IOException {
+  /** Removes each unfinished record candidate. A readable record already exists at this point. */
+  private void removeCandidateResidueLocked() throws IOException {
     for (var path : temporaryPaths) {
-      if (!Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
-        continue;
+      if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+        Files.delete(path);
       }
-      if (records.isEmpty()) {
-        throw new IOException("Interrupted bootstrap publication left a temporary file");
-      }
-      Files.delete(path);
     }
+  }
+
+  /** Reports whether the given file name belongs to the bootstrap authority artifact set. */
+  public static boolean isBootstrapArtifactName(final String fileName) {
+    Objects.requireNonNull(fileName, "fileName");
+    if (fileName.equals(LOCK_FILE_NAME)) {
+      return true;
+    }
+    for (var authorityName : AUTHORITY_FILE_NAMES) {
+      if (fileName.equals(authorityName) || fileName.equals(authorityName + ".tmp")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean anyPublicationResourceExists() {
@@ -622,6 +1129,11 @@ public final class StorageBootstrapMetadata {
       return false;
     }
     if (prior.lineageIdentity().equals(next.lineageIdentity())) {
+      if (prior.state() == State.BIRTH_IN_PROGRESS && next.state() == State.RESTORE_IN_PROGRESS) {
+        // A restore target publishes the restore-in-progress state directly from the
+        // birth-in-progress state, so a restore target never appears as an empty active database.
+        return true;
+      }
       return prior.state() == next.state()
           || (prior.state() != State.ACTIVE && next.state() == State.ACTIVE);
     }
@@ -635,7 +1147,8 @@ public final class StorageBootstrapMetadata {
     buffer.putInt(snapshot.format().version());
     buffer.putLong(snapshot.generation());
     buffer.putInt(snapshot.state().code);
-    buffer.putInt(0);
+    // The field of the former spare value now carries the supported storage layout version.
+    buffer.putInt(SUPPORTED_STORAGE_LAYOUT_VERSION);
     writeUuid(buffer, snapshot.storageIdentity().value());
     writeUuid(buffer, snapshot.lineageIdentity().value());
     buffer.putLong(snapshot.sequenceFloor().highestIssued());
@@ -684,17 +1197,11 @@ public final class StorageBootstrapMetadata {
   private record RecordAt(Path path, Snapshot snapshot) {
   }
 
-  private static final class DamagedRecordException extends IOException {
+  /** Reports one authority copy that failed its integrity check. Selection tolerates one copy. */
+  private final class DamagedRecordException extends StorageAdmissionException {
 
     private DamagedRecordException(final String message) {
-      super(message);
-    }
-  }
-
-  private static final class UnsupportedRecordException extends IOException {
-
-    private UnsupportedRecordException(final String message) {
-      super(message);
+      super(Reason.AUTHORITY_DAMAGED, directory, message);
     }
   }
 
@@ -722,6 +1229,20 @@ public final class StorageBootstrapMetadata {
     void remove(Path candidate) throws IOException;
   }
 
+  /** Removes every file of one storage directory that is no bootstrap authority artifact. */
+  @FunctionalInterface
+  public interface ContentDeletion {
+
+    void deleteEveryContentFile(Path storageDirectory) throws IOException;
+  }
+
+  /** Unlinks one authority copy of one storage directory. */
+  @FunctionalInterface
+  interface AuthorityCopyDeletion {
+
+    void deleteAuthorityCopy(Path authorityCopy) throws IOException;
+  }
+
   public enum State {
     BIRTH_IN_PROGRESS(1), ACTIVE(2), RESTORE_IN_PROGRESS(3);
 
@@ -731,14 +1252,18 @@ public final class StorageBootstrapMetadata {
       this.code = code;
     }
 
-    private static State fromCode(final int code) throws IOException {
+    private static State fromCode(final int code, final Path storageDirectory)
+        throws StorageAdmissionException {
       for (var state : values()) {
         if (state.code == code) {
           return state;
         }
       }
       // A checksum-valid unknown state came from software this reader does not understand.
-      throw new UnsupportedRecordException("Unsupported bootstrap state: " + code);
+      throw new StorageAdmissionException(
+          Reason.UNSUPPORTED_LIFECYCLE_STATE,
+          storageDirectory,
+          "Unsupported bootstrap state: " + code);
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageIdentity.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageIdentity.java
@@ -1,0 +1,16 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/** Identifies one physical disk-storage target across lineage replacements. */
+public record StorageIdentity(UUID value) {
+
+  public StorageIdentity {
+    Objects.requireNonNull(value, "value");
+  }
+
+  public static StorageIdentity random() {
+    return new StorageIdentity(UUID.randomUUID());
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageLineageIdentity.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageLineageIdentity.java
@@ -1,0 +1,16 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/** Identifies one activated lifetime of a physical disk-storage target. */
+public record StorageLineageIdentity(UUID value) {
+
+  public StorageLineageIdentity {
+    Objects.requireNonNull(value, "value");
+  }
+
+  public static StorageLineageIdentity random() {
+    return new StorageLineageIdentity(UUID.randomUUID());
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
@@ -174,9 +174,15 @@ public interface AtomicOperation {
 
   void truncateFile(long fileId) throws IOException;
 
+  enum ComponentLockMode {
+    SHARED, EXCLUSIVE
+  }
+
   boolean containsInLockedObjects(String lockName);
 
-  void addLockedObject(String lockName);
+  @Nullable ComponentLockMode lockedObjectMode(String lockName);
+
+  void addLockedObject(String lockName, ComponentLockMode mode);
 
   void rollbackInProgress();
 
@@ -188,6 +194,9 @@ public interface AtomicOperation {
 
   /** Tracks a locked StorageComponent so it can be released at operation end. */
   void addLockedComponent(StorageComponent component);
+
+  /** Returns the number of distinct physical pages touched by this operation. */
+  int touchedPagesCount();
 
   /** Returns the StorageComponents locked by this operation. */
   Iterable<StorageComponent> lockedComponents();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
@@ -193,10 +193,10 @@ public interface AtomicOperation {
   /** Tracks a locked StorageComponent so it can be released at operation end. */
   void addLockedComponent(StorageComponent component);
 
-  /** Enables exact distinct-page accounting for this operation. Disabled by default. */
+  /** Enables distinct-page accounting for subsequent page accesses. Disabled by default. */
   void enablePageTracking();
 
-  /** Returns the tracked distinct-page count, or zero while tracking is disabled. */
+  /** Returns the distinct pages touched after tracking was enabled, or zero before then. */
   int touchedPagesCount();
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperation.java
@@ -178,8 +178,6 @@ public interface AtomicOperation {
     SHARED, EXCLUSIVE
   }
 
-  boolean containsInLockedObjects(String lockName);
-
   @Nullable ComponentLockMode lockedObjectMode(String lockName);
 
   void addLockedObject(String lockName, ComponentLockMode mode);
@@ -195,8 +193,17 @@ public interface AtomicOperation {
   /** Tracks a locked StorageComponent so it can be released at operation end. */
   void addLockedComponent(StorageComponent component);
 
-  /** Returns the number of distinct physical pages touched by this operation. */
+  /** Enables exact distinct-page accounting for this operation. Disabled by default. */
+  void enablePageTracking();
+
+  /** Returns the tracked distinct-page count, or zero while tracking is disabled. */
   int touchedPagesCount();
+
+  /**
+   * Enforces the one-collection contract of caller-owned record writes. Future multi-collection
+   * support must acquire collection locks in ascending identifier order before any mutation.
+   */
+  void validateRecordCollectionLockOrder(int collectionId);
 
   /** Returns the StorageComponents locked by this operation. */
   Iterable<StorageComponent> lockedComponents();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -88,7 +88,11 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   private boolean rollback;
 
   private final Set<String> lockedObjects = new HashSet<>();
+  private final Map<String, ComponentLockMode> lockedObjectModes = new HashMap<>();
   private final ArrayList<StorageComponent> lockedComponents = new ArrayList<>();
+  private final Long2ObjectOpenHashMap<LongOpenHashSet> touchedPages =
+      new Long2ObjectOpenHashMap<>();
+  private int touchedPagesCount;
   private final Long2ObjectOpenHashMap<FileChanges> fileChanges = new Long2ObjectOpenHashMap<>();
   private final Object2LongOpenHashMap<String> newFileNamesId = new Object2LongOpenHashMap<>();
   private final LongOpenHashSet deletedFiles = new LongOpenHashSet();
@@ -263,6 +267,7 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
 
     assert pageCount > 0;
     fileId = checkFileIdCompatibility(fileId, storageId);
+    registerPageTouch(fileId, pageIndex);
 
     if (deletedFiles.contains(fileId)) {
       throw new StorageException(writeCache.getStorageName(),
@@ -309,6 +314,7 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     checkIfActive();
 
     fileId = checkFileIdCompatibility(fileId, storageId);
+    registerPageTouch(fileId, pageIndex);
 
     if (deletedFiles.contains(fileId)) {
       throw new StorageException(writeCache.getStorageName(),
@@ -485,6 +491,7 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     assert pageIndex >= 0 : "pageIndex out of range: " + pageIndex;
 
     fileId = checkFileIdCompatibility(fileId, storageId);
+    registerPageTouch(fileId, pageIndex);
 
     if (deletedFiles.contains(fileId)) {
       throw new StorageException(writeCache.getStorageName(),
@@ -1484,13 +1491,20 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   }
 
   @Override
-  public void addLockedObject(final String lockedObject) {
+  public void addLockedObject(
+      final String lockedObject, final ComponentLockMode mode) {
     lockedObjects.add(lockedObject);
+    lockedObjectModes.put(lockedObject, mode);
   }
 
   @Override
   public boolean containsInLockedObjects(final String objectToLock) {
     return lockedObjects.contains(objectToLock);
+  }
+
+  @Nullable @Override
+  public ComponentLockMode lockedObjectMode(final String objectToLock) {
+    return lockedObjectModes.get(objectToLock);
   }
 
   @Override
@@ -1506,6 +1520,18 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   @Override
   public Iterable<StorageComponent> lockedComponents() {
     return lockedComponents;
+  }
+
+  @Override
+  public int touchedPagesCount() {
+    return touchedPagesCount;
+  }
+
+  private void registerPageTouch(final long fileId, final long pageIndex) {
+    final var filePages = touchedPages.computeIfAbsent(fileId, ignored -> new LongOpenHashSet());
+    if (filePages.add(pageIndex)) {
+      touchedPagesCount++;
+    }
   }
 
   // --- Snapshot / Visibility index proxy methods ---

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -62,12 +62,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -87,12 +85,11 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
 
   private boolean rollback;
 
-  private final Set<String> lockedObjects = new HashSet<>();
-  private final Map<String, ComponentLockMode> lockedObjectModes = new HashMap<>();
+  private final Map<String, ComponentLockMode> lockedObjects = new HashMap<>();
   private final ArrayList<StorageComponent> lockedComponents = new ArrayList<>();
-  private final Long2ObjectOpenHashMap<LongOpenHashSet> touchedPages =
-      new Long2ObjectOpenHashMap<>();
+  @Nullable private Long2ObjectOpenHashMap<LongOpenHashSet> touchedPages;
   private int touchedPagesCount;
+  private int recordWriteCollectionId = -1;
   private final Long2ObjectOpenHashMap<FileChanges> fileChanges = new Long2ObjectOpenHashMap<>();
   private final Object2LongOpenHashMap<String> newFileNamesId = new Object2LongOpenHashMap<>();
   private final LongOpenHashSet deletedFiles = new LongOpenHashSet();
@@ -1493,23 +1490,17 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   @Override
   public void addLockedObject(
       final String lockedObject, final ComponentLockMode mode) {
-    lockedObjects.add(lockedObject);
-    lockedObjectModes.put(lockedObject, mode);
-  }
-
-  @Override
-  public boolean containsInLockedObjects(final String objectToLock) {
-    return lockedObjects.contains(objectToLock);
+    lockedObjects.put(lockedObject, mode);
   }
 
   @Nullable @Override
   public ComponentLockMode lockedObjectMode(final String objectToLock) {
-    return lockedObjectModes.get(objectToLock);
+    return lockedObjects.get(objectToLock);
   }
 
   @Override
   public Iterable<String> lockedObjects() {
-    return lockedObjects;
+    return lockedObjects.keySet();
   }
 
   @Override
@@ -1523,12 +1514,37 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   }
 
   @Override
+  public void enablePageTracking() {
+    if (touchedPages == null) {
+      touchedPages = new Long2ObjectOpenHashMap<>();
+    }
+  }
+
+  @Override
   public int touchedPagesCount() {
     return touchedPagesCount;
   }
 
+  @Override
+  public void validateRecordCollectionLockOrder(final int collectionId) {
+    if (recordWriteCollectionId < 0) {
+      recordWriteCollectionId = collectionId;
+    } else if (recordWriteCollectionId != collectionId) {
+      throw new IllegalStateException(
+          "Caller-owned record writes currently support one collection per atomic operation;"
+              + " attempted collections " + recordWriteCollectionId + " and " + collectionId
+              + ". Future multi-collection callers must lock collections in ascending identifier"
+              + " order before mutation");
+    }
+  }
+
   private void registerPageTouch(final long fileId, final long pageIndex) {
-    final var filePages = touchedPages.computeIfAbsent(fileId, ignored -> new LongOpenHashSet());
+    final var pages = touchedPages;
+    if (pages == null) {
+      return;
+    }
+
+    final var filePages = pages.computeIfAbsent(fileId, ignored -> new LongOpenHashSet());
     if (filePages.add(pageIndex)) {
       touchedPagesCount++;
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -522,20 +522,22 @@ public class AtomicOperationsManager {
   }
 
   private void releaseLocks(AtomicOperation operation) {
-    // Release StorageComponent locks (the common case).
-    // Check isExclusiveOwner() to make this method idempotent — it may be called
-    // twice (once by endAtomicOperation, once by ensureThatComponentsUnlocked
-    // in the finally block of AbstractStorage.commit).
+    // The component list is drained, which makes a second cleanup call idempotent.
     var compIter = operation.lockedComponents().iterator();
     while (compIter.hasNext()) {
       var component = compIter.next();
-      if (component.isExclusiveOwner()) {
+      final var mode = operation.lockedObjectMode(component.getLockName());
+      if (mode == AtomicOperation.ComponentLockMode.SHARED) {
+        component.unlockShared();
+      } else if (component.isExclusiveOwner()) {
+        // A null mode is treated as exclusive for compatibility with test doubles and
+        // operations created before mode-aware bookkeeping was introduced.
         component.unlockExclusive();
       }
       compIter.remove();
     }
 
-    // Clear the combined dedup set
+    // Clear the combined dedup set.
     var nameIter = operation.lockedObjects().iterator();
     while (nameIter.hasNext()) {
       nameIter.next();
@@ -543,24 +545,45 @@ public class AtomicOperationsManager {
     }
   }
 
+  /** Acquires a shared component lock for the lifetime of the atomic operation. */
+  public void acquireSharedLockTillOperationComplete(
+      @Nonnull AtomicOperation operation, @Nonnull StorageComponent component) {
+    storage.checkErrorState();
+
+    final var lockName = component.getLockName();
+    final var heldMode = operation.lockedObjectMode(lockName);
+    if (heldMode != null || operation.containsInLockedObjects(lockName)) {
+      // Exclusive mode is stronger, while a repeated shared acquisition is idempotent.
+      return;
+    }
+
+    component.lockShared();
+    operation.addLockedComponent(component);
+    operation.addLockedObject(lockName, AtomicOperation.ComponentLockMode.SHARED);
+  }
+
   /**
-   * Acquires exclusive lock on the given {@link StorageComponent} for the lifetime of the
-   * atomic operation. Uses the component's own
-   * {@link com.jetbrains.youtrackdb.internal.common.concur.resource.SharedResourceAbstract
-   * ReentrantReadWriteLock} directly — no external map lookup needed. The lock is natively
-   * reentrant.
+   * Acquires an exclusive component lock for the lifetime of the atomic operation.
+   * Shared-to-exclusive upgrades fail before entering the non-upgradable component lock.
    */
   public void acquireExclusiveLockTillOperationComplete(
       @Nonnull AtomicOperation operation, @Nonnull StorageComponent component) {
     storage.checkErrorState();
 
-    if (operation.containsInLockedObjects(component.getLockName())) {
+    final var lockName = component.getLockName();
+    final var heldMode = operation.lockedObjectMode(lockName);
+    if (heldMode == AtomicOperation.ComponentLockMode.SHARED) {
+      throw new IllegalStateException(
+          "Cannot upgrade component '" + lockName + "' from SHARED to EXCLUSIVE mode");
+    }
+    if (heldMode == AtomicOperation.ComponentLockMode.EXCLUSIVE
+        || operation.containsInLockedObjects(lockName)) {
       return;
     }
 
     component.lockExclusive();
     operation.addLockedComponent(component);
-    operation.addLockedObject(component.getLockName());
+    operation.addLockedObject(lockName, AtomicOperation.ComponentLockMode.EXCLUSIVE);
   }
 
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -540,7 +540,7 @@ public class AtomicOperationsManager {
       } catch (RuntimeException | Error failure) {
         if (releaseFailure == null) {
           releaseFailure = failure;
-        } else {
+        } else if (releaseFailure != failure) {
           releaseFailure.addSuppressed(failure);
         }
       } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -522,26 +522,44 @@ public class AtomicOperationsManager {
   }
 
   private void releaseLocks(AtomicOperation operation) {
-    // The component list is drained, which makes a second cleanup call idempotent.
+    Throwable releaseFailure = null;
+    // Drain every component even when one release fails, so one broken lock cannot leak the rest.
     var compIter = operation.lockedComponents().iterator();
     while (compIter.hasNext()) {
       var component = compIter.next();
-      final var mode = operation.lockedObjectMode(component.getLockName());
-      if (mode == AtomicOperation.ComponentLockMode.SHARED) {
-        component.unlockShared();
-      } else if (component.isExclusiveOwner()) {
-        // A null mode is treated as exclusive for compatibility with test doubles and
-        // operations created before mode-aware bookkeeping was introduced.
-        component.unlockExclusive();
+      try {
+        final var mode = operation.lockedObjectMode(component.getLockName());
+        if (mode == AtomicOperation.ComponentLockMode.SHARED) {
+          if (component.isSharedOwner()) {
+            component.unlockShared();
+          }
+        } else if (component.isExclusiveOwner()) {
+          // A null mode is treated as exclusive for compatibility with test doubles.
+          component.unlockExclusive();
+        }
+      } catch (RuntimeException | Error failure) {
+        if (releaseFailure == null) {
+          releaseFailure = failure;
+        } else {
+          releaseFailure.addSuppressed(failure);
+        }
+      } finally {
+        compIter.remove();
       }
-      compIter.remove();
     }
 
-    // Clear the combined dedup set.
+    // The mode map is the dedup structure. Draining its key view clears names and modes together.
     var nameIter = operation.lockedObjects().iterator();
     while (nameIter.hasNext()) {
       nameIter.next();
       nameIter.remove();
+    }
+
+    if (releaseFailure instanceof RuntimeException runtimeException) {
+      throw runtimeException;
+    }
+    if (releaseFailure instanceof Error error) {
+      throw error;
     }
   }
 
@@ -552,7 +570,7 @@ public class AtomicOperationsManager {
 
     final var lockName = component.getLockName();
     final var heldMode = operation.lockedObjectMode(lockName);
-    if (heldMode != null || operation.containsInLockedObjects(lockName)) {
+    if (heldMode != null) {
       // Exclusive mode is stronger, while a repeated shared acquisition is idempotent.
       return;
     }
@@ -576,8 +594,7 @@ public class AtomicOperationsManager {
       throw new IllegalStateException(
           "Cannot upgrade component '" + lockName + "' from SHARED to EXCLUSIVE mode");
     }
-    if (heldMode == AtomicOperation.ComponentLockMode.EXCLUSIVE
-        || operation.containsInLockedObjects(lockName)) {
+    if (heldMode == AtomicOperation.ComponentLockMode.EXCLUSIVE) {
       return;
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -126,7 +126,7 @@ public class AtomicOperationsManager {
   }
 
   public void startToApplyOperations(AtomicOperation atomicOperation) {
-    startToApplyOperations(atomicOperation, false, null);
+    startToApplyOperations(atomicOperation, false, null, true);
   }
 
   /**
@@ -139,6 +139,14 @@ public class AtomicOperationsManager {
    */
   public void startToApplyOperations(AtomicOperation atomicOperation, final boolean schemaArmed,
       @Nullable final Supplier<? extends BaseException> schemaGate) {
+    startToApplyOperations(atomicOperation, schemaArmed, schemaGate, false);
+  }
+
+  private void startToApplyOperations(
+      AtomicOperation atomicOperation,
+      final boolean schemaArmed,
+      @Nullable final Supplier<? extends BaseException> schemaGate,
+      final boolean moveToErrorOnFailure) {
     writeOperationsFreezer.startOperation(schemaArmed, schemaGate);
 
     final long activeSegment;
@@ -149,25 +157,61 @@ public class AtomicOperationsManager {
     // could register before a lower-TS one, creating NOT_STARTED gaps that
     // violate Snapshot Isolation's assumption that all TXs below minActiveTs
     // are completed.
-    final long commitTs;
-    segmentLock.exclusiveLock();
+    long commitTs = -1;
+    var operationRegistered = false;
     try {
-      commitTs = idGen.nextId();
-      activeSegment = writeAheadLog.activeSegment();
-      atomicOperationsTable.startOperation(commitTs, activeSegment);
-    } finally {
-      segmentLock.exclusiveUnlock();
-    }
+      segmentLock.exclusiveLock();
+      try {
+        commitTs = idGen.nextId();
+        activeSegment = writeAheadLog.activeSegment();
+        atomicOperationsTable.startOperation(commitTs, activeSegment);
+        operationRegistered = true;
+      } finally {
+        segmentLock.exclusiveUnlock();
+      }
 
-    atomicOperation.startToApplyOperations(commitTs);
+      atomicOperation.startToApplyOperations(commitTs);
+    } catch (RuntimeException | Error startFailure) {
+      // Internal wrappers previously reached endAtomicOperation after start failures. Preserve their
+      // error-state transition. Direct commits previously bypassed that transition for runtime
+      // failures, so their overload performs lifecycle cleanup without broadening storage shutdown.
+      if (moveToErrorOnFailure) {
+        try {
+          storage.moveToErrorStateIfNeeded(startFailure);
+        } catch (RuntimeException | Error cleanupFailure) {
+          if (startFailure != cleanupFailure) {
+            startFailure.addSuppressed(cleanupFailure);
+          }
+        }
+      }
+      if (operationRegistered) {
+        try {
+          atomicOperationsTable.rollbackOperation(commitTs);
+        } catch (RuntimeException | Error cleanupFailure) {
+          if (startFailure != cleanupFailure) {
+            startFailure.addSuppressed(cleanupFailure);
+          }
+        }
+      }
+      try {
+        writeOperationsFreezer.endOperation();
+      } catch (RuntimeException | Error cleanupFailure) {
+        if (startFailure != cleanupFailure) {
+          startFailure.addSuppressed(cleanupFailure);
+        }
+      }
+      throw startFailure;
+    }
   }
 
   public <T> T calculateInsideAtomicOperation(final TxFunction<T> function)
       throws IOException {
     Throwable error = null;
+    var applyStarted = false;
     final var atomicOperation = startAtomicOperation();
     try {
       startToApplyOperations(atomicOperation);
+      applyStarted = true;
       return function.accept(atomicOperation);
     } catch (Exception | AssertionError e) {
       // AssertionError is included so a -ea-only assert thrown from the lambda body
@@ -185,16 +229,20 @@ public class AtomicOperationsManager {
                   + storage.getName()),
           e, storage.getName());
     } finally {
-      endAtomicOperation(atomicOperation, error);
+      if (applyStarted) {
+        endAtomicOperation(atomicOperation, error);
+      }
     }
   }
 
   public void executeInsideAtomicOperation(final TxConsumer consumer)
       throws IOException {
     Throwable error = null;
+    var applyStarted = false;
     final var atomicOperation = startAtomicOperation();
     try {
       startToApplyOperations(atomicOperation);
+      applyStarted = true;
       consumer.accept(atomicOperation);
     } catch (Exception | AssertionError e) {
       // AssertionError is included so a -ea-only assert thrown from the lambda body
@@ -212,7 +260,9 @@ public class AtomicOperationsManager {
                   + storage.getName()),
           e, storage.getName());
     } finally {
-      endAtomicOperation(atomicOperation, error);
+      if (applyStarted) {
+        endAtomicOperation(atomicOperation, error);
+      }
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsTable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsTable.java
@@ -151,9 +151,9 @@ public class AtomicOperationsTable {
   /// - Otherwise → **Visible** (committed between min and max)
   ///
   /// @param minActiveOperationTs the minimum timestamp among all in-progress operations,
-  ///                             or `currentTimestamp + 1` if no operations are active
+  ///                             or the saturated value after `currentTimestamp` if none are active
   /// @param maxActiveOperationTs the maximum timestamp among all in-progress operations,
-  ///                             or `currentTimestamp + 1` if no operations are active
+  ///                             or the saturated value after `currentTimestamp` if none are active
   /// @param inProgressTxs        set of timestamps for all currently in-progress transactions
   /// @param snapshotTs            the timestamp at which this snapshot was taken (the last
   ///                             registered operation ID); any record with a timestamp above
@@ -299,12 +299,13 @@ public class AtomicOperationsTable {
 
       final boolean hasActiveOps = (maxOp != Long.MIN_VALUE);
 
-      // No active operations: everything at or below currentTimestamp is visible,
-      // everything above is not. We always check if an entry version equals
-      // currentTimestamp so a thread can read its own writes.
+      // No active operations: everything at or below currentTimestamp is visible. Saturate the
+      // fast-path boundary because Long.MAX_VALUE has no signed successor.
       if (!hasActiveOps) {
-        maxOp = currentTimestamp + 1;
-        minOp = currentTimestamp + 1;
+        final var visibilityBoundary =
+            currentTimestamp == Long.MAX_VALUE ? Long.MAX_VALUE : currentTimestamp + 1;
+        maxOp = visibilityBoundary;
+        minOp = visibilityBoundary;
       }
 
       assert !hasActiveOps || minOp <= maxOp : "min must be <= max";

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -127,6 +127,16 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     return lockName;
   }
 
+  /** Acquires the shared lock on this component for use by {@link AtomicOperationsManager}. */
+  public void lockShared() {
+    acquireSharedLock();
+  }
+
+  /** Releases the shared lock on this component. */
+  public void unlockShared() {
+    releaseSharedLock();
+  }
+
   /**
    * Acquires the exclusive lock on this component for use by
    * {@link AtomicOperationsManager}. Delegates to the protected

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/IdentifiableMultiValueTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/IdentifiableMultiValueTest.java
@@ -3,12 +3,18 @@ package com.jetbrains.youtrackdb.internal.common.collection;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -76,6 +82,55 @@ public class IdentifiableMultiValueTest {
     Assert.assertEquals(2, collection.size());
     Assert.assertEquals("foo", collection.get(0));
     Assert.assertEquals("baz", collection.get(1));
+  }
+
+  /** The error message reports only the container class without reading its size or elements. */
+  @Test
+  public void readErrorMessageNamesContainerClassWithoutSizeOrElements() {
+    var collection = new ArrayList<>(List.of("secret-element", "other-element"));
+
+    var message = MultiValue.readErrorMessage("indexed", collection);
+
+    Assert.assertEquals(
+        "Error on reading the indexed item of the Multi-value container java.util.ArrayList",
+        message);
+    Assert.assertFalse(message.contains("size="));
+    Assert.assertFalse(message.contains("secret-element"));
+    Assert.assertFalse(message.contains("other-element"));
+  }
+
+  /** The read-error call site logs the container class without formatting an element. */
+  @Test
+  public void readErrorLogNamesContainerClassWithoutElementText() {
+    var records = new CopyOnWriteArrayList<LogRecord>();
+    var logger = Logger.getLogger(MultiValue.class.getName());
+    var previousLevel = logger.getLevel();
+    var handler = new CapturingHandler(records);
+    handler.setLevel(Level.ALL);
+    logger.addHandler(handler);
+    logger.setLevel(Level.ALL);
+    try {
+      Assert.assertNull(MultiValue.getValue(new ExplodingList(), 0));
+    } finally {
+      logger.removeHandler(handler);
+      logger.setLevel(previousLevel);
+    }
+
+    var message =
+        records.stream()
+            .map(LogRecord::getMessage)
+            .filter(recordMessage -> recordMessage.contains("Error on reading the indexed item"))
+            .findFirst()
+            .orElse(null);
+    Assert.assertNotNull(message);
+    Assert.assertTrue(message.contains(ExplodingList.class.getName()));
+    Assert.assertFalse(message.contains("secret-element"));
+  }
+
+  /** The container summary catches runtime failures while reading class metadata. */
+  @Test
+  public void containerSummaryUsesPlaceholderForNullContainer() {
+    Assert.assertEquals("<unavailable>", MultiValue.containerSummary(null));
   }
 
   @Test
@@ -370,6 +425,41 @@ public class IdentifiableMultiValueTest {
    * Stub that implements both Iterable and Identifiable — used to verify that isMultiValue returns
    * false for such types (a record that happens to be iterable is not a multi-value collection).
    */
+  private static final class CapturingHandler extends Handler {
+
+    private final List<LogRecord> records;
+
+    private CapturingHandler(List<LogRecord> records) {
+      this.records = records;
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  private static final class ExplodingList extends AbstractList<String> {
+
+    @Override
+    public String get(int index) {
+      throw new IllegalStateException("secret-element");
+    }
+
+    @Override
+    public int size() {
+      return 1;
+    }
+  }
+
   private static class IdentifiableIterable
       implements Iterable<Object>, Identifiable {
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLockTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/lock/ScalableRWLockTest.java
@@ -233,6 +233,66 @@ public class ScalableRWLockTest {
     lock.exclusiveUnlock();
   }
 
+  /** The write-owner predicate follows normal acquisition and release on the current thread. */
+  @Test
+  public void writeOwnerPredicateTracksAcquireAndRelease() {
+    final var lock = new ScalableRWLock();
+
+    assertFalse(lock.isWriteLockedByCurrentThread());
+    lock.exclusiveLock();
+    assertTrue(lock.isWriteLockedByCurrentThread());
+    lock.exclusiveUnlock();
+    assertFalse(lock.isWriteLockedByCurrentThread());
+  }
+
+  /** The write-owner predicate is false on a thread that does not own the held write mode. */
+  @Test
+  public void writeOwnerPredicateIdentifiesOnlyCurrentThread() throws Exception {
+    final var lock = new ScalableRWLock();
+    final var otherThreadOwnsWriteMode = new AtomicBoolean(true);
+
+    lock.exclusiveLock();
+    var observer =
+        new Thread(
+            () -> otherThreadOwnsWriteMode.set(lock.isWriteLockedByCurrentThread()));
+    observer.start();
+    observer.join(5_000);
+    try {
+      assertFalse(observer.isAlive());
+      assertFalse(otherThreadOwnsWriteMode.get());
+    } finally {
+      lock.exclusiveUnlock();
+    }
+  }
+
+  /** A failed immediate write attempt clears current-thread ownership. */
+  @Test
+  public void failedImmediateWriteAttemptClearsOwner() {
+    final var lock = new ScalableRWLock();
+
+    lock.sharedLock();
+    try {
+      assertFalse(lock.exclusiveTryLock());
+      assertFalse(lock.isWriteLockedByCurrentThread());
+    } finally {
+      lock.sharedUnlock();
+    }
+  }
+
+  /** A timed write attempt clears current-thread ownership after its reader drain expires. */
+  @Test
+  public void expiredTimedWriteAttemptClearsOwner() throws Exception {
+    final var lock = new ScalableRWLock();
+
+    lock.sharedLock();
+    try {
+      assertFalse(lock.exclusiveTryLockNanos(TimeUnit.MILLISECONDS.toNanos(1)));
+      assertFalse(lock.isWriteLockedByCurrentThread());
+    } finally {
+      lock.sharedUnlock();
+    }
+  }
+
   /**
    * Verifies that a writer blocks while a reader holds the lock, and proceeds once the reader
    * releases it.
@@ -333,9 +393,14 @@ public class ScalableRWLockTest {
     lock.exclusiveLock(); // the competing writer holds the bit for the whole phase-1 park
     final var abort = new AtomicBoolean(false);
     final var result = new AtomicReference<Boolean>();
-    final var waiter = new Thread(
-        () -> result.set(
-            lock.exclusiveLockWithAbort(abort::get, TimeUnit.MILLISECONDS.toNanos(5))));
+    final var ownsWriteModeAfterAbort = new AtomicBoolean(true);
+    final var waiter =
+        new Thread(
+            () -> {
+              result.set(
+                  lock.exclusiveLockWithAbort(abort::get, TimeUnit.MILLISECONDS.toNanos(5)));
+              ownsWriteModeAfterAbort.set(lock.isWriteLockedByCurrentThread());
+            });
     waiter.setDaemon(true);
     waiter.start();
     try {
@@ -350,6 +415,8 @@ public class ScalableRWLockTest {
     waiter.join(5_000);
     assertFalse("the aborted waiter must exit promptly (one poll granularity)", waiter.isAlive());
     assertEquals("the aborted acquisition must return false", Boolean.FALSE, result.get());
+    assertFalse(
+        "the aborted waiter must not retain write ownership", ownsWriteModeAfterAbort.get());
     assertTrue("the competing writer's bit must be untouched by the abort", lock.isWriteLocked());
 
     lock.exclusiveUnlock();
@@ -386,12 +453,18 @@ public class ScalableRWLockTest {
 
     final var abort = new AtomicBoolean(false);
     final var result = new AtomicReference<Boolean>();
+    final var ownsWriteModeAfterAbort = new AtomicBoolean(true);
     try {
       assertTrue("the residual reader must be inside", readerIn.await(5, TimeUnit.SECONDS));
 
-      final var writer = new Thread(
-          () -> result.set(
-              lock.exclusiveLockWithAbort(abort::get, TimeUnit.MILLISECONDS.toNanos(5))));
+      final var writer =
+          new Thread(
+              () -> {
+                result.set(
+                    lock.exclusiveLockWithAbort(
+                        abort::get, TimeUnit.MILLISECONDS.toNanos(5)));
+                ownsWriteModeAfterAbort.set(lock.isWriteLockedByCurrentThread());
+              });
       writer.setDaemon(true);
       writer.start();
       // The writer acquires the bit once and enters the drain spin against the parked reader.
@@ -403,6 +476,9 @@ public class ScalableRWLockTest {
       assertFalse("the aborted drain must exit promptly", writer.isAlive());
       assertEquals("the aborted acquisition must return false", Boolean.FALSE, result.get());
       assertFalse("the abort must release the write bit fully", lock.isWriteLocked());
+      assertFalse(
+          "the drain abort must clear current-thread ownership",
+          ownsWriteModeAfterAbort.get());
       // Readers proceed after the abort: a fresh shared acquire succeeds while the residual
       // reader is still inside (no reader stranded, no lost wakeup — readers poll the released
       // bit).
@@ -442,6 +518,9 @@ public class ScalableRWLockTest {
         + " a different count means the scenario drifted off the edge",
         2, calls.get());
     assertFalse("the success-edge abort must release the write bit", lock.isWriteLocked());
+    assertFalse(
+        "the success-edge abort must clear current-thread ownership",
+        lock.isWriteLockedByCurrentThread());
     // Reusable immediately.
     assertTrue(lock.exclusiveLockWithAbort(() -> false, TimeUnit.MILLISECONDS.toNanos(10)));
     lock.exclusiveUnlock();
@@ -668,6 +747,9 @@ public class ScalableRWLockTest {
     }
     assertFalse("the write bit must be released before the predicate failure propagates",
         lock.isWriteLocked());
+    assertFalse(
+        "the failed acquisition must clear current-thread write ownership",
+        lock.isWriteLockedByCurrentThread());
     assertTrue("readers must be admitted after the failed acquisition", lock.sharedTryLock());
     lock.sharedUnlock();
     assertTrue("the primitive must be reusable after the failed acquisition",
@@ -702,9 +784,10 @@ public class ScalableRWLockTest {
       assertTrue("the residual reader must be inside", readerIn.await(5, TimeUnit.SECONDS));
 
       final var thrown = new AtomicReference<Throwable>();
+      final var ownsWriteModeAfterFailure = new AtomicBoolean(true);
       final var writer = new Thread(() -> {
         try {
-          // Phase 1 poll returns false; the drain poll against the parked reader throws.
+          // Phase 1 poll returns false. The drain poll against the parked reader throws.
           final var calls = new AtomicInteger();
           lock.exclusiveLockWithAbort(() -> {
             if (calls.incrementAndGet() >= 2) {
@@ -714,6 +797,7 @@ public class ScalableRWLockTest {
           }, TimeUnit.MILLISECONDS.toNanos(10));
         } catch (Throwable t) {
           thrown.set(t);
+          ownsWriteModeAfterFailure.set(lock.isWriteLockedByCurrentThread());
         }
       });
       writer.setDaemon(true);
@@ -726,6 +810,9 @@ public class ScalableRWLockTest {
               && thrown.get().getMessage().contains("forced drain-poll predicate failure"));
       assertFalse("the write bit must be released before the predicate failure propagates",
           lock.isWriteLocked());
+      assertFalse(
+          "the drain failure must clear current-thread ownership",
+          ownsWriteModeAfterFailure.get());
       assertTrue("a fresh reader must be admitted after the failed acquisition",
           lock.sharedTryLock());
       lock.sharedUnlock();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/io/FileUtilsDurableAtomicMoveTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/io/FileUtilsDurableAtomicMoveTest.java
@@ -1,20 +1,31 @@
 package com.jetbrains.youtrackdb.internal.common.io;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.sun.jna.Native;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Pins {@link FileUtils#durableAtomicMove} (the CS40 promote recipe): the source replaces a
- * pre-existing target atomically and disappears; a fresh target is created likewise. The fsync
- * legs are not black-box observable — the recipe's ordering is the reviewed contract.
+ * Pins the CS40 recipe in {@link FileUtils#durableAtomicMove}.
+ * The source atomically replaces an existing target and then disappears.
+ * A fresh target follows the same recipe.
+ * Each supported platform runs its production durability mechanism in these tests.
  */
 public class FileUtilsDurableAtomicMoveTest {
 
@@ -27,12 +38,22 @@ public class FileUtilsDurableAtomicMoveTest {
 
   @After
   public void tearDown() throws IOException {
-    try (var files = Files.list(directory)) {
-      for (var file : files.toList()) {
-        Files.deleteIfExists(file);
+    if (Files.notExists(directory)) {
+      return;
+    }
+    try (var files = Files.walk(directory)) {
+      try {
+        files.sorted(Comparator.reverseOrder()).forEach(file -> {
+          try {
+            Files.deleteIfExists(file);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
       }
     }
-    Files.deleteIfExists(directory);
   }
 
   @Test
@@ -50,6 +71,235 @@ public class FileUtilsDurableAtomicMoveTest {
     assertTrue("the source must be gone after the move", Files.notExists(source));
   }
 
+  /** A required Unix directory barrier failure is reported after the atomic replacement. */
+  @Test
+  public void directoryBarrierFailureIsReported() throws IOException {
+    var source = directory.resolve("barrier-source.tmp");
+    var target = directory.resolve("barrier-target.gz");
+    Files.write(source, "PAYLOAD".getBytes(StandardCharsets.UTF_8));
+
+    var failure =
+        assertThrows(
+            IOException.class,
+            () -> FileUtils.durableAtomicMove(
+                source,
+                target,
+                false,
+                ignored -> {
+                  throw new IOException("injected directory barrier failure");
+                }));
+
+    assertTrue(failure.getMessage().contains("injected directory barrier failure"));
+  }
+
+  /**
+   * An unavailable native helper uses the portable move and records one warning. The target must
+   * contain the source payload after the fallback.
+   */
+  @Test
+  public void unavailableWindowsNativeHelperUsesPortableMove() throws IOException {
+    var source = directory.resolve("fallback-source.tmp");
+    var target = directory.resolve("fallback-target.bin");
+    var payload = "FALLBACK-PAYLOAD".getBytes(StandardCharsets.UTF_8);
+    Files.write(source, payload);
+    Files.write(target, "OLD".getBytes(StandardCharsets.UTF_8));
+    var loadFailure = new UnsatisfiedLinkError("missing native helper");
+    var warningCount = new AtomicInteger();
+
+    FileUtils.durableAtomicMove(
+        source,
+        target,
+        this,
+        true,
+        ignored -> {
+          throw new AssertionError("the Unix directory barrier must not run");
+        },
+        FileUtils.WindowsMoveBinding.unavailable(loadFailure),
+        FileUtils::portableWindowsMove,
+        (ignored, message, failure) -> {
+          assertTrue(message.contains("native helper"));
+          assertTrue(message.contains("crash-atomic guarantee is not available"));
+          assertSame(loadFailure, failure);
+          warningCount.incrementAndGet();
+        },
+        new AtomicBoolean());
+
+    assertArrayEquals(payload, Files.readAllBytes(target));
+    assertTrue(Files.notExists(source));
+    assertEquals(1, warningCount.get());
+  }
+
+  /** Both native loading and portable movement causes remain visible when fallback also fails. */
+  @Test
+  public void unavailableWindowsNativeHelperAndPortableFailureNameBothCauses()
+      throws IOException {
+    var source = directory.resolve("failed-fallback-source.tmp");
+    var target = directory.resolve("failed-fallback-target.bin");
+    Files.write(source, "PAYLOAD".getBytes(StandardCharsets.UTF_8));
+    var loadFailure = new UnsatisfiedLinkError("missing native helper cause");
+    var portableFailure = new IOException("portable move cause");
+
+    var failure =
+        assertThrows(
+            IOException.class,
+            () -> FileUtils.durableAtomicMove(
+                source,
+                target,
+                this,
+                true,
+                ignored -> {
+                  throw new AssertionError("the Unix directory barrier must not run");
+                },
+                FileUtils.WindowsMoveBinding.unavailable(loadFailure),
+                (ignoredSource, ignoredTarget, ignoredRequester) -> {
+                  throw portableFailure;
+                },
+                (ignoredRequester, ignoredMessage, ignoredFailure) -> {
+                },
+                new AtomicBoolean()));
+
+    assertTrue(failure.getMessage().contains("missing native helper cause"));
+    assertTrue(failure.getMessage().contains("portable move cause"));
+    assertSame(portableFailure, failure.getCause());
+    assertEquals(1, failure.getSuppressed().length);
+    assertSame(loadFailure, failure.getSuppressed()[0]);
+  }
+
+  /** A plain error from native-helper loading becomes the memorized fallback result. */
+  @Test
+  public void plainNativeLoadErrorCannotEscape() {
+    var loadFailure = new Error("incompatible native helper version");
+
+    var binding =
+        FileUtils.loadWindowsMoveBinding(() -> {
+          throw loadFailure;
+        });
+
+    assertSame(loadFailure, binding.loadFailure());
+    assertEquals(null, binding.nativeMove());
+  }
+
+  /** One process-level warning guard suppresses duplicate warnings across fallback moves. */
+  @Test
+  public void unavailableWindowsNativeHelperWarnsOnceAcrossSeveralCalls() throws IOException {
+    var loadFailure = new NoClassDefFoundError("missing native helper");
+    var warningRecorded = new AtomicBoolean();
+    var warningCount = new AtomicInteger();
+
+    for (var index = 0; index < 3; index++) {
+      var source = directory.resolve("repeated-source-" + index + ".tmp");
+      var target = directory.resolve("repeated-target-" + index + ".bin");
+      Files.write(source, ("payload-" + index).getBytes(StandardCharsets.UTF_8));
+      FileUtils.durableAtomicMove(
+          source,
+          target,
+          this,
+          true,
+          ignored -> {
+            throw new AssertionError("the Unix directory barrier must not run");
+          },
+          FileUtils.WindowsMoveBinding.unavailable(loadFailure),
+          FileUtils::portableWindowsMove,
+          (ignored, message, failure) -> warningCount.incrementAndGet(),
+          warningRecorded);
+      assertTrue(Files.exists(target));
+    }
+
+    assertEquals(1, warningCount.get());
+  }
+
+  /**
+   * Windows path conversion preserves relative and device paths. It extends drive and UNC paths
+   * so native replacement does not depend on the legacy path-length setting.
+   */
+  @Test
+  public void windowsNativePathsPreserveMeaningAndEnableLongPaths() {
+    assertEquals("relative\\file.tmp", FileUtils.toWindowsNativePath("relative\\file.tmp"));
+    assertEquals("C:relative\\file.tmp", FileUtils.toWindowsNativePath("C:relative\\file.tmp"));
+    assertEquals("\\\\?\\C:\\data\\file.tmp",
+        FileUtils.toWindowsNativePath("C:\\data\\file.tmp"));
+    assertEquals("\\\\?\\UNC\\server\\share\\file.tmp",
+        FileUtils.toWindowsNativePath("\\\\server\\share\\file.tmp"));
+    assertEquals("\\\\?\\C:\\data\\file.tmp",
+        FileUtils.toWindowsNativePath("\\\\?\\C:\\data\\file.tmp"));
+    assertEquals("\\\\?\\UNC\\server\\share\\file.tmp",
+        FileUtils.toWindowsNativePath("\\\\?\\UNC\\server\\share\\file.tmp"));
+    assertEquals("\\\\.\\PhysicalDrive0",
+        FileUtils.toWindowsNativePath("\\\\.\\PhysicalDrive0"));
+  }
+
+  /** Ordinary drive and UNC paths resolve dot segments before entering the extended namespace. */
+  @Test
+  public void windowsNativePathsNormalizeDotSegmentsBeforePrefixing() {
+    assertEquals("\\\\?\\C:\\data\\final.tmp",
+        FileUtils.toWindowsNativePath("C:\\data\\work\\..\\.\\final.tmp"));
+    assertEquals("\\\\?\\C:\\final.tmp",
+        FileUtils.toWindowsNativePath("C:\\..\\final.tmp"));
+    assertEquals("\\\\?\\UNC\\server\\share\\final.tmp",
+        FileUtils.toWindowsNativePath("\\\\server\\share\\work\\..\\.\\final.tmp"));
+    assertEquals("\\\\?\\C:\\data\\..\\literal.tmp",
+        FileUtils.toWindowsNativePath("\\\\?\\C:\\data\\..\\literal.tmp"));
+  }
+
+  /** The selected JNA artifact contains native dispatch support for Windows ARM64. */
+  @Test
+  public void jnaContainsWindowsArm64Dispatcher() {
+    assertNotNull(
+        "JNA must contain the Windows ARM64 native dispatcher",
+        Native.class.getResource("/com/sun/jna/win32-aarch64/jnidispatch.dll"));
+  }
+
+  /**
+   * On Windows, an available long-path file system performs the real write-through replacement.
+   * This checks API behavior only. It does not simulate power loss or certify physical durability.
+   */
+  @Test
+  public void windowsLongPathMoveReplacesExistingTarget() throws IOException {
+    Assume.assumeTrue("Windows-only native replacement test", IOUtils.isOsWindows());
+    var deepDirectory = directory;
+    while (deepDirectory.toAbsolutePath().toString().length() < 280) {
+      deepDirectory = deepDirectory.resolve("long-path-segment");
+    }
+    try {
+      Files.createDirectories(deepDirectory);
+    } catch (IOException | UnsupportedOperationException e) {
+      Assume.assumeNoException("The test environment does not support long paths", e);
+    }
+
+    var source = deepDirectory.resolve("source.tmp");
+    var target = deepDirectory.resolve("target.bin");
+    var payload = "LONG-PATH-PAYLOAD".getBytes(StandardCharsets.UTF_8);
+    Files.write(source, payload);
+    Files.write(target, "OLD".getBytes(StandardCharsets.UTF_8));
+
+    FileUtils.durableAtomicMove(source, target, this);
+
+    assertArrayEquals(payload, Files.readAllBytes(target));
+    assertTrue(Files.notExists(source));
+  }
+
+  /**
+   * On Windows, ordinary dot-segment paths keep their meaning during native replacement. This
+   * checks functional API behavior only. It does not simulate power loss.
+   */
+  @Test
+  public void windowsDotSegmentMoveReplacesIntendedTarget() throws IOException {
+    Assume.assumeTrue("Windows-only native replacement test", IOUtils.isOsWindows());
+    var sourceIntermediate = Files.createDirectory(directory.resolve("source-intermediate"));
+    var targetIntermediate = Files.createDirectory(directory.resolve("target-intermediate"));
+    var source = sourceIntermediate.resolve("..").resolve("source.tmp");
+    var target = targetIntermediate.resolve("..").resolve("target.bin");
+    var payload = "DOT-SEGMENT-PAYLOAD".getBytes(StandardCharsets.UTF_8);
+    Files.write(directory.resolve("source.tmp"), payload);
+    Files.write(directory.resolve("target.bin"), "OLD".getBytes(StandardCharsets.UTF_8));
+
+    FileUtils.durableAtomicMove(source, target, this);
+
+    assertArrayEquals(payload, Files.readAllBytes(directory.resolve("target.bin")));
+    assertTrue(Files.notExists(directory.resolve("source.tmp")));
+  }
+
+  /** A supported platform creates and durably publishes a previously absent target. */
   @Test
   public void moveCreatesAbsentTarget() throws IOException {
     var source = directory.resolve("source.tmp");

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/GenesisFailureContainmentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/GenesisFailureContainmentTest.java
@@ -13,6 +13,7 @@ import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.config.YouTrackDBConfig;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
 import com.jetbrains.youtrackdb.internal.core.exception.GenesisIncompleteException;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
 import com.jetbrains.youtrackdb.internal.core.tx.Transaction;
@@ -256,17 +257,27 @@ public class GenesisFailureContainmentTest {
     assertFalse(youTrackDB.exists(dbName));
   }
 
+  /**
+   * Asserts the named inconsistent-metadata result of the genesis consistency check.
+   *
+   * <p>Track 24 turned the later genesis check into a consistency check. The check compares the
+   * accepted lifecycle state against the genesis marker of the storage configuration. The check
+   * reports the genesis marker value of the named inconsistent-metadata result.
+   */
   private static void assertGenesisRefusal(RuntimeException failure) {
-    GenesisIncompleteException refusal = null;
+    InconsistentStorageMetadataException refusal = null;
     for (Throwable t = failure; t != null; t = t.getCause()) {
-      if (t instanceof GenesisIncompleteException g) {
+      if (t instanceof InconsistentStorageMetadataException g) {
         refusal = g;
         break;
       }
     }
-    assertNotNull("the refusal must be the genesis-completion check, saw: " + failure, refusal);
+    assertNotNull("the refusal must be the genesis consistency check, saw: " + failure, refusal);
+    assertEquals("the result must name the genesis marker source, saw: " + refusal.inconsistency(),
+        InconsistentStorageMetadataException.Inconsistency.GENESIS_MARKER,
+        refusal.inconsistency());
     assertTrue("the refusal must prescribe discard-and-recreate, saw: " + refusal.getMessage(),
-        refusal.getMessage().contains("did not run to completion"));
+        refusal.getMessage().contains("never ran to completion"));
   }
 
   /**
@@ -354,10 +365,16 @@ public class GenesisFailureContainmentTest {
       youTrackDB.open(dbName, "admin", ADMIN_PASSWORD);
       fail("an old-format database must be rejected");
     } catch (RuntimeException e) {
+      // Track 24 keeps the present expectation of this fixture. The fixture mutates two durable
+      // sources, because the fixture rewrites the schema version and removes the genesis marker.
+      // The schema version gate of the schema load therefore throws before the genesis
+      // consistency check runs. The assertion below covers the old refusal type and the new
+      // inconsistent-metadata result, so the fixture keeps guarding the same order.
       ConfigurationException redirect = null;
       for (Throwable t = e; t != null; t = t.getCause()) {
         assertFalse("the genesis refusal must NOT pre-empt the version gate (CS52), saw: " + e,
-            t instanceof GenesisIncompleteException);
+            t instanceof GenesisIncompleteException
+                || t instanceof InconsistentStorageMetadataException);
         if (t instanceof ConfigurationException c) {
           redirect = c;
         }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/StorageBirthActivationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/StorageBirthActivationTest.java
@@ -1,0 +1,699 @@
+package com.jetbrains.youtrackdb.internal.core.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.config.YouTrackDBConfig;
+import com.jetbrains.youtrackdb.internal.core.exception.GenesisIncompleteException;
+import com.jetbrains.youtrackdb.internal.core.storage.disk.DiskStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.StorageBirthTestSupport;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
+import com.jetbrains.youtrackdb.internal.core.storage.memory.DirectMemoryStorage;
+import com.jetbrains.youtrackdb.internal.core.tx.Transaction;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the delayed publication of the active lifecycle state of Track 24.
+ *
+ * <p>Storage birth is the creation of a new storage image. Genesis is the creation of the initial
+ * database metadata. Genesis creates the schema, the index manager, the index statistics, and the
+ * default users. Storage admission is the decision that accepts an existing storage image for use.
+ *
+ * <p>Each test of this class states one scenario and one expected outcome in its own comment.
+ */
+public class StorageBirthActivationTest {
+
+  private static final String ADMIN = "admin";
+  private static final String PASSWORD = "adminpwd";
+  private static final String LOCK_FILE_NAME = "storage-bootstrap.bsml";
+
+  private Path directory;
+
+  @Before
+  public void createDirectory() throws Exception {
+    directory = Files.createTempDirectory("storage-birth-activation-");
+  }
+
+  @After
+  public void deleteDirectory() {
+    FileUtils.deleteRecursively(directory.toFile());
+  }
+
+  /**
+   * The active lifecycle state appears only after genesis finished.
+   *
+   * <p>The scenario probes storage admission from inside every genesis commit of one disk
+   * creation. The expected outcome has three parts. Every probe during genesis reports the
+   * interrupted-birth reason. The finished creation carries the active lifecycle state. A later
+   * open of the same database succeeds.
+   */
+  @Test
+  public void activeStateAppearsOnlyAfterGenesisFinished() throws Exception {
+    var databaseName = "delayedActivation";
+    var probe = new AdmissionProbeListener(directory.resolve(databaseName));
+
+    try (var youTrackDB = openManager()) {
+      youTrackDB.create(
+          databaseName, DatabaseType.DISK, listenerConfig(probe), ADMIN, PASSWORD, ADMIN);
+
+      // The recorded list holds one entry per commit of the creating session. The genesis
+      // commits come first and must report the interrupted-birth reason. The user-creation
+      // commit of the create call follows the activation and must report an accepted image.
+      assertTrue(
+          "genesis must run at least one commit that the probe can observe",
+          probe.observedReasons.size() > 0);
+      assertEquals(
+          "the first genesis commit must run while the image is still inadmissible",
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+          probe.observedReasons.get(0));
+      var acceptedSeen = false;
+      for (var reason : probe.observedReasons) {
+        if (reason == null) {
+          acceptedSeen = true;
+          continue;
+        }
+        assertEquals(
+            "a rejection must never follow the activation",
+            false,
+            acceptedSeen);
+        assertEquals(
+            "every probe before the activation must report the interrupted-birth reason",
+            StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+            reason);
+      }
+      assertEquals(
+          "the finished creation must publish the active lifecycle state",
+          StorageBootstrapMetadata.State.ACTIVE,
+          authority(databaseName).readActiveRequired().state());
+    }
+
+    // A clean creation stays openable after the activation moved behind genesis.
+    try (var youTrackDB = openManager();
+        var session = youTrackDB.open(databaseName, ADMIN, PASSWORD)) {
+      assertTrue(session.getMetadata().getSchema().existsClass("OUser"));
+    }
+  }
+
+  /**
+   * A crash-like interruption between two genesis steps leaves an inadmissible image.
+   *
+   * <p>The scenario copies the storage directory during one genesis commit. That copy is the image
+   * that a crash between two genesis steps leaves behind. The expected outcome has three parts.
+   * The copy fails every open with the interrupted-birth reason. The copy stays visible to the
+   * existence probe. A clean creation under another name still opens.
+   */
+  @Test
+  public void interruptedGenesisImageStaysInadmissible() throws Exception {
+    var crashName = "interruptedGenesis";
+    createCrashCopy("genesisSource", crashName);
+
+    try (var youTrackDB = openManager()) {
+      assertTrue("the incomplete image must stay visible", youTrackDB.exists(crashName));
+      var failure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(crashName, ADMIN, PASSWORD));
+      assertEquals(
+          "the incomplete image must be rejected with the interrupted-birth reason",
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+          admissionReason(failure));
+
+      // A second open repeats the same rejection, so the image stays permanently inadmissible.
+      var secondFailure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(crashName, ADMIN, PASSWORD));
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH, admissionReason(secondFailure));
+
+      youTrackDB.create("cleanAfterCrash", DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+      try (var session = youTrackDB.open("cleanAfterCrash", ADMIN, PASSWORD)) {
+        assertTrue(session.getMetadata().getSchema().existsClass("OUser"));
+      }
+    }
+  }
+
+  /**
+   * Drop tolerates the interrupted-birth reason and deletes the incomplete image.
+   *
+   * <p>The scenario drops the copy of an interrupted genesis. The expected outcome has two parts.
+   * The drop reports no failure. The image is gone afterwards.
+   */
+  @Test
+  public void dropDeletesInterruptedBirthImageWithoutFailure() throws Exception {
+    var crashName = "dropInterruptedBirth";
+    createCrashCopy("dropSource", crashName);
+
+    try (var youTrackDB = openManager()) {
+      youTrackDB.drop(crashName);
+
+      assertFalse("the incomplete image must be gone after the drop", youTrackDB.exists(crashName));
+      assertEquals(
+          "the drop must leave no bootstrap authority artifact behind",
+          Set.of(),
+          bootstrapArtifactNames(directory.resolve(crashName)));
+    }
+  }
+
+  /**
+   * Drop stays loud for an admission reason other than the interrupted birth.
+   *
+   * <p>The scenario replaces the authority lock file of a complete image with a directory. Storage
+   * admission then reports the non-regular-authority-file reason. The expected outcome is a failed
+   * drop that names that reason.
+   */
+  @Test
+  public void dropStaysLoudForAnotherAdmissionReason() throws Exception {
+    var databaseName = "loudDrop";
+    try (var youTrackDB = openManager()) {
+      youTrackDB.create(databaseName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+    }
+    var lockPath = directory.resolve(databaseName).resolve(LOCK_FILE_NAME);
+    Files.deleteIfExists(lockPath);
+    Files.createDirectory(lockPath);
+
+    try (var youTrackDB = openManager()) {
+      var failure = assertThrows(RuntimeException.class, () -> youTrackDB.drop(databaseName));
+
+      assertEquals(
+          "an unrelated admission reason must still reach the operator",
+          StorageAdmissionException.Reason.NON_REGULAR_AUTHORITY_FILE,
+          admissionReason(failure));
+    }
+  }
+
+  /**
+   * The create-if-absent path keeps its tailored explanation for an incomplete image.
+   *
+   * <p>The tolerant create is the create call that accepts an existing database. The scenario
+   * calls the tolerant create over the copy of an interrupted genesis. The expected outcome has
+   * five parts. The call fails with the genesis-incomplete refusal. The refusal names the
+   * interrupted-birth reason. The refusal names the interrupted creation as one cause. The
+   * refusal names damaged authority records of a complete database as the other cause. The
+   * refusal offers a backup restore beside the drop, and the image stays droppable.
+   *
+   * <p>The last three parts matter, because damaged authority records of a complete database
+   * reach the same refusal. A refusal that prescribes only the drop would then advise the
+   * destruction of real data.
+   */
+  @Test
+  public void createIfNotExistsReportsTailoredExplanationForInterruptedBirth() throws Exception {
+    var crashName = "tolerantCreateInterruptedBirth";
+    createCrashCopy("tolerantCreateSource", crashName);
+
+    try (var youTrackDB = openManager()) {
+      var internal = (YouTrackDBInternalEmbedded) youTrackDB.internal;
+      try {
+        youTrackDB.createIfNotExists(crashName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+        fail("the tolerant create must refuse an image whose genesis never finished");
+      } catch (RuntimeException failure) {
+        GenesisIncompleteException refusal = null;
+        for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+          if (cause instanceof GenesisIncompleteException incomplete) {
+            refusal = incomplete;
+            break;
+          }
+        }
+        assertNotNull("the refusal must be the tailored genesis-incomplete refusal", refusal);
+        assertTrue(
+            "the refusal must name the interrupted-birth reason, saw: " + refusal.getMessage(),
+            refusal.getMessage().contains("interrupted-birth reason"));
+        assertTrue(
+            "the refusal must name the interrupted creation as one cause, saw: "
+                + refusal.getMessage(),
+            refusal.getMessage().contains("An interrupted creation produces this state."));
+        assertTrue(
+            "the refusal must name damaged authority records as the other cause, saw: "
+                + refusal.getMessage(),
+            refusal
+                .getMessage()
+                .contains("Damaged bootstrap authority records of a complete database"));
+        assertTrue(
+            "the refusal must offer a backup restore, saw: " + refusal.getMessage(),
+            refusal.getMessage().contains("A backup restores a complete database."));
+        assertTrue(
+            "the refusal must still offer the drop, saw: " + refusal.getMessage(),
+            refusal.getMessage().contains("A drop removes a database"));
+      }
+
+      assertEquals(
+          "the refused image must leave no storage registration behind",
+          null,
+          internal.getStorage(crashName));
+      youTrackDB.drop(crashName);
+      assertFalse(youTrackDB.exists(crashName));
+    }
+  }
+
+  /**
+   * A refused open frees the storage identifier of the refused image.
+   *
+   * <p>Every storage carries one storage identifier, and the manager keeps every live identifier
+   * in one static set. A refused open discards the storage, so the identifier of that storage
+   * must return to the pool of free identifiers. The scenario refuses forty tolerant creations
+   * over the copy of an interrupted genesis. The expected outcome is a growth of the identifier
+   * set far below the number of refused creations.
+   *
+   * <p>The identifier set is static and the test runner runs four test classes at once, so a
+   * database of another test class can enter and leave the set during this test. The assertion
+   * therefore uses a generous noise bound instead of an exact count. A retained identifier per
+   * refused creation would add forty entries, which the bound below still catches.
+   */
+  @Test
+  public void refusedOpenFreesTheStorageIdentifier() throws Exception {
+    var crashName = "identifierInterruptedBirth";
+    var refusedCreations = 40;
+    var concurrencyNoiseBound = 20;
+    createCrashCopy("identifierSource", crashName);
+
+    try (var youTrackDB = openManager()) {
+      var identifierCountBefore = liveStorageIdentifierCount();
+
+      for (var attempt = 0; attempt < refusedCreations; attempt++) {
+        assertThrows(
+            RuntimeException.class,
+            () -> youTrackDB.createIfNotExists(
+                crashName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN));
+      }
+
+      var growth = liveStorageIdentifierCount() - identifierCountBefore;
+      assertTrue(
+          "every refused open must free the storage identifier of the refused image, saw a"
+              + " growth of "
+              + growth
+              + " identifiers over "
+              + refusedCreations
+              + " refused creations",
+          growth < concurrencyNoiseBound);
+    }
+  }
+
+  /**
+   * Returns the number of live storage identifiers of the embedded manager.
+   *
+   * <p>The set of live identifiers is private, so this helper reads that set by reflection. No
+   * public accessor exists, and a leak of that set is only observable through its size.
+   */
+  @SuppressWarnings("unchecked")
+  private static int liveStorageIdentifierCount() throws Exception {
+    var identifierField =
+        YouTrackDBInternalEmbedded.class.getDeclaredField("currentStorageIds");
+    identifierField.setAccessible(true);
+    return ((Set<Integer>) identifierField.get(null)).size();
+  }
+
+  /**
+   * The barrier writes index histogram content of genesis before the activation.
+   *
+   * <p>An index histogram is index statistics data that the index engine keeps in a separate file.
+   * The plain flush helper of the storage skips that data by contract, so only the wider barrier
+   * writes that data out. The scenario inspects a freshly created image without any close and
+   * copies that image. The expected outcome has three parts. Genesis produced at least one index
+   * histogram file. Every such file carries content of a positive size. The copy holds the same
+   * files with the same sizes.
+   *
+   * <p>This test proves no durability under power loss. The copy reads the files through the page
+   * cache of the operating system, so the copy sees written bytes that no file synchronization
+   * needs to have reached the storage medium. Power-loss certification is an explicit non-goal of
+   * the Track 24 design.
+   */
+  @Test
+  public void barrierWritesIndexHistogramContentAtCreation() throws Exception {
+    var databaseName = "barrierSource";
+    var copyName = "barrierCopy";
+
+    try (var youTrackDB = openManager()) {
+      // The creation without an extra user keeps the barrier as the last write act of the image.
+      // The copy is taken while the manager stays open, so no close and no shutdown flush can
+      // contribute. Every byte of the copy therefore comes from the barrier or from genesis.
+      youTrackDB.create(databaseName, DatabaseType.DISK);
+      copyDirectory(directory.resolve(databaseName), directory.resolve(copyName));
+    }
+
+    var originalHistograms = histogramFileSizes(directory.resolve(databaseName));
+    var copiedHistograms = histogramFileSizes(directory.resolve(copyName));
+    assertFalse(
+        "genesis must create at least one index histogram file", originalHistograms.isEmpty());
+    for (var entry : originalHistograms.entrySet()) {
+      assertTrue(
+          "the barrier must leave written content in index histogram file " + entry.getKey(),
+          entry.getValue() > 0);
+    }
+    assertEquals(
+        "the copy must carry every index histogram file of the original",
+        originalHistograms,
+        copiedHistograms);
+  }
+
+  /**
+   * Memory storage keeps the default barrier and the default activation.
+   *
+   * <p>The scenario has two parts. The first part inspects the declared methods of the three
+   * storage classes. The second part calls the birth completion of one memory storage a second
+   * time, and calls the birth completion of one disk storage a second time.
+   *
+   * <p>The expected outcome has three parts. The memory storage class declares neither the barrier
+   * nor the activation. The second call on the memory storage performs no work and reports no
+   * failure, which proves that memory storage runs two inherited empty method bodies. The second
+   * call on the disk storage fails, because the disk activation refuses an already active record.
+   *
+   * <p>This test proves the absence of an activation and the absence of any failing work. This
+   * test proves no flush count, because a flush count needs a metric seam that no build offers.
+   */
+  @Test
+  public void memoryStorageKeepsTheDefaultBarrier() throws Exception {
+    assertNotNull(
+        "the abstract storage must declare the barrier",
+        AbstractStorage.class.getDeclaredMethod("barrierOverGenesisArtifacts"));
+    assertNotNull(
+        "disk storage must override the barrier",
+        DiskStorage.class.getDeclaredMethod("barrierOverGenesisArtifacts"));
+    assertThrows(
+        NoSuchMethodException.class,
+        () -> DirectMemoryStorage.class.getDeclaredMethod("barrierOverGenesisArtifacts"));
+    assertThrows(
+        NoSuchMethodException.class,
+        () -> DirectMemoryStorage.class.getDeclaredMethod("activateStorageBirth"));
+
+    try (var youTrackDB = openManager()) {
+      youTrackDB.create("memoryBirth", DatabaseType.MEMORY, ADMIN, PASSWORD, ADMIN);
+      youTrackDB.create("diskBirth", DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+      var internal = (YouTrackDBInternalEmbedded) youTrackDB.internal;
+      var memoryStorage = internal.getStorage("memoryBirth");
+      var diskStorage = internal.getStorage("diskBirth");
+      assertNotNull("the memory database must hold one registered storage", memoryStorage);
+      assertNotNull("the disk database must hold one registered storage", diskStorage);
+
+      // Both hooks of the memory storage are inherited empty bodies, so a repeated call is safe.
+      memoryStorage.completeStorageBirth();
+      // The disk storage overrides both hooks, so the repeated activation refuses the record.
+      assertThrows(RuntimeException.class, diskStorage::completeStorageBirth);
+
+      try (var session = youTrackDB.open("memoryBirth", ADMIN, PASSWORD)) {
+        assertTrue(session.getMetadata().getSchema().existsClass("OUser"));
+      }
+    }
+  }
+
+  /**
+   * A crash after genesis and before the durability barrier leaves an inadmissible image.
+   *
+   * <p>This test covers crash point three of the design. The scenario copies the storage directory
+   * at the boundary between the end of genesis and the start of the durability barrier. That copy
+   * is the image that a crash at that boundary leaves behind. The copy reads the files through the
+   * page cache of the operating system, so the copy proves no power-loss behavior. The expected
+   * outcome has three parts. The copy stays visible to the existence probe. Every open of the copy reports the
+   * interrupted-birth reason. A drop discards the copy and reports success.
+   */
+  @Test
+  public void crashAfterGenesisAndBeforeTheBarrierStaysInadmissible() throws Exception {
+    var crashName = "crashBeforeBarrier";
+    createBirthBoundaryCopy("beforeBarrierSource", crashName, true);
+
+    assertInadmissibleAndDroppable(crashName);
+  }
+
+  /**
+   * A crash after the durability barrier and before the activation leaves an inadmissible image.
+   *
+   * <p>This test covers crash point four of the design. The scenario copies the storage directory
+   * at the boundary between the end of the durability barrier and the start of the activation.
+   * That copy holds complete genesis content under a birth record. The expected outcome has four
+   * parts. The copy stays visible to the existence probe. Every open of the copy reports the
+   * interrupted-birth reason. The copy carries written index histogram content, which proves that
+   * the barrier ran before the copy. A drop discards the copy and reports success.
+   *
+   * <p>This test proves no durability under power loss. The copy runs inside the same process and
+   * reads the files through the page cache of the operating system.
+   */
+  @Test
+  public void crashAfterTheBarrierAndBeforeActivationStaysInadmissible() throws Exception {
+    var crashName = "crashBeforeActivation";
+    createBirthBoundaryCopy("beforeActivationSource", crashName, false);
+
+    var histograms = histogramFileSizes(directory.resolve(crashName));
+    assertFalse("the barrier must leave at least one index histogram file", histograms.isEmpty());
+    for (var entry : histograms.entrySet()) {
+      assertTrue(
+          "the barrier must leave written content in index histogram file " + entry.getKey(),
+          entry.getValue() > 0);
+    }
+    assertInadmissibleAndDroppable(crashName);
+  }
+
+  /**
+   * A failed durability barrier keeps the new image out of the active lifecycle state.
+   *
+   * <p>The scenario moves the storage into the internal error state at the end of genesis. A
+   * storage in that state flushes nothing, so the barrier cannot make genesis content durable. The
+   * expected outcome has four parts. The creation reports a failure that names the durability
+   * barrier. The creation never reaches the boundary after the barrier, so the activation never
+   * runs. The creation publishes no active lifecycle state, so no accepted image survives. The
+   * database name is free again, because the failed creation removed its own residue.
+   */
+  @Test
+  public void barrierFailureKeepsTheImageOutOfTheActiveState() throws Exception {
+    var databaseName = "barrierFailure";
+    var reachedTheActivationBoundary = new java.util.concurrent.atomic.AtomicBoolean();
+
+    try (var youTrackDB = openManager()) {
+      try (var ignored =
+          StorageBirthTestSupport.observeBirthCompletion(
+              storage -> storage.moveToErrorStateIfNeeded(
+                  new IllegalStateException("injected internal storage error")),
+              storage -> reachedTheActivationBoundary.set(true))) {
+        var failure =
+            assertThrows(
+                RuntimeException.class,
+                () -> youTrackDB.create(databaseName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN));
+
+        assertTrue(
+            "the failure must name the durability barrier, saw: " + messageChain(failure),
+            messageChain(failure).contains("durability barrier"));
+        assertFalse(
+            "a failed barrier must stop the creation before the activation",
+            reachedTheActivationBoundary.get());
+      }
+
+      assertFalse(
+          "a failed barrier must leave no usable database", youTrackDB.exists(databaseName));
+    }
+
+    assertEquals(
+        "a failed barrier must publish no active lifecycle state",
+        Set.of(),
+        bootstrapArtifactNames(directory.resolve(databaseName)));
+  }
+
+  /**
+   * Creates one database and copies the storage directory at one birth completion boundary.
+   *
+   * @param beforeBarrier true copies after genesis and before the barrier, false copies after the
+   *                      barrier and before the activation
+   */
+  private void createBirthBoundaryCopy(String sourceName, String copyName, boolean beforeBarrier)
+      throws Exception {
+    var sourceDirectory = directory.resolve(sourceName);
+    var copyDirectory = directory.resolve(copyName);
+    Consumer<AbstractStorage> copy =
+        storage -> {
+          try {
+            copyDirectory(sourceDirectory, copyDirectory);
+          } catch (IOException failure) {
+            throw new UncheckedIOException(failure);
+          }
+        };
+    Consumer<AbstractStorage> skip = storage -> {
+    };
+
+    try (var youTrackDB = openManager()) {
+      try (var ignored =
+          StorageBirthTestSupport.observeBirthCompletion(
+              beforeBarrier ? copy : skip, beforeBarrier ? skip : copy)) {
+        youTrackDB.create(sourceName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+      }
+      youTrackDB.drop(sourceName);
+    }
+    assertTrue("the boundary copy must exist", Files.isDirectory(copyDirectory));
+  }
+
+  /** Asserts that one image stays visible, stays inadmissible, and stays droppable. */
+  private void assertInadmissibleAndDroppable(String crashName) throws Exception {
+    try (var youTrackDB = openManager()) {
+      assertTrue("the incomplete image must stay visible", youTrackDB.exists(crashName));
+      var failure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(crashName, ADMIN, PASSWORD));
+      assertEquals(
+          "the incomplete image must be rejected with the interrupted-birth reason",
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+          admissionReason(failure));
+
+      var secondFailure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(crashName, ADMIN, PASSWORD));
+      assertEquals(
+          "the second open must repeat the same rejection",
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+          admissionReason(secondFailure));
+
+      youTrackDB.drop(crashName);
+      assertFalse("the drop must discard the incomplete image", youTrackDB.exists(crashName));
+    }
+  }
+
+  /** Joins every message of one failure chain. */
+  private static String messageChain(Throwable failure) {
+    var message = new StringBuilder();
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      message.append(cause.getMessage()).append(' ');
+    }
+    return message.toString();
+  }
+
+  /**
+   * Creates one database and copies the storage directory during one genesis commit.
+   *
+   * <p>The copy is the image shape that a crash between two genesis steps leaves behind.
+   */
+  private void createCrashCopy(String sourceName, String copyName) {
+    var copier =
+        new CrashCopyListener(directory.resolve(sourceName), directory.resolve(copyName));
+    try (var youTrackDB = openManager()) {
+      youTrackDB.create(
+          sourceName, DatabaseType.DISK, listenerConfig(copier), ADMIN, PASSWORD, ADMIN);
+      youTrackDB.drop(sourceName);
+    }
+    assertTrue("the crash copy must exist", Files.isDirectory(directory.resolve(copyName)));
+  }
+
+  /** Probes storage admission from inside every genesis commit and records each reason. */
+  private static final class AdmissionProbeListener implements SessionListener {
+
+    private final Path storageDirectory;
+    private final List<StorageAdmissionException.Reason> observedReasons = new ArrayList<>();
+
+    private AdmissionProbeListener(Path storageDirectory) {
+      this.storageDirectory = storageDirectory;
+    }
+
+    @Override
+    public void onBeforeTxCommit(Transaction transaction) {
+      try {
+        new StorageBootstrapMetadata(storageDirectory, new FeatureFormatIdentity(1))
+            .readActiveRequired();
+        observedReasons.add(null);
+      } catch (StorageAdmissionException rejection) {
+        observedReasons.add(rejection.reason());
+      } catch (IOException failure) {
+        throw new UncheckedIOException(failure);
+      }
+    }
+  }
+
+  /** Copies the storage directory once, during the first genesis commit. */
+  private static final class CrashCopyListener implements SessionListener {
+
+    private final Path storageDirectory;
+    private final Path copyDirectory;
+    private boolean copied;
+
+    private CrashCopyListener(Path storageDirectory, Path copyDirectory) {
+      this.storageDirectory = storageDirectory;
+      this.copyDirectory = copyDirectory;
+    }
+
+    @Override
+    public void onBeforeTxCommit(Transaction transaction) {
+      if (copied) {
+        return;
+      }
+      copied = true;
+      try {
+        copyDirectory(storageDirectory, copyDirectory);
+      } catch (IOException failure) {
+        throw new UncheckedIOException(failure);
+      }
+    }
+  }
+
+  private static YouTrackDBConfig listenerConfig(SessionListener listener) {
+    return YouTrackDBConfig.builder().addSessionListener(listener).build();
+  }
+
+  private YouTrackDBImpl openManager() {
+    return (YouTrackDBImpl) YourTracks.instance(directory.toString());
+  }
+
+  private StorageBootstrapMetadata authority(String databaseName) throws IOException {
+    return new StorageBootstrapMetadata(
+        directory.resolve(databaseName), new FeatureFormatIdentity(1));
+  }
+
+  private static StorageAdmissionException.Reason admissionReason(Throwable failure) {
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof StorageAdmissionException admission) {
+        return admission.reason();
+      }
+    }
+    return null;
+  }
+
+  private static Set<String> bootstrapArtifactNames(Path storageDirectory) throws IOException {
+    if (!Files.isDirectory(storageDirectory)) {
+      return Set.of();
+    }
+    try (var paths = Files.list(storageDirectory)) {
+      return paths
+          .map(path -> path.getFileName().toString())
+          .filter(StorageBootstrapMetadata::isBootstrapArtifactName)
+          .collect(Collectors.toCollection(TreeSet::new));
+    }
+  }
+
+  private static Map<String, Long> histogramFileSizes(Path storageDirectory) throws IOException {
+    var sizes = new TreeMap<String, Long>();
+    try (var paths = Files.list(storageDirectory)) {
+      for (var path : paths.toList()) {
+        var fileName = path.getFileName().toString();
+        if (fileName.endsWith(".ixs")) {
+          sizes.put(fileName, Files.size(path));
+        }
+      }
+    }
+    return sizes;
+  }
+
+  private static void copyDirectory(Path source, Path target) throws IOException {
+    try (var paths = Files.walk(source)) {
+      for (var path : paths.toList()) {
+        var destination = target.resolve(source.relativize(path).toString());
+        if (Files.isDirectory(path)) {
+          Files.createDirectories(destination);
+        } else {
+          Files.createDirectories(destination.getParent());
+          Files.copy(path, destination, StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/StorageEmbeddedBlobCollectionsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/StorageEmbeddedBlobCollectionsTest.java
@@ -89,8 +89,8 @@ public class StorageEmbeddedBlobCollectionsTest {
   }
 
   /**
-   * The shared per-profile body: verifies the storage-birth layout ({@code internal} = 0,
-   * {@code $blob0..N-1} = 1..N), the registration equality of pin G.5 #7, the persisted root
+   * The shared per-profile body verifies the storage-birth layout and blob registration.
+   * The body also verifies the persisted root
    * payload, and a blob record round-trip landing inside a storage-birth blob collection.
    */
   private void assertBlobLayoutAndRoundTrip(DatabaseType type) {
@@ -100,15 +100,16 @@ public class StorageEmbeddedBlobCollectionsTest {
       var expectedCount =
           GlobalConfiguration.STORAGE_BLOB_COLLECTIONS_COUNT.getValueAsInteger();
 
-      // Layout pinned by the design: internal = 0, $blob0..N-1 = 1..N (class collections
-      // follow from N+1). The blob collections are storage-birth collections created right
-      // after the internal collection inside the storage-create atomic operation.
+      // The build-state collection follows blobs to preserve established blob identifiers.
       assertEquals("the internal collection keeps id 0",
           0, session.getCollectionIdByName(MetadataDefault.COLLECTION_INTERNAL_NAME));
       for (var i = 0; i < expectedCount; i++) {
         assertEquals("$blob" + i + " must occupy the storage-birth slot " + (i + 1),
             i + 1, session.getCollectionIdByName("$blob" + i));
       }
+      assertEquals("the build state collection follows the storage-birth blob slots",
+          expectedCount + 1,
+          session.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME));
 
       var storageIds = storageBlobCollectionIds(session);
       assertEquals("exactly the configured number of $blob* collections must exist",
@@ -171,9 +172,8 @@ public class StorageEmbeddedBlobCollectionsTest {
   /**
    * CN50 (single config read at storage birth): a database created with a non-default
    * {@code STORAGE_BLOB_COLLECTIONS_COUNT} gets exactly that many {@code $blob*} collections at
-   * ids 1..N, and the schema registration matches them — the process-global default (a different
-   * value) is never consulted after create, because the register loop enumerates the storage's
-   * actual collections by name instead of re-reading the configuration.
+   * ids 1..N, and the schema registration matches them. The process-global default differs and
+   * is never consulted after create because registration enumerates the storage collections.
    */
   @Test
   public void blobCollectionsCountIsFrozenAtStorageBirth() {
@@ -207,7 +207,7 @@ public class StorageEmbeddedBlobCollectionsTest {
   }
 
   /**
-   * The renumbered layout survives a full context close and disk reopen: a fresh
+   * The storage-birth layout survives a full context close and disk reopen. A fresh
    * {@link SharedContext} loaded from disk shows the same registration and the previously
    * written blob record still reads back byte-for-byte.
    */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExportImportRoundTripTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseExportImportRoundTripTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.command.CommandOutputListener;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityHelper;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
@@ -291,6 +293,25 @@ public class DatabaseExportImportRoundTripTest extends DbTestBase {
     } finally {
       // Reactivate the YourTracks-managed handle so drop runs on the right session.
       youTrackDB.drop(importDbName);
+    }
+  }
+
+  /**
+   * Lifecycle records use the blob record type internally. Logical export must omit every record
+   * whose source identity belongs to the index build state collection.
+   */
+  @Test
+  public void exportOmitsIndexBuildStateRecords() throws IOException {
+    var output = new ByteArrayOutputStream();
+    new DatabaseExport(session, output, iText -> {
+    }).exportDatabase();
+
+    var dump = new ObjectMapper().readTree(output.toByteArray());
+    var buildStateCollectionId =
+        session.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    for (var record : dump.get("records")) {
+      assertFalse("logical export must omit index build state records",
+          record.path("@rid").asText().startsWith("#" + buildStateCollectionId + ":"));
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImportHardeningTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImportHardeningTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.db.tool;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -10,6 +11,7 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.config.YouTrackDBConfig;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -238,7 +240,57 @@ public class DatabaseImportHardeningTest extends DbTestBase {
       target.begin();
       var blobCount = target.countCollectionElements(target.getBlobCollectionIds());
       target.rollback();
-      assertTrue("the dump's blob record must land in a blob collection", blobCount >= 1);
+      assertEquals("the dump's only blob record must land in a blob collection", 1, blobCount);
+    }
+  }
+
+  /**
+   * A legacy dump can contain lifecycle bytes from an older exporter. The importer must ignore
+   * those bytes instead of creating a blob or replacing target lifecycle state.
+   */
+  @Test
+  public void importIgnoresDumpRecordsForIndexBuildStateCollection() throws Exception {
+    var dump = exportSmallDump();
+    var mapper = new ObjectMapper();
+    var root = (ObjectNode) mapper.readTree(gunzip(dump));
+    ((ObjectNode) root.get("info")).put("exporter-version", 14);
+    root.remove("manifest");
+
+    var buildStateCollectionId = -1;
+    for (var collection : root.get("collections")) {
+      if (MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME.equals(
+          collection.get("name").asText())) {
+        buildStateCollectionId = collection.get("id").asInt();
+        break;
+      }
+    }
+    assertTrue("the dump must declare the index build state collection",
+        buildStateCollectionId >= 0);
+    root.withArray("records")
+        .addObject()
+        .put("@rid", "#" + buildStateCollectionId + ":999999")
+        .put("@version", 0)
+        .put("@type", "b")
+        .put("value", "dump-lifecycle".getBytes(StandardCharsets.UTF_8));
+    gzipTo(dump, mapper.writeValueAsBytes(root));
+
+    try (var target = createTargetDatabase("buildStateRecordTarget")) {
+      target.begin();
+      var lifecycleCountBefore =
+          target.countCollectionElements(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+      target.rollback();
+      runImport(target, dump);
+
+      target.begin();
+      var lifecycleCountAfter =
+          target.countCollectionElements(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+      target.rollback();
+      assertEquals("target lifecycle records must remain unchanged", lifecycleCountBefore,
+          lifecycleCountAfter);
+      target.begin();
+      var blobCount = target.countCollectionElements(target.getBlobCollectionIds());
+      target.rollback();
+      assertEquals("a dump lifecycle record must not become a blob", 0, blobCount);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImportInfoMatrixTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseImportInfoMatrixTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.db.tool;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -8,12 +9,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildFailure;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass.INDEX_TYPE;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -595,6 +603,79 @@ public class DatabaseImportInfoMatrixTest extends DbTestBase {
       assertTrue("the declared-v14 dump must ride the lenient path regardless of its"
           + " schema-version field", target.getMetadata().getSchema().existsClass("Matrix"));
     }
+  }
+
+  /**
+   * Import may replace index descriptors and lifecycle records. Every resulting descriptor must
+   * reach one healthy lifecycle record, with no orphan records, and its index must stay usable.
+   * The target-only index and retained RID map exercise deletion-sweep-sensitive configurations.
+   */
+  @Test
+  public void importKeepsLifecycleRecordsReachableAfterImport() throws Exception {
+    var dump = exportSmallDump();
+
+    try (var target = createTargetDatabase("lifecycleReachabilityTarget")) {
+      runImport(target, dump);
+      assertHealthyLifecycleRecordsAndUsableIndexes(target);
+    }
+
+    try (var target = createTargetDatabase("unrebuiltIndexTarget")) {
+      var userClass = target.getMetadata().getSchema().getClass("OUser");
+      userClass.createIndex("TargetOnlyUserStatus", INDEX_TYPE.NOTUNIQUE, "status");
+
+      runImport(target, dump, "-rebuildIndexes=false");
+
+      assertHealthyLifecycleRecordsAndUsableIndexes(target);
+      assertNotNull("the target-only index must survive when rebuilding is disabled",
+          target.getSharedContext().getIndexManager().getIndex("TargetOnlyUserStatus"));
+    }
+
+    try (var target = createTargetDatabase("retainedRidMappingTarget")) {
+      runImport(target, dump, "-deleteRIDMapping=false");
+      assertHealthyLifecycleRecordsAndUsableIndexes(target);
+    }
+  }
+
+  private static void assertHealthyLifecycleRecordsAndUsableIndexes(
+      DatabaseSessionEmbedded database) {
+    var linkedRecords = new HashSet<RID>();
+    var indexes = database.getSharedContext().getIndexManager().getIndexes(database);
+    for (var index : indexes) {
+      var lifecycleIdentity = lifecycleIdentity(database, index);
+      var snapshot = database.getStorage().getIndexBuildStateStore()
+          .read(index.getIdentity(), lifecycleIdentity);
+      assertTrue("each index must link to a distinct lifecycle record: " + index.getName(),
+          linkedRecords.add(lifecycleIdentity));
+      var state = snapshot.buildState();
+      assertFalse("an index lifecycle must not report a missing build state: " + index.getName(),
+          state.lifecycle() == IndexLifecycle.INVALID
+              && state.failure() == IndexBuildFailure.INDEX_BUILD_STATE_MISSING);
+      database.computeInTx(transaction -> index.size(database));
+    }
+    assertEquals("every lifecycle record must be linked by exactly one index", linkedRecords,
+        lifecycleRecordIds(database));
+  }
+
+  private static RID lifecycleIdentity(DatabaseSessionEmbedded database, Index index) {
+    return database.computeInTx(transaction -> {
+      var identity =
+          transaction.loadEntity(index.getIdentity()).getLink(Index.LIFECYCLE_RECORD);
+      assertNotNull("every index must retain a lifecycle link: " + index.getName(), identity);
+      return identity;
+    });
+  }
+
+  private static Set<RID> lifecycleRecordIds(DatabaseSessionEmbedded database) {
+    return database.computeInTx(transaction -> {
+      var identities = new HashSet<RID>();
+      try (var records =
+          database.browseCollection(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME)) {
+        while (records.hasNext()) {
+          identities.add(records.next().getIdentity());
+        }
+      }
+      return identities;
+    });
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/UniformCtorExceptionFanTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/UniformCtorExceptionFanTest.java
@@ -167,6 +167,8 @@ public class UniformCtorExceptionFanTest {
                 EnumSet.of(Shape.DBNAME_MESSAGE, Shape.COPY)},
             {"StorageExistsException", StorageExistsException.class, BaseException.class,
                 EnumSet.of(Shape.DBNAME_MESSAGE, Shape.COPY)},
+            {"StaleIndexEngineException", StaleIndexEngineException.class, BaseException.class,
+                EnumSet.allOf(Shape.class)},
             {"TransactionBlockedException", TransactionBlockedException.class, BaseException.class,
                 EnumSet.of(Shape.MESSAGE, Shape.DBNAME_MESSAGE, Shape.COPY)},
             {"TransactionException", TransactionException.class, BaseException.class,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -513,6 +513,12 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         engineIsRegistered(keepIndexName));
     assertTrue("the surviving committed index's engine must be reconstructed after the failed drop",
         engineIsRegistered(goneIndexName));
+    var restoredKeep = (IndexAbstract) indexManager.getIndex(keepIndexName);
+    var restoredGone = (IndexAbstract) indexManager.getIndex(goneIndexName);
+    assertEquals("the restored keep engine must be bound to its descriptor owner",
+        restoredKeep.getIndexId(), storage.resolveIndexEngineByOwner(restoredKeep.getIdentity()));
+    assertEquals("the restored gone engine must be bound to its descriptor owner",
+        restoredGone.getIndexId(), storage.resolveIndexEngineByOwner(restoredGone.getIdentity()));
 
     // The invariant bar: a query through the surviving index must return its committed row without an
     // unregistered-engine / null-slot throw — the whole point of the drop-restore arm.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -277,6 +277,10 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     var indexManager = session.getSharedContext().getIndexManager();
     assertTrue("the index must exist before the drop", indexManager.existsIndex(indexName));
     assertTrue("the engine must be registered before the drop", engineIsRegistered(indexName));
+    var droppedIndex = (IndexAbstract) indexManager.getIndex(indexName);
+    var droppedDescriptorIdentity = droppedIndex.getIdentity();
+    assertNotNull("the descriptor must have a lifecycle cell before drop",
+        droppedIndex.getLifecycleCell());
 
     session.executeInTx(tx -> indexManager.dropIndex(session, indexName));
 
@@ -284,6 +288,8 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         indexManager.existsIndex(indexName));
     assertFalse("the dropped index's engine must be unregistered after commit",
         engineIsRegistered(indexName));
+    assertNull("the committed drop must remove its lifecycle registry entry",
+        storage().getIndexLifecycle(droppedDescriptorIdentity));
 
     session.getSharedContext().getIndexManager().reload(session);
     reOpen("admin", ADMIN_PASSWORD);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -929,6 +930,56 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         replacementEngine.getId());
     assertEquals("the empty replacement must not inherit dropped histogram work", 0L,
         replacementEngine.getStatistics().totalCount());
+  }
+
+  /**
+   * S1 drops and recreates an index before invoking the old manager outside the commit window. The
+   * stale build must neither throw nor change the replacement statistics in the reused slot.
+   */
+  @Test
+  public void staleHistogramBuildCannotPublishIntoReusedSlot() throws Exception {
+    var cls = session.getMetadata().getSchema().createClass("HistogramSlotReuse");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "HistogramSlotReuse.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var indexManager = session.getSharedContext().getIndexManager();
+    var original = (IndexAbstract) indexManager.getIndex(indexName);
+    var originalEngine = (BTreeIndexEngine) storage().getIndexEngine(original.getIndexId());
+    var originalHistogram = originalEngine.getHistogramManager();
+    assertNotNull("the original engine must have a histogram manager", originalHistogram);
+    var reusedSlot = originalEngine.getId();
+
+    session.begin();
+    indexManager.dropIndex(session, indexName);
+    session.getMetadata().getSchema().getClass("HistogramSlotReuse")
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    session.commit();
+
+    var replacement = (IndexAbstract) indexManager.getIndex(indexName);
+    var replacementEngine = (BTreeIndexEngine) storage().getIndexEngine(replacement.getIndexId());
+    assertEquals("the replacement must reuse the dropped engine slot", reusedSlot,
+        replacementEngine.getId());
+
+    session.begin();
+    var entity = (EntityImpl) session.newEntity("HistogramSlotReuse");
+    entity.setProperty("name", "current");
+    session.commit();
+    var statisticsBeforeStaleBuild = replacementEngine.getStatistics();
+    assertNotNull("the replacement must expose histogram statistics", statisticsBeforeStaleBuild);
+
+    session.begin();
+    try {
+      originalHistogram.buildHistogram(
+          session.getActiveTransaction().getAtomicOperation(), Stream.of("stale"), 1, 0, 1);
+      session.commit();
+    } catch (Exception e) {
+      session.rollback();
+      throw e;
+    }
+
+    assertEquals("the stale build must preserve replacement statistics",
+        statisticsBeforeStaleBuild, replacementEngine.getStatistics());
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -554,6 +554,16 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         session.computeInTx(tx -> reloadedKeep.getRids(session, "survivor").toList());
     assertEquals("the surviving committed index must return its row after a reopen", 1,
         reloadedRids.size());
+
+    // A second transactional drop starts from the restored handle generation. It must refresh the
+    // carrier inside the commit window and complete instead of rejecting the restored reference.
+    session.begin();
+    reloadedManager.dropIndex(session, goneIndexName);
+    session.commit();
+    assertFalse("a retry must drop an engine restored after the failed commit",
+        reloadedManager.existsIndex(goneIndexName));
+    assertTrue("the unrelated restored index must remain usable",
+        reloadedManager.existsIndex(keepIndexName));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -534,36 +534,34 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
             + " drop commit",
         1, survivorRids.size());
 
-    // The durable arm: re-parse the index manager's persisted records and reopen the session;
-    // both committed indexes must re-derive from durable state with loadable engines, and the
-    // survivor must still return its committed row. On the disk profile this catches a rollback
-    // that failed to restore the dropped engines' durable configuration entries.
+    // Retry one transactional drop before reload, while its handle still carries the generation
+    // from before failed-drop restoration. The commit-window retry must refresh that carrier.
+    session.begin();
+    indexManager.dropIndex(session, goneIndexName);
+    session.commit();
+    assertFalse("a retry must drop an engine restored after the failed commit",
+        indexManager.existsIndex(goneIndexName));
+    assertTrue("the unrelated restored index must remain usable",
+        indexManager.existsIndex(keepIndexName));
+
+    // The durable arm re-parses the index manager records and reopens the session. The retained
+    // index must load, while the successfully retried drop must remain absent.
     session.getSharedContext().getIndexManager().reload(session);
     reOpen("admin", ADMIN_PASSWORD);
     var reloadedManager = session.getSharedContext().getIndexManager();
     assertTrue("the committed indexes must survive the failed drop in durable state",
         reloadedManager.existsIndex(keepIndexName));
-    assertTrue("the committed indexes must survive the failed drop in durable state",
+    assertFalse("the retried drop must remain durable after reopen",
         reloadedManager.existsIndex(goneIndexName));
-    assertTrue("the surviving indexes' engines must load after a reopen",
+    assertTrue("the surviving index engine must load after a reopen",
         engineIsRegistered(keepIndexName));
-    assertTrue("the surviving indexes' engines must load after a reopen",
+    assertFalse("the dropped engine must remain unregistered after a reopen",
         engineIsRegistered(goneIndexName));
     var reloadedKeep = reloadedManager.getIndex(keepIndexName);
     var reloadedRids =
         session.computeInTx(tx -> reloadedKeep.getRids(session, "survivor").toList());
     assertEquals("the surviving committed index must return its row after a reopen", 1,
         reloadedRids.size());
-
-    // A second transactional drop starts from the restored handle generation. It must refresh the
-    // carrier inside the commit window and complete instead of rejecting the restored reference.
-    session.begin();
-    reloadedManager.dropIndex(session, goneIndexName);
-    session.commit();
-    assertFalse("a retry must drop an engine restored after the failed commit",
-        reloadedManager.existsIndex(goneIndexName));
-    assertTrue("the unrelated restored index must remain usable",
-        reloadedManager.existsIndex(keepIndexName));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -32,6 +32,8 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.api.exception.RecordDuplicatedException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDelta;
+import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -840,6 +842,115 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         session.computeInTx(
             tx -> reloadedManager.getIndex(indexName).getRids(session, "replaced").toList());
     assertEquals("the recreated index's row must survive the reload", 1, reloadedRids.size());
+  }
+
+  /**
+   * A count delta accumulated for the old engine must not follow its reused slot into the empty
+   * replacement. The commit-window hook models old-engine work before reconciliation. The
+   * replacement must retain an empty entry count after the drop and recreate commit.
+   */
+  @Test
+  public void dropThenRecreateDiscardsDroppedIndexCountDelta() throws Exception {
+    var cls = session.getMetadata().getSchema().createClass("CountDeltaReplace");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "CountDeltaReplace.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var indexManager = session.getSharedContext().getIndexManager();
+    var original = (IndexAbstract) indexManager.getIndex(indexName);
+    var originalEngine = (BTreeIndexEngine) storage().getIndexEngine(original.getIndexId());
+    var reusedSlot = originalEngine.getId();
+
+    session.begin();
+    indexManager.dropIndex(session, indexName);
+    session.getMetadata().getSchema().getClass("CountDeltaReplace")
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    storage().setCommitWindowTestHook(
+        () -> IndexCountDelta.accumulate(
+            session.getActiveTransaction().getAtomicOperation(), reusedSlot, 1, false));
+    try {
+      session.commit();
+    } finally {
+      storage().setCommitWindowTestHook(null);
+    }
+
+    var replacement = (IndexAbstract) indexManager.getIndex(indexName);
+    var replacementEngine = (BTreeIndexEngine) storage().getIndexEngine(replacement.getIndexId());
+    assertEquals("the replacement must reuse the dropped engine slot", reusedSlot,
+        replacementEngine.getId());
+    assertEquals("the empty replacement must not inherit the dropped engine count", 0L,
+        session.computeInTx(tx -> replacement.size(session)).longValue());
+  }
+
+  /**
+   * A histogram delta accumulated for the old engine must not follow its reused slot into the empty
+   * replacement. The replacement statistics must remain at their freshly-built zero state.
+   */
+  @Test
+  public void dropThenRecreateDiscardsDroppedIndexHistogramDelta() throws Exception {
+    var cls = session.getMetadata().getSchema().createClass("HistogramDeltaReplace");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "HistogramDeltaReplace.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var indexManager = session.getSharedContext().getIndexManager();
+    var original = (IndexAbstract) indexManager.getIndex(indexName);
+    var originalEngine = (BTreeIndexEngine) storage().getIndexEngine(original.getIndexId());
+    var originalHistogram = originalEngine.getHistogramManager();
+    assertNotNull("the original engine must have a histogram manager", originalHistogram);
+    var reusedSlot = originalEngine.getId();
+
+    session.begin();
+    indexManager.dropIndex(session, indexName);
+    session.getMetadata().getSchema().getClass("HistogramDeltaReplace")
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    storage().setCommitWindowTestHook(
+        () -> originalHistogram.onPut(
+            session.getActiveTransaction().getAtomicOperation(), "ghost", true, true));
+    try {
+      session.commit();
+    } finally {
+      storage().setCommitWindowTestHook(null);
+    }
+
+    var replacement = (IndexAbstract) indexManager.getIndex(indexName);
+    var replacementEngine = (BTreeIndexEngine) storage().getIndexEngine(replacement.getIndexId());
+    assertEquals("the replacement must reuse the dropped engine slot", reusedSlot,
+        replacementEngine.getId());
+    assertEquals("the empty replacement must not inherit dropped histogram work", 0L,
+        replacementEngine.getStatistics().totalCount());
+  }
+
+  /**
+   * Dropping an unrelated engine must discard only that engine's slot. A normal insertion into a
+   * surviving index must still advance both its approximate count and histogram statistics.
+   */
+  @Test
+  public void unrelatedDropPreservesSurvivingIndexCountAndHistogram() throws Exception {
+    var schema = session.getMetadata().getSchema();
+    var survivorClass = schema.createClass("DeltaDiscardSurvivor");
+    survivorClass.createProperty("name", PropertyType.STRING);
+    var survivorName = "DeltaDiscardSurvivor.name";
+    survivorClass.createIndex(survivorName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var droppedClass = schema.createClass("DeltaDiscardUnrelated");
+    droppedClass.createProperty("name", PropertyType.STRING);
+    var droppedName = "DeltaDiscardUnrelated.name";
+    droppedClass.createIndex(droppedName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var indexManager = session.getSharedContext().getIndexManager();
+    session.begin();
+    var entity = (EntityImpl) session.newEntity("DeltaDiscardSurvivor");
+    entity.setProperty("name", "kept");
+    indexManager.dropIndex(session, droppedName);
+    session.commit();
+
+    var survivor = (IndexAbstract) indexManager.getIndex(survivorName);
+    var survivorEngine = (BTreeIndexEngine) storage().getIndexEngine(survivor.getIndexId());
+    assertEquals("the survivor must keep its committed entry count", 1L,
+        session.computeInTx(tx -> survivor.size(session)).longValue());
+    assertEquals("the survivor must keep its committed histogram delta", 1L,
+        survivorEngine.getStatistics().totalCount());
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -865,14 +865,19 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     indexManager.dropIndex(session, indexName);
     session.getMetadata().getSchema().getClass("CountDeltaReplace")
         .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var hookFired = new AtomicBoolean();
     storage().setCommitWindowTestHook(
-        () -> IndexCountDelta.accumulate(
-            session.getActiveTransaction().getAtomicOperation(), reusedSlot, 1, false));
+        () -> {
+          hookFired.set(true);
+          IndexCountDelta.accumulate(
+              session.getActiveTransaction().getAtomicOperation(), reusedSlot, 1, false);
+        });
     try {
       session.commit();
     } finally {
       storage().setCommitWindowTestHook(null);
     }
+    assertTrue("the count-delta test hook must fire inside the commit window", hookFired.get());
 
     var replacement = (IndexAbstract) indexManager.getIndex(indexName);
     var replacementEngine = (BTreeIndexEngine) storage().getIndexEngine(replacement.getIndexId());
@@ -904,14 +909,19 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     indexManager.dropIndex(session, indexName);
     session.getMetadata().getSchema().getClass("HistogramDeltaReplace")
         .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var hookFired = new AtomicBoolean();
     storage().setCommitWindowTestHook(
-        () -> originalHistogram.onPut(
-            session.getActiveTransaction().getAtomicOperation(), "ghost", true, true));
+        () -> {
+          hookFired.set(true);
+          originalHistogram.onPut(
+              session.getActiveTransaction().getAtomicOperation(), "ghost", true, true);
+        });
     try {
       session.commit();
     } finally {
       storage().setCommitWindowTestHook(null);
     }
+    assertTrue("the histogram-delta test hook must fire inside the commit window", hookFired.get());
 
     var replacement = (IndexAbstract) indexManager.getIndex(indexName);
     var replacementEngine = (BTreeIndexEngine) storage().getIndexEngine(replacement.getIndexId());

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -519,9 +519,11 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     var restoredKeep = (IndexAbstract) indexManager.getIndex(keepIndexName);
     var restoredGone = (IndexAbstract) indexManager.getIndex(goneIndexName);
     assertEquals("the restored keep engine must be bound to its descriptor owner",
-        restoredKeep.getIndexId(), storage.resolveIndexEngineByOwner(restoredKeep.getIdentity()));
+        restoredKeep.getIndexId(),
+        storage.resolveIndexEngineByOwner(restoredKeep.getIdentity()).engineIdentifier());
     assertEquals("the restored gone engine must be bound to its descriptor owner",
-        restoredGone.getIndexId(), storage.resolveIndexEngineByOwner(restoredGone.getIdentity()));
+        restoredGone.getIndexId(),
+        storage.resolveIndexEngineByOwner(restoredGone.getIdentity()).engineIdentifier());
 
     // The invariant bar: a query through the surviving index must return its committed row without an
     // unregistered-engine / null-slot throw — the whole point of the drop-restore arm.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -32,6 +32,7 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.api.exception.RecordDuplicatedException;
 import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.common.concur.lock.ScalableRWLock;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
@@ -462,6 +463,97 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     assertEquals(durable, cellAfter.snapshot());
     assertEquals(durable, storage().getIndexBuildStateStore().read(index.getIdentity(), lifecycle));
     assertTrue("recovery must preserve the current-lineage cell", cellBefore == cellAfter);
+  }
+
+  /** A pure-data commit retains state read mode while creating a lifecycle record. */
+  @Test
+  public void pureDataCommitRetainsStateReadModeThroughLifecycleCreation() throws Exception {
+    var stateLockField = AbstractStorage.class.getDeclaredField("stateLock");
+    stateLockField.setAccessible(true);
+    var stateLock = (ScalableRWLock) stateLockField.get(storage());
+    var observedReadMode = new AtomicBoolean();
+
+    storage()
+        .setEndTxCommitFailureTestHook(
+            () -> observedReadMode.set(stateLock.isReadLockedByCurrentThread()));
+    try {
+      session.begin();
+      var descriptor = session.newEntity().getIdentity();
+      storage().registerTopLevelIndexLifecycle(session.getTransactionInternal(), descriptor);
+      session.commit();
+    } finally {
+      storage().setEndTxCommitFailureTestHook(null);
+    }
+
+    assertTrue(
+        "lifecycle creation must not release the pure-data commit's outer state read mode",
+        observedReadMode.get());
+  }
+
+  /** Protected publication rejects before reading and leaves its applying data commit reversible. */
+  @Test
+  public void protectedPublishRejectsBeforeReadAndOuterCommitRollsBack() {
+    var cls = session.getMetadata().getSchema().createClass("ProtectedPublishRollbackTarget");
+    cls.createProperty("name", PropertyType.STRING);
+    cls.createIndex(
+        "ProtectedPublishRollbackTarget.name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var index =
+        session
+            .getSharedContext()
+            .getIndexManager()
+            .getIndex("ProtectedPublishRollbackTarget.name");
+    var lifecycle = lifecycleIdentity(index);
+    var store = storage().getIndexBuildStateStore();
+    var durableBefore = store.read(index.getIdentity(), lifecycle);
+    var state = durableBefore.buildState();
+    var replacement =
+        new IndexBuildState(
+            state.formatVersion(),
+            state.descriptorIdentity(),
+            state.lifecycle(),
+            state.buildIncarnation(),
+            state.ownerEpoch(),
+            state.completionCut(),
+            state.completedUnits() + 1,
+            state.suspended(),
+            state.failure(),
+            state.failureMessage());
+
+    storage()
+        .setEndTxCommitFailureTestHook(
+            () -> store.publish(index.getIdentity(), lifecycle, durableBefore, replacement));
+    try {
+      session.begin();
+      var inserted = session.newEntity("ProtectedPublishRollbackTarget");
+      inserted.setProperty("name", "rolled-back");
+      assertThrows(
+          "the protected publication must reject during the applying commit",
+          IllegalStateException.class,
+          session::commit);
+    } finally {
+      storage().setEndTxCommitFailureTestHook(null);
+    }
+
+    assertEquals(
+        "the lifecycle record must not advance",
+        durableBefore,
+        store.read(index.getIdentity(), lifecycle));
+    session.begin();
+    try (var records = session.query("select from ProtectedPublishRollbackTarget")) {
+      assertEquals("the outer data commit must roll back", 0L, records.stream().count());
+    }
+    session.commit();
+
+    session.executeInTx(
+        transaction -> {
+          var usable = session.newEntity("ProtectedPublishRollbackTarget");
+          usable.setProperty("name", "usable");
+        });
+    session.begin();
+    try (var records = session.query("select from ProtectedPublishRollbackTarget")) {
+      assertEquals("the storage must accept a later write", 1L, records.stream().count());
+    }
+    session.commit();
   }
 
   /** A pure data commit does not allocate top-level lifecycle bookkeeping. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/CommitTimeIndexBuildTest.java
@@ -30,10 +30,17 @@ import static org.junit.Assert.fail;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.api.exception.RecordDuplicatedException;
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDelta;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildFailure;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildState;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -100,6 +107,477 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
    */
   private boolean engineIsRegistered(String indexName) {
     return storage().loadIndexEngine(indexName) >= 0;
+  }
+
+  private long lifecycleRecordCount() {
+    return session.computeInTx(
+        transaction -> {
+          long count = 0;
+          try (var records =
+              session.browseCollection(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME)) {
+            while (records.hasNext()) {
+              records.next();
+              count++;
+            }
+          }
+          return count;
+        });
+  }
+
+  private RID lifecycleIdentity(Index index) {
+    return session.computeInTx(
+        transaction -> transaction.loadEntity(index.getIdentity()).getLink(Index.LIFECYCLE_RECORD));
+  }
+
+  private boolean managerLinks(Index index) {
+    var managerIdentity = RecordIdInternal.fromString(storage().getIndexMgrRecordId(), false);
+    var manager = (IndexManagerAbstract) session.getSharedContext().getIndexManager();
+    return session.computeInTx(
+        transaction -> transaction
+            .loadEntity(managerIdentity)
+            .getLinkSet(manager.CONFIG_INDEXES)
+            .contains(index.getIdentity()));
+  }
+
+  /** Successful creation commits every durable artifact before lifecycle publication. */
+  @Test
+  public void atomicCreationCommitsAllArtifactsAndThenPublishesLifecycle() {
+    var schema = session.getMetadata().getSchema();
+    var target = schema.createClass("AtomicCreateTarget");
+    target.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    session.getMetadata().getSchema().getClass("AtomicCreateTarget")
+        .createIndex("AtomicCreateTarget.name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var deferred =
+        (IndexAbstract) session.getSharedContext().getIndexManager()
+            .getIndex(session, "AtomicCreateTarget.name");
+    assertNull("the deferred handle must not publish a lifecycle before commit",
+        deferred.getLifecycleCell());
+    session.commit();
+
+    var index = session.getSharedContext().getIndexManager().getIndex("AtomicCreateTarget.name");
+    var lifecycleIdentity = lifecycleIdentity(index);
+    var durable =
+        storage().getIndexBuildStateStore().read(index.getIdentity(), lifecycleIdentity);
+    assertTrue("the descriptor record must be durable", index.getIdentity().isPersistent());
+    assertNotNull("the descriptor must link its lifecycle record", lifecycleIdentity);
+    assertTrue("the manager record must link the descriptor", managerLinks(index));
+    assertTrue("the engine configuration must register the engine",
+        engineIsRegistered(index.getName()));
+    assertEquals(IndexLifecycle.EXISTS, durable.lifecycle());
+    assertNotNull("the committed snapshot must be published",
+        storage().getIndexLifecycle(index.getIdentity()));
+    assertEquals(durable, storage().getIndexLifecycle(index.getIdentity()).snapshot());
+  }
+
+  /** A failed creation commit removes every artifact and publishes no lifecycle snapshot. */
+  @Test
+  public void failedAtomicCreationLeavesNoArtifactOrLifecyclePublication() {
+    var schema = session.getMetadata().getSchema();
+    var target = schema.createClass("AtomicRollbackTarget");
+    target.createProperty("name", PropertyType.STRING);
+    var recordsBefore = lifecycleRecordCount();
+    var created = new AtomicReference<Index>();
+
+    storage().setPostEngineBuildTestHook(
+        () -> {
+          throw new CommandInterruptedException(
+              session.getDatabaseName(), "injected atomic creation failure");
+        });
+    try {
+      session.begin();
+      session.getMetadata().getSchema().getClass("AtomicRollbackTarget")
+          .createIndex("AtomicRollbackTarget.name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+      created.set(
+          session.getSharedContext().getIndexManager()
+              .getIndex(session, "AtomicRollbackTarget.name"));
+      assertThrows(RuntimeException.class, session::commit);
+    } finally {
+      storage().setPostEngineBuildTestHook(null);
+    }
+
+    var index = created.get();
+    assertFalse("the manager must not publish the failed index",
+        session.getSharedContext().getIndexManager().existsIndex(index.getName()));
+    assertFalse("the engine registry must remove the failed engine",
+        engineIsRegistered(index.getName()));
+    assertEquals("the lifecycle record must roll back", recordsBefore, lifecycleRecordCount());
+    assertNull("the lifecycle registry must remain empty for the failed descriptor",
+        storage().getIndexLifecycle(index.getIdentity()));
+    assertThrows(
+        "the descriptor record must roll back",
+        RecordNotFoundException.class,
+        () -> session.computeInTx(transaction -> transaction.loadEntity(index.getIdentity())));
+    assertFalse("the manager record must not retain the failed descriptor", managerLinks(index));
+  }
+
+  /** Top-level creation rejects another lifecycle registration for one descriptor. */
+  @Test
+  public void topLevelCreationRejectsSecondLifecycleRecord() {
+    var schema = session.getMetadata().getSchema();
+    var target = schema.createClass("TopLevelLifecycleTarget");
+    target.createProperty("name", PropertyType.STRING);
+    target.createIndex(
+        "TopLevelLifecycleTarget.name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var index =
+        session.getSharedContext().getIndexManager().getIndex("TopLevelLifecycleTarget.name");
+    var lifecycleIdentity = lifecycleIdentity(index);
+    var recordsBefore = lifecycleRecordCount();
+
+    session.begin();
+    assertThrows(
+        "a descriptor with a durable link must reject another lifecycle registration",
+        IllegalStateException.class,
+        () -> storage().registerTopLevelIndexLifecycle(
+            session.getTransactionInternal(), index.getIdentity()));
+    session.rollback();
+
+    assertEquals(recordsBefore, lifecycleRecordCount());
+    assertEquals(lifecycleIdentity, lifecycleIdentity(index));
+  }
+
+  /** A pending top-level registration rejects the same descriptor before commit. */
+  @Test
+  public void duplicatePendingTopLevelRegistrationIsRejected() {
+    var descriptor = session.computeInTx(transaction -> transaction.newEntity().getIdentity());
+    var recordsBefore = lifecycleRecordCount();
+
+    session.begin();
+    storage().registerTopLevelIndexLifecycle(session.getTransactionInternal(), descriptor);
+    var failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> storage()
+                .registerTopLevelIndexLifecycle(
+                    session.getTransactionInternal(), descriptor));
+    session.rollback();
+
+    assertEquals("Index descriptor already awaits a lifecycle record", failure.getMessage());
+    assertEquals(recordsBefore, lifecycleRecordCount());
+    assertNull(storage().getIndexLifecycle(descriptor));
+  }
+
+  /** A failed top-level descriptor commit leaves no lifecycle record or index. */
+  @Test
+  public void failedTopLevelDescriptorCommitLeavesNoLifecycleArtifact() {
+    var cls = session.getMetadata().getSchema().createClass("TopLevelCommitFailureTarget");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "TopLevelCommitFailureTarget.name";
+    var recordsBefore = lifecycleRecordCount();
+
+    storage()
+        .setEndTxCommitFailureTestHook(
+            () -> {
+              throw new CommandInterruptedException(
+                  session.getDatabaseName(), "injected top-level descriptor commit failure");
+            });
+    try {
+      assertThrows(
+          RuntimeException.class,
+          () -> cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name"));
+    } finally {
+      storage().setEndTxCommitFailureTestHook(null);
+    }
+
+    assertEquals(recordsBefore, lifecycleRecordCount());
+    var failed = session.getSharedContext().getIndexManager().getIndex(indexName);
+    assertNotNull("the engine-first handle remains observable after descriptor failure", failed);
+    assertNull(storage().getIndexLifecycle(failed.getIdentity()));
+    assertThrows(
+        RecordNotFoundException.class,
+        () -> session.computeInTx(transaction -> transaction.loadEntity(failed.getIdentity())));
+  }
+
+  /** Genesis security indexes use durable links and committed lifecycle snapshots. */
+  @Test
+  public void genesisSecurityIndexesUseAtomicLifecycleContract() {
+    for (var name : List.of("OUser.name", "ORole.name", "OSecurityPolicy.name")) {
+      var index = session.getSharedContext().getIndexManager().getIndex(name);
+      assertNotNull("the genesis security index must exist: " + name, index);
+      var lifecycleIdentity = lifecycleIdentity(index);
+      assertNotNull("the genesis descriptor must link lifecycle state: " + name,
+          lifecycleIdentity);
+      assertEquals(
+          storage().getIndexBuildStateStore().read(index.getIdentity(), lifecycleIdentity),
+          storage().getIndexLifecycle(index.getIdentity()).snapshot());
+    }
+  }
+
+  /** Top-level deletion removes the descriptor and linked lifecycle record together. */
+  @Test
+  public void topLevelDeletionRemovesLinkedLifecycleRecord() {
+    var cls = session.getMetadata().getSchema().createClass("LifecycleDeleteTarget");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "LifecycleDeleteTarget.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var index = session.getSharedContext().getIndexManager().getIndex(indexName);
+    var descriptorIdentity = index.getIdentity();
+    var linkedLifecycle = lifecycleIdentity(index);
+
+    session.getSharedContext().getIndexManager().dropIndex(session, indexName);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> storage().getIndexBuildStateStore().read(descriptorIdentity, linkedLifecycle));
+    assertThrows(
+        RecordNotFoundException.class,
+        () -> session.computeInTx(tx -> tx.loadEntity(descriptorIdentity)));
+  }
+
+  /** A failed transactional deletion preserves the lifecycle record and descriptor link. */
+  @Test
+  public void failedTransactionalDeletionPreservesLifecycleRecordAndLink() {
+    var cls = session.getMetadata().getSchema().createClass("LifecycleDropRollbackTarget");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "LifecycleDropRollbackTarget.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var manager = session.getSharedContext().getIndexManager();
+    var index = manager.getIndex(indexName);
+    var linkedLifecycle = lifecycleIdentity(index);
+    var snapshot =
+        storage().getIndexBuildStateStore().read(index.getIdentity(), linkedLifecycle);
+
+    var deletionEnrolled = new AtomicBoolean();
+    storage().setPostEngineBuildTestHook(
+        () -> {
+          deletionEnrolled.set(
+              session.getTransactionInternal().isDeletedInTx(linkedLifecycle));
+          throw new CommandInterruptedException(
+              session.getDatabaseName(), "injected lifecycle deletion failure");
+        });
+    try {
+      session.begin();
+      manager.dropIndex(session, indexName);
+      assertThrows(RuntimeException.class, session::commit);
+    } finally {
+      storage().setPostEngineBuildTestHook(null);
+    }
+
+    assertTrue(
+        "the lifecycle deletion must join the failing transaction",
+        deletionEnrolled.get());
+    assertEquals(linkedLifecycle, lifecycleIdentity(index));
+    assertEquals(
+        snapshot,
+        storage().getIndexBuildStateStore().read(index.getIdentity(), linkedLifecycle));
+  }
+
+  /** Metadata reload publishes durable progress and clears process-local ownership. */
+  @Test
+  public void lifecycleRecoveryPreservesProgressAndClearsOwnership() {
+    var cls = session.getMetadata().getSchema().createClass("LifecycleRecoveryTarget");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "LifecycleRecoveryTarget.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var manager = session.getSharedContext().getIndexManager();
+    var index = manager.getIndex(indexName);
+    var lifecycle = lifecycleIdentity(index);
+    var store = storage().getIndexBuildStateStore();
+    var current = store.read(index.getIdentity(), lifecycle);
+    var state = current.buildState();
+    var owned =
+        new IndexBuildState(
+            state.formatVersion(),
+            state.descriptorIdentity(),
+            state.lifecycle(),
+            state.buildIncarnation(),
+            71L,
+            state.completionCut(),
+            19,
+            true,
+            state.failure(),
+            state.failureMessage());
+    var ownedSnapshot = store.publish(index.getIdentity(), lifecycle, current, owned);
+
+    manager.reload(session);
+
+    var recovered = storage().getIndexLifecycle(index.getIdentity()).snapshot();
+    assertEquals(19, recovered.buildState().completedUnits());
+    assertTrue(recovered.buildState().suspended());
+    assertNull(recovered.buildState().ownerEpoch());
+    assertEquals(ownedSnapshot, store.read(index.getIdentity(), lifecycle));
+  }
+
+  /** Publication accepts the recovered owner-free snapshot after metadata reload. */
+  @Test
+  public void publicationAfterRecoveryIgnoresStaleDurableOwnerEpoch() {
+    var index = createIndexForRecovery("LifecycleRecoveryPublicationTarget");
+    var lifecycle = lifecycleIdentity(index);
+    var store = storage().getIndexBuildStateStore();
+    var current = store.read(index.getIdentity(), lifecycle);
+    var state = current.buildState();
+    var owned =
+        new IndexBuildState(
+            state.formatVersion(),
+            state.descriptorIdentity(),
+            state.lifecycle(),
+            state.buildIncarnation(),
+            71L,
+            state.completionCut(),
+            19,
+            true,
+            state.failure(),
+            state.failureMessage());
+    var ownedSnapshot = store.publish(index.getIdentity(), lifecycle, current, owned);
+
+    session.getSharedContext().getIndexManager().reload(session);
+
+    var recovered = storage().getIndexLifecycle(index.getIdentity()).snapshot();
+    var recoveredState = recovered.buildState();
+    var replacement =
+        new IndexBuildState(
+            recoveredState.formatVersion(),
+            recoveredState.descriptorIdentity(),
+            recoveredState.lifecycle(),
+            recoveredState.buildIncarnation(),
+            null,
+            recoveredState.completionCut(),
+            20,
+            recoveredState.suspended(),
+            recoveredState.failure(),
+            recoveredState.failureMessage());
+    var published = store.publish(index.getIdentity(), lifecycle, recovered, replacement);
+
+    assertEquals(ownedSnapshot.recordVersion(), recovered.recordVersion());
+    assertNull(recoveredState.ownerEpoch());
+    assertEquals(20, published.buildState().completedUnits());
+    assertNull(published.buildState().ownerEpoch());
+    assertTrue(published.recordVersion() > ownedSnapshot.recordVersion());
+    assertEquals(published, store.read(index.getIdentity(), lifecycle));
+  }
+
+  /** Metadata reload preserves an owner-free durable snapshot without replacement. */
+  @Test
+  public void ownerFreeLifecycleRecoveryKeepsDurableSnapshot() {
+    var index = createIndexForRecovery("OwnerFreeRecoveryTarget");
+    var lifecycle = lifecycleIdentity(index);
+    var durable = storage().getIndexBuildStateStore().read(index.getIdentity(), lifecycle);
+    assertNull(durable.buildState().ownerEpoch());
+    var cellBefore = storage().getIndexLifecycle(index.getIdentity());
+
+    session.getSharedContext().getIndexManager().reload(session);
+
+    var cellAfter = storage().getIndexLifecycle(index.getIdentity());
+    assertEquals(durable, cellAfter.snapshot());
+    assertEquals(durable, storage().getIndexBuildStateStore().read(index.getIdentity(), lifecycle));
+    assertTrue("recovery must preserve the current-lineage cell", cellBefore == cellAfter);
+  }
+
+  /** A pure data commit does not allocate top-level lifecycle bookkeeping. */
+  @Test
+  public void pureDataCommitDoesNotAllocateTopLevelLifecycleBookkeeping() {
+    session.begin();
+    var transaction = session.getTransactionInternal();
+    session.newEntity();
+
+    session.commit();
+
+    var key = AbstractStorage.class.getName() + ".topLevelIndexLifecycles";
+    assertNull(transaction.getCustomData(key));
+  }
+
+  /** An absent durable link quarantines only its index with a stable reason. */
+  @Test
+  public void absentLifecycleLinkQuarantinesIndexAndContinuesLoading() {
+    var broken = createIndexForRecovery("AbsentLifecycleTarget");
+    var healthy = createIndexForRecovery("AbsentLifecycleHealthy");
+    session.executeInTx(
+        tx -> tx.loadEntity(broken.getIdentity()).setLink(Index.LIFECYCLE_RECORD, null));
+    var recordsBefore = lifecycleRecordCount();
+
+    session.getSharedContext().getIndexManager().reload(session);
+
+    assertEquals(recordsBefore, lifecycleRecordCount());
+
+    var manager = session.getSharedContext().getIndexManager();
+    assertNotNull(manager.getIndex(broken.getName()));
+    assertNotNull(manager.getIndex(healthy.getName()));
+    var quarantine = storage().getIndexLifecycle(broken.getIdentity()).snapshot().buildState();
+    assertEquals(IndexLifecycle.INVALID, quarantine.lifecycle());
+    assertEquals(IndexBuildFailure.INDEX_BUILD_STATE_MISSING, quarantine.failure());
+    assertEquals("Index descriptor has no lifecycle record link", quarantine.failureMessage());
+  }
+
+  /** A dangling durable link quarantines only its index with a stable reason. */
+  @Test
+  public void missingLifecycleRecordQuarantinesIndexAndContinuesLoading() {
+    var broken = createIndexForRecovery("MissingLifecycleTarget");
+    var healthy = createIndexForRecovery("MissingLifecycleHealthy");
+    var collection =
+        storage().getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var missing = new com.jetbrains.youtrackdb.internal.core.id.RecordId(
+        collection, Long.MAX_VALUE - 17);
+    session.disableLinkConsistencyCheck();
+    try {
+      session.executeInTx(
+          tx -> tx.loadEntity(broken.getIdentity()).setLink(Index.LIFECYCLE_RECORD, missing));
+    } finally {
+      session.enableLinkConsistencyCheck();
+    }
+    var recordsBefore = lifecycleRecordCount();
+
+    session.getSharedContext().getIndexManager().reload(session);
+
+    assertEquals(recordsBefore, lifecycleRecordCount());
+    var manager = session.getSharedContext().getIndexManager();
+    assertNotNull(manager.getIndex(broken.getName()));
+    assertNotNull(manager.getIndex(healthy.getName()));
+    var quarantine = storage().getIndexLifecycle(broken.getIdentity()).snapshot().buildState();
+    assertEquals(IndexLifecycle.INVALID, quarantine.lifecycle());
+    assertEquals(IndexBuildFailure.INDEX_BUILD_STATE_MISSING, quarantine.failure());
+    assertEquals("Linked index build state record is missing", quarantine.failureMessage());
+  }
+
+  /** Dropping a quarantined dangling-link index removes its descriptor. */
+  @Test
+  public void danglingLifecycleLinkDoesNotBlockDropAndRebuild() {
+    var broken = createIndexForRecovery("DanglingDropTarget");
+    var descriptor = broken.getIdentity();
+    var collection =
+        storage().getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var missing = new com.jetbrains.youtrackdb.internal.core.id.RecordId(
+        collection, Long.MAX_VALUE - 23);
+    session.disableLinkConsistencyCheck();
+    try {
+      session.executeInTx(
+          tx -> tx.loadEntity(descriptor).setLink(Index.LIFECYCLE_RECORD, missing));
+    } finally {
+      session.enableLinkConsistencyCheck();
+    }
+    session.getSharedContext().getIndexManager().reload(session);
+
+    session.getSharedContext().getIndexManager().dropIndex(session, broken.getName());
+    assertThrows(
+        RecordNotFoundException.class,
+        () -> session.computeInTx(tx -> tx.loadEntity(descriptor)));
+
+    var cls = session.getMetadata().getSchema().getClass("DanglingDropTarget");
+    cls.createIndex(broken.getName(), SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(broken.getName()));
+  }
+
+  /** A missing lifecycle collection blocks loading without clearing shared indexes. */
+  @Test
+  public void missingBuildStateCollectionBlocksIndexLoading() {
+    session.dropCollection(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+
+    var manager = session.getSharedContext().getIndexManager();
+    var existing = manager.getIndex("OUser.name");
+    var failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> manager.reload(session));
+
+    assertEquals("The index build state collection is missing", failure.getMessage());
+    assertEquals(existing, manager.getIndex("OUser.name"));
+  }
+
+  private Index createIndexForRecovery(String className) {
+    var cls = session.getMetadata().getSchema().createClass(className);
+    cls.createProperty("name", PropertyType.STRING);
+    cls.createIndex(className + ".name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    return session.getSharedContext().getIndexManager().getIndex(className + ".name");
   }
 
   /**
@@ -282,6 +760,11 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
     assertTrue("the engine must be registered before the drop", engineIsRegistered(indexName));
     var droppedIndex = (IndexAbstract) indexManager.getIndex(indexName);
     var droppedDescriptorIdentity = droppedIndex.getIdentity();
+    var droppedLifecycleIdentity = lifecycleIdentity(droppedIndex);
+    var droppedLifecycleSnapshot =
+        storage()
+            .getIndexBuildStateStore()
+            .read(droppedDescriptorIdentity, droppedLifecycleIdentity);
     assertNotNull("the descriptor must have a lifecycle cell before drop",
         droppedIndex.getLifecycleCell());
 
@@ -293,6 +776,18 @@ public class CommitTimeIndexBuildTest extends DbTestBase {
         engineIsRegistered(indexName));
     assertNull("the committed drop must remove its lifecycle registry entry",
         storage().getIndexLifecycle(droppedDescriptorIdentity));
+    assertThrows(
+        "the transactional drop must delete the linked lifecycle record",
+        IllegalStateException.class,
+        () -> storage()
+            .getIndexBuildStateStore()
+            .read(droppedDescriptorIdentity, droppedLifecycleIdentity));
+    assertThrows(
+        "the transactional drop must delete the descriptor record",
+        RecordNotFoundException.class,
+        () -> session.computeInTx(
+            transaction -> transaction.loadEntity(droppedDescriptorIdentity)));
+    assertEquals(IndexLifecycle.EXISTS, droppedLifecycleSnapshot.lifecycle());
 
     session.getSharedContext().getIndexManager().reload(session);
     reOpen("admin", ADMIN_PASSWORD);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/ForeignIndexFactory.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/ForeignIndexFactory.java
@@ -1,0 +1,58 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import com.jetbrains.youtrackdb.internal.core.config.IndexEngineData;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.storage.Storage;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.lang.reflect.Proxy;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/** Service-loader fixture that returns a handle outside the supported implementation hierarchy. */
+public final class ForeignIndexFactory implements IndexFactory {
+
+  static final String INDEX_TYPE = "FOREIGN_TEST_INDEX";
+  static final String ALGORITHM = "FOREIGN_TEST_ALGORITHM";
+
+  private static final Index FOREIGN_HANDLE =
+      (Index) Proxy.newProxyInstance(
+          Index.class.getClassLoader(), new Class<?>[] {Index.class},
+          (proxy, method, args) -> null);
+
+  static String foreignHandleClassName() {
+    return FOREIGN_HANDLE.getClass().getName();
+  }
+
+  @Override
+  public int getLastVersion(String algorithm) {
+    return 0;
+  }
+
+  @Override
+  public Set<String> getTypes() {
+    return Set.of(INDEX_TYPE);
+  }
+
+  @Override
+  public Set<String> getAlgorithms() {
+    return Set.of(ALGORITHM);
+  }
+
+  @Override
+  public Index createIndex(String indexType, @Nonnull Storage storage) {
+    return FOREIGN_HANDLE;
+  }
+
+  @Override
+  public Index createIndex(String indexType, @Nullable RID identity,
+      @Nonnull FrontendTransactionImpl transaction, @Nonnull Storage storage) {
+    return FOREIGN_HANDLE;
+  }
+
+  @Override
+  public BaseIndexEngine createIndexEngine(Storage storage, IndexEngineData data) {
+    throw new UnsupportedOperationException("The foreign-index fixture creates no engines");
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
@@ -37,6 +40,43 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
   // if multiple tests shared the same class — which they don't here.
   private static final String CLASS_NAME = "AbsCorePathsTest";
 
+  /** Reattachment refreshes a same-slot engine replacement when its generation changes. */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void attachmentRefreshesSameSlotReplacementGeneration() throws Exception {
+    var cls = session.createClass("SameSlotRefresh");
+    cls.createProperty("value", PropertyType.INTEGER);
+    var indexName = "SameSlotRefresh.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var index = (IndexAbstract) session.getSharedContext().getIndexManager().getIndex(indexName);
+    var oldReference = index.getEngineReference();
+    var oldCell = index.getLifecycleCell();
+    var storage = (AbstractStorage) session.getStorage();
+    var enginesField = AbstractStorage.class.getDeclaredField("indexEngines");
+    enginesField.setAccessible(true);
+    var engines = (List<BaseIndexEngine>) enginesField.get(storage);
+    var oldEngine = (BTreeSingleValueIndexEngine) engines.get(oldReference.slot());
+    var replacement = new BTreeSingleValueIndexEngine(
+        oldReference.slot(), oldEngine.getFileBaseId(), oldEngine.getName(), storage, 4);
+
+    engines.set(oldReference.slot(), replacement);
+    try {
+      index.attachDescriptorIdentity();
+
+      assertSame("attachment must install the replacement reference",
+          replacement.getEngineReference(), index.getEngineReference());
+      assertTrue("the replacement generation must advance",
+          index.getEngineReference().generation() > oldReference.generation());
+      assertEquals("the replacement must bind to the existing descriptor", index.getIdentity(),
+          index.getEngineReference().ownerDescriptorIdentity());
+      assertSame("an engine replacement must retain the descriptor lifecycle cell", oldCell,
+          index.getLifecycleCell());
+    } finally {
+      engines.set(oldReference.slot(), oldEngine);
+    }
+  }
+
   /** A lock-free identifier reader cannot attach a replacement engine to the old rebuild RID. */
   @Test
   public void identifierAccessorRacingRebuildCannotBindStaleDescriptor() throws Exception {
@@ -54,15 +94,17 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
     var oldDescriptorIdentity = index.getIdentity();
     var oldIndexId = index.getIndexId();
     var started = new CountDownLatch(1);
+    var observedReplacement = new CountDownLatch(1);
     var stop = new AtomicBoolean();
-    var observedReplacement = new AtomicBoolean();
     var readerFailure = new AtomicReference<Throwable>();
     var reader = new Thread(() -> {
       started.countDown();
+      var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
       try {
-        while (!stop.get()) {
+        while (!stop.get() && System.nanoTime() < deadline) {
           if (index.getIndexId() != oldIndexId) {
-            observedReplacement.set(true);
+            observedReplacement.countDown();
+            return;
           }
         }
       } catch (Throwable failure) {
@@ -71,19 +113,21 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
     }, "index-id-reader");
 
     reader.start();
-    started.await();
+    assertTrue("the identifier reader must start within ten seconds",
+        started.await(10, TimeUnit.SECONDS));
+    boolean replacementObserved;
     try {
       index.rebuild(session);
-      for (var i = 0; i < 10_000 && !observedReplacement.get(); i++) {
-        Thread.onSpinWait();
-      }
+      replacementObserved = observedReplacement.await(10, TimeUnit.SECONDS);
     } finally {
       stop.set(true);
-      reader.join();
+      reader.join(TimeUnit.SECONDS.toMillis(10));
     }
 
+    assertFalse("the identifier reader must stop by its deadline", reader.isAlive());
     assertNull("the pure identifier accessor must not fail during rebuild", readerFailure.get());
-    assertTrue("the reader must observe the replacement engine", observedReplacement.get());
+    assertTrue("the reader must observe the replacement engine within ten seconds",
+        replacementObserved);
     assertFalse("rebuild must allocate a fresh descriptor identity",
         oldDescriptorIdentity.equals(index.getIdentity()));
     assertEquals("the replacement engine must bind to the replacement descriptor",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -44,10 +44,10 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
   // if multiple tests shared the same class — which they don't here.
   private static final String CLASS_NAME = "AbsCorePathsTest";
 
-  /** Reattachment refreshes a same-slot engine replacement when its generation changes. */
+  /** Reattachment rejects an unbound same-slot replacement from an older carrier. */
   @SuppressWarnings("unchecked")
   @Test
-  public void attachmentRefreshesSameSlotReplacementGeneration() throws Exception {
+  public void attachmentRejectsUnboundSameSlotReplacementGeneration() throws Exception {
     var cls = session.createClass("SameSlotRefresh");
     cls.createProperty("value", PropertyType.INTEGER);
     var indexName = "SameSlotRefresh.value";
@@ -66,15 +66,13 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
 
     engines.set(oldReference.slot(), replacement);
     try {
-      index.attachDescriptorIdentity();
+      assertThrows(IllegalStateException.class, index::attachDescriptorIdentity);
 
-      assertSame("attachment must install the replacement reference",
-          replacement.getEngineReference(), index.getEngineReference());
-      assertTrue("the replacement generation must advance",
-          index.getEngineReference().generation() > oldReference.generation());
-      assertEquals("the replacement must bind to the existing descriptor", index.getIdentity(),
-          index.getEngineReference().ownerDescriptorIdentity());
-      assertSame("an engine replacement must retain the descriptor lifecycle cell", oldCell,
+      assertSame("rejected attachment must retain the old reference",
+          oldReference, index.getEngineReference());
+      assertNull("rejected attachment must not claim the replacement",
+          replacement.getEngineReference().ownerDescriptorIdentity());
+      assertSame("rejected attachment must retain the descriptor lifecycle cell", oldCell,
           index.getLifecycleCell());
     } finally {
       engines.set(oldReference.slot(), oldEngine);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -636,6 +637,19 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
             tx -> staleIndex.getRids(session, "replacement-value").toList()));
     session.begin();
     try {
+      assertThrows(
+          StaleIndexEngineException.class,
+          () -> staleIndex.doPut(
+              session, (AbstractStorage) session.getStorage(), "foreign-write",
+              new RecordId(7, 42)));
+      assertEquals("a stale write must not poison storage", "OPEN",
+          session.getStorage().getStatus().name());
+      assertThrows(
+          StaleIndexEngineException.class,
+          () -> staleIndex.acquireAtomicExclusiveLock(
+              session.getActiveTransaction().getAtomicOperation()));
+      assertEquals("detached lock acquisition must not poison storage", "OPEN",
+          session.getStorage().getStatus().name());
       assertThrows(
           StaleIndexEngineException.class,
           () -> staleIndex.delete(session.getTransactionInternal()));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -5,9 +5,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -604,6 +606,49 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
   // -----------------------------------------------------------------------
   //  clear / drop lifecycle — observable via stream
   // -----------------------------------------------------------------------
+
+  /**
+   * A handle retained across a same-name drop and recreate must not recover to the replacement
+   * engine. Reads and deletes through that stale handle fail closed, while the new index remains
+   * registered and readable.
+   */
+  @Test
+  public void staleHandleCannotReadOrDeleteSameNameReplacement() {
+    var clsName = CLASS_NAME + "StaleReplacement";
+    var cls = session.createClass(clsName);
+    cls.createProperty("prop", PropertyType.STRING);
+    var indexName = clsName + ".prop";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "prop");
+
+    var indexManager = session.getSharedContext().getIndexManager();
+    var staleIndex = (IndexAbstract) indexManager.getIndex(indexName);
+    indexManager.dropIndex(session, indexName);
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "prop");
+    session.executeInTx(
+        tx -> tx.newEntity(clsName).setProperty("prop", "replacement-value"));
+
+    var replacement = (IndexAbstract) indexManager.getIndex(indexName);
+    assertTrue("the recreated index must use a different descriptor",
+        !staleIndex.getIdentity().equals(replacement.getIdentity()));
+    assertThrows(
+        StaleIndexEngineException.class,
+        () -> session.computeInTx(
+            tx -> staleIndex.getRids(session, "replacement-value").toList()));
+    session.begin();
+    try {
+      assertThrows(
+          StaleIndexEngineException.class,
+          () -> staleIndex.delete(session.getTransactionInternal()));
+    } finally {
+      session.rollback();
+    }
+
+    assertSame("the stale delete must leave the replacement published", replacement,
+        indexManager.getIndex(indexName));
+    var replacementRids = session.computeInTx(
+        tx -> replacement.getRids(session, "replacement-value").toList());
+    assertEquals("the stale handle must not damage replacement data", 1, replacementRids.size());
+  }
 
   /**
    * After inserting records and then deleting the index via {@code SchemaClass.dropIndex},

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
 import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
@@ -602,6 +603,86 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
 
     // UNIQUE index: get() returns null (not an iterator) when nothing is found.
     assertNull("UNIQUE index get() must return null for a missing key", result);
+  }
+
+  // -----------------------------------------------------------------------
+  //  engine creation failure transitions
+  // -----------------------------------------------------------------------
+
+  /** A failed initial engine construction leaves the new handle in the never-built shape. */
+  @Test
+  public void createEngineFailureLeavesNeverBuiltCarrier() {
+    var clsName = CLASS_NAME + "CreateEngineFailure";
+    var cls = session.createClass(clsName);
+    cls.createProperty("prop", PropertyType.STRING);
+    var sourceName = clsName + ".source";
+    cls.createIndex(sourceName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "prop");
+    var source = (IndexAbstract) session.getSharedContext().getIndexManager().getIndex(sourceName);
+    var failedName = clsName + ".failed";
+    var metadata = new IndexMetadata(
+        failedName, source.getDefinition(), source.getCollections(), source.getType(),
+        source.getAlgorithm(), source.getVersion(), source.getMetadata());
+    var failed = new IndexNotUnique(session.getStorage());
+    var storage = (AbstractStorage) session.getStorage();
+
+    storage.setIndexEngineCreationTestHook(
+        () -> {
+          throw new CommandInterruptedException(
+              session.getDatabaseName(), "injected initial engine construction failure");
+        });
+    session.begin();
+    try {
+      assertThrows(
+          IndexException.class,
+          () -> failed.create(session.getTransactionInternal(), metadata));
+    } finally {
+      storage.setIndexEngineCreationTestHook(null);
+      session.rollback();
+    }
+
+    assertFalse("failed creation must not publish an engine", failed.state().hasEngine());
+    assertNull("failed creation must not allocate descriptor identity",
+        failed.state().descriptorIdentity());
+    assertNull("failed creation must not retain lifecycle ownership",
+        failed.state().lifecycleCell());
+    assertEquals("failed creation must leave no registered engine", -1,
+        storage.loadIndexEngine(failedName));
+  }
+
+  /** A failed rebuild replacement remains durably identified and fails closed on later reads. */
+  @Test
+  public void rebuildEngineFailureLeavesDetachedFailClosedCarrier() {
+    var clsName = CLASS_NAME + "RebuildEngineFailure";
+    var cls = session.createClass(clsName);
+    cls.createProperty("prop", PropertyType.STRING);
+    var indexName = clsName + ".prop";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "prop");
+    var index = (IndexAbstract) session.getSharedContext().getIndexManager().getIndex(indexName);
+    var descriptorIdentity = index.getIdentity();
+    var storage = (AbstractStorage) session.getStorage();
+
+    storage.setIndexEngineCreationTestHook(
+        () -> {
+          throw new CommandInterruptedException(
+              session.getDatabaseName(), "injected rebuild replacement construction failure");
+        });
+    try {
+      assertThrows(IndexException.class, () -> index.rebuild(session));
+    } finally {
+      storage.setIndexEngineCreationTestHook(null);
+    }
+
+    assertFalse("failed rebuild must leave the old engine detached", index.state().hasEngine());
+    assertEquals("failed rebuild must retain the deleted descriptor identity",
+        descriptorIdentity, index.state().descriptorIdentity());
+    assertNull("failed rebuild must release lifecycle ownership", index.state().lifecycleCell());
+    assertEquals("failed replacement must leave no registered engine", -1,
+        storage.loadIndexEngine(indexName));
+    assertThrows(
+        StaleIndexEngineException.class,
+        () -> session.computeInTx(tx -> index.getRids(session, "missing").toList()));
+    assertEquals("failed rebuild reads must not poison storage", "OPEN",
+        session.getStorage().getStatus().name());
   }
 
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -10,10 +10,14 @@ import static org.junit.Assert.assertTrue;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 /**
@@ -32,6 +36,61 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
   // Inline class names per test keep each fixture independent. Constants would only be useful
   // if multiple tests shared the same class — which they don't here.
   private static final String CLASS_NAME = "AbsCorePathsTest";
+
+  /** A lock-free identifier reader cannot attach a replacement engine to the old rebuild RID. */
+  @Test
+  public void identifierAccessorRacingRebuildCannotBindStaleDescriptor() throws Exception {
+    var cls = session.createClass("AccessorRebuildRace");
+    cls.createProperty("value", PropertyType.INTEGER);
+    var indexName = "AccessorRebuildRace.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+    session.executeInTx(tx -> {
+      for (var i = 0; i < 500; i++) {
+        tx.newEntity("AccessorRebuildRace").setProperty("value", i);
+      }
+    });
+
+    var index = (IndexAbstract) session.getSharedContext().getIndexManager().getIndex(indexName);
+    var oldDescriptorIdentity = index.getIdentity();
+    var oldIndexId = index.getIndexId();
+    var started = new CountDownLatch(1);
+    var stop = new AtomicBoolean();
+    var observedReplacement = new AtomicBoolean();
+    var readerFailure = new AtomicReference<Throwable>();
+    var reader = new Thread(() -> {
+      started.countDown();
+      try {
+        while (!stop.get()) {
+          if (index.getIndexId() != oldIndexId) {
+            observedReplacement.set(true);
+          }
+        }
+      } catch (Throwable failure) {
+        readerFailure.set(failure);
+      }
+    }, "index-id-reader");
+
+    reader.start();
+    started.await();
+    try {
+      index.rebuild(session);
+      for (var i = 0; i < 10_000 && !observedReplacement.get(); i++) {
+        Thread.onSpinWait();
+      }
+    } finally {
+      stop.set(true);
+      reader.join();
+    }
+
+    assertNull("the pure identifier accessor must not fail during rebuild", readerFailure.get());
+    assertTrue("the reader must observe the replacement engine", observedReplacement.get());
+    assertFalse("rebuild must allocate a fresh descriptor identity",
+        oldDescriptorIdentity.equals(index.getIdentity()));
+    assertEquals("the replacement engine must bind to the replacement descriptor",
+        index.getIdentity(), index.getEngineReference().ownerDescriptorIdentity());
+    assertNull("the replaced descriptor must leave the lifecycle registry",
+        ((AbstractStorage) session.getStorage()).getIndexLifecycle(oldDescriptorIdentity));
+  }
 
   // -----------------------------------------------------------------------
   //  Key normalization: enhanceToCompositeKeyBetweenAsc / Desc

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractCorePathsTest.java
@@ -578,6 +578,27 @@ public class IndexAbstractCorePathsTest extends DbTestBase {
     assertNotNull("index definition must survive round-trip", loaded.getIndexDefinition());
   }
 
+  /** Loading an index descriptor rejects forged metadata in the reserved namespace. */
+  @Test
+  public void loadMetadataRejectsReservedPrefix() {
+    var clsName = CLASS_NAME + "Reserved";
+    var cls = session.createClass(clsName);
+    cls.createProperty("prop", PropertyType.STRING);
+    var idxName = clsName + ".prop";
+    cls.createIndex(idxName, SchemaClass.INDEX_TYPE.UNIQUE, "prop");
+    var index = (IndexAbstract) session.getSharedContext().getIndexManager().getIndex(idxName);
+    Map<String, Object> config = index.getConfiguration(session);
+    config.put("metadata", Map.of("__ytdb_state", "forged"));
+
+    session.begin();
+    try {
+      assertThrows(IllegalArgumentException.class,
+          () -> IndexAbstract.loadMetadataFromMap(session.getTransactionInternal(), config));
+    } finally {
+      session.rollback();
+    }
+  }
+
   // -----------------------------------------------------------------------
   //  get() — no-result branch on a UNIQUE index
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
@@ -151,7 +151,8 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(5))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(7);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(7, null));
     when(storage.getIndexEngine(7)).thenReturn(btreeEngine);
 
     // When
@@ -223,7 +224,8 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(4))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(8);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(8, null));
     when(storage.getIndexEngine(8)).thenReturn(btreeEngine);
 
     // When
@@ -319,7 +321,8 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(3))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(9);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(9, null));
     when(storage.getIndexEngine(9)).thenReturn(btreeEngine);
 
     // When
@@ -426,7 +429,8 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(6))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(10);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(10, null));
     when(storage.getIndexEngine(10)).thenReturn(btreeEngine);
 
     // When
@@ -579,7 +583,8 @@ public class IndexAbstractHistogramDelegationTest {
     var engine = mock(BaseIndexEngine.class);
     when(storage.getIndexEngine(7))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(11);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(11, null));
     when(storage.getIndexEngine(11)).thenReturn(engine);
 
     // When

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
@@ -49,28 +49,14 @@ public class IndexAbstractHistogramDelegationTest {
     setDescriptorIdentity(DESCRIPTOR_IDENTITY);
   }
 
-  /**
-   * Sets the indexId field on the IndexAbstract via reflection.
-   */
+  /** Sets the engine identifier used by the delegation fixture. */
   private void setIndexId(int indexId) {
-    try {
-      var field = IndexAbstract.class.getDeclaredField("indexId");
-      field.setAccessible(true);
-      field.set(index, indexId);
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException("Failed to set indexId", e);
-    }
+    index.setEngineIdentifierForTest(indexId);
   }
 
   /** Sets the descriptor identity needed for owner-bound stale-engine recovery. */
   private void setDescriptorIdentity(RecordId descriptorIdentity) {
-    try {
-      var field = IndexAbstract.class.getDeclaredField("identity");
-      field.setAccessible(true);
-      field.set(index, descriptorIdentity);
-    } catch (ReflectiveOperationException e) {
-      throw new RuntimeException("Failed to set descriptor identity", e);
-    }
+    index.setDescriptorIdentityForTest(descriptorIdentity);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
@@ -52,6 +52,12 @@ public class IndexAbstractHistogramDelegationTest {
   /** Sets the engine identifier used by the delegation fixture. */
   private void setIndexId(int indexId) {
     index.setEngineIdentifierForTest(indexId);
+    try {
+      when(storage.getIndexEngine(indexId, null))
+          .thenAnswer(invocation -> storage.getIndexEngine(indexId));
+    } catch (InvalidIndexEngineIdException exception) {
+      throw new AssertionError(exception);
+    }
   }
 
   /** Sets the descriptor identity needed for owner-bound stale-engine recovery. */
@@ -140,6 +146,7 @@ public class IndexAbstractHistogramDelegationTest {
     when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
         .thenReturn(new AbstractStorage.ResolvedIndexEngine(7, null));
     when(storage.getIndexEngine(7)).thenReturn(btreeEngine);
+    when(storage.getIndexEngine(7, null)).thenReturn(btreeEngine);
 
     // When
     var result = index.getStatistics(session);
@@ -213,6 +220,7 @@ public class IndexAbstractHistogramDelegationTest {
     when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
         .thenReturn(new AbstractStorage.ResolvedIndexEngine(8, null));
     when(storage.getIndexEngine(8)).thenReturn(btreeEngine);
+    when(storage.getIndexEngine(8, null)).thenReturn(btreeEngine);
 
     // When
     var result = index.getHistogram(session);
@@ -310,6 +318,7 @@ public class IndexAbstractHistogramDelegationTest {
     when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY))
         .thenReturn(new AbstractStorage.ResolvedIndexEngine(9, null));
     when(storage.getIndexEngine(9)).thenReturn(btreeEngine);
+    when(storage.getIndexEngine(9, null)).thenReturn(btreeEngine);
 
     // When
     var result = index.analyzeHistogram(session);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexAbstractHistogramDelegationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.EquiDepthHistogram;
 import com.jetbrains.youtrackdb.internal.core.index.engine.HistogramSnapshot;
@@ -34,6 +35,8 @@ import org.junit.Test;
  */
 public class IndexAbstractHistogramDelegationTest {
 
+  private static final RecordId DESCRIPTOR_IDENTITY = new RecordId(17, 42);
+
   private AbstractStorage storage;
   private DatabaseSessionEmbedded session;
   private IndexNotUnique index;
@@ -43,6 +46,7 @@ public class IndexAbstractHistogramDelegationTest {
     storage = mock(AbstractStorage.class);
     session = mock(DatabaseSessionEmbedded.class);
     index = new IndexNotUnique(storage);
+    setDescriptorIdentity(DESCRIPTOR_IDENTITY);
   }
 
   /**
@@ -55,6 +59,17 @@ public class IndexAbstractHistogramDelegationTest {
       field.set(index, indexId);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException("Failed to set indexId", e);
+    }
+  }
+
+  /** Sets the descriptor identity needed for owner-bound stale-engine recovery. */
+  private void setDescriptorIdentity(RecordId descriptorIdentity) {
+    try {
+      var field = IndexAbstract.class.getDeclaredField("identity");
+      field.setAccessible(true);
+      field.set(index, descriptorIdentity);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to set descriptor identity", e);
     }
   }
 
@@ -118,11 +133,11 @@ public class IndexAbstractHistogramDelegationTest {
   }
 
   /**
-   * Verifies that getStatistics() retries when InvalidIndexEngineIdException
-   * is thrown, reloads the engine ID, and succeeds on the second attempt.
+   * Verifies that getStatistics() resolves a stale identifier through its descriptor owner and
+   * succeeds on the second attempt.
    */
   @Test
-  public void getStatistics_retriesOnInvalidEngineId()
+  public void getStatistics_staleIdentifier_recoversByDescriptorOwner()
       throws InvalidIndexEngineIdException {
     // Given: first call throws, second call succeeds
     setIndexId(5);
@@ -136,16 +151,15 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(5))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    // After reload, the new indexId is 7
-    when(storage.loadIndexEngine("testIndex")).thenReturn(7);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(7);
     when(storage.getIndexEngine(7)).thenReturn(btreeEngine);
 
     // When
     var result = index.getStatistics(session);
 
-    // Then: returns the stats from the reloaded engine
+    // Then: returns the stats from the owner-resolved engine
     assertSame(stats, result);
-    verify(storage).loadIndexEngine("testIndex");
+    verify(storage).resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY);
   }
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -192,11 +206,11 @@ public class IndexAbstractHistogramDelegationTest {
   }
 
   /**
-   * Verifies that getHistogram() retries on InvalidIndexEngineIdException,
-   * reloads, and returns the histogram on the second attempt.
+   * Verifies that getHistogram() resolves a stale identifier through its descriptor owner and
+   * returns the histogram on the second attempt.
    */
   @Test
-  public void getHistogram_retriesOnInvalidEngineId()
+  public void getHistogram_staleIdentifier_recoversByDescriptorOwner()
       throws InvalidIndexEngineIdException {
     setIndexId(4);
     var im = mock(IndexMetadata.class);
@@ -209,7 +223,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(4))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.loadIndexEngine("hIdx")).thenReturn(8);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(8);
     when(storage.getIndexEngine(8)).thenReturn(btreeEngine);
 
     // When
@@ -217,7 +231,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     // Then
     assertSame(histogram, result);
-    verify(storage).loadIndexEngine("hIdx");
+    verify(storage).resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY);
   }
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -286,11 +300,11 @@ public class IndexAbstractHistogramDelegationTest {
   }
 
   /**
-   * Verifies that analyzeHistogram() retries on InvalidIndexEngineIdException
-   * and returns the snapshot after reload.
+   * Verifies that analyzeHistogram() resolves a stale identifier through its descriptor owner and
+   * returns the snapshot on the second attempt.
    */
   @Test
-  public void analyzeHistogram_retriesOnInvalidEngineId()
+  public void analyzeHistogram_staleIdentifier_recoversByDescriptorOwner()
       throws InvalidIndexEngineIdException {
     setIndexId(3);
     var im = mock(IndexMetadata.class);
@@ -305,7 +319,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(3))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.loadIndexEngine("aIdx")).thenReturn(9);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(9);
     when(storage.getIndexEngine(9)).thenReturn(btreeEngine);
 
     // When
@@ -313,7 +327,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     // Then
     assertSame(snapshot, result);
-    verify(storage).loadIndexEngine("aIdx");
+    verify(storage).resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY);
   }
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -397,11 +411,9 @@ public class IndexAbstractHistogramDelegationTest {
     verify(storage).getIndexEngine(6);
   }
 
-  /**
-   * Verifies that setBulkLoading() retries on InvalidIndexEngineIdException.
-   */
+  /** Verifies that setBulkLoading() recovers a stale identifier through its descriptor owner. */
   @Test
-  public void setBulkLoading_retriesOnInvalidEngineId()
+  public void setBulkLoading_staleIdentifier_recoversByDescriptorOwner()
       throws Exception {
     setIndexId(6);
     var im = mock(IndexMetadata.class);
@@ -414,7 +426,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     when(storage.getIndexEngine(6))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.loadIndexEngine("bulkIdx")).thenReturn(10);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(10);
     when(storage.getIndexEngine(10)).thenReturn(btreeEngine);
 
     // When
@@ -422,7 +434,7 @@ public class IndexAbstractHistogramDelegationTest {
 
     // Then
     verify(manager).setBulkLoading(true);
-    verify(storage).loadIndexEngine("bulkIdx");
+    verify(storage).resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY);
   }
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -552,11 +564,11 @@ public class IndexAbstractHistogramDelegationTest {
   }
 
   /**
-   * Verifies that buildHistogramAfterFill() retries on
-   * InvalidIndexEngineIdException and proceeds correctly.
+   * Verifies that buildHistogramAfterFill() resolves a stale identifier through its descriptor
+   * owner and proceeds correctly.
    */
   @Test
-  public void buildHistogramAfterFill_retriesOnInvalidEngineId()
+  public void buildHistogramAfterFill_staleIdentifier_recoversByDescriptorOwner()
       throws Exception {
     setIndexId(7);
     var im = mock(IndexMetadata.class);
@@ -567,14 +579,14 @@ public class IndexAbstractHistogramDelegationTest {
     var engine = mock(BaseIndexEngine.class);
     when(storage.getIndexEngine(7))
         .thenThrow(new InvalidIndexEngineIdException("stale"));
-    when(storage.loadIndexEngine("fillIdx")).thenReturn(11);
+    when(storage.resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY)).thenReturn(11);
     when(storage.getIndexEngine(11)).thenReturn(engine);
 
     // When
     invokeBuildHistogramAfterFill();
 
-    // Then: reload was triggered
-    verify(storage).loadIndexEngine("fillIdx");
+    // Then: owner recovery was triggered
+    verify(storage).resolveIndexEngineByOwner(DESCRIPTOR_IDENTITY);
   }
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexEngineTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexEngineTestSupport.java
@@ -35,4 +35,8 @@ public final class IndexEngineTestSupport {
       DatabaseSessionEmbedded session, String indexName) {
     return engine(session, indexName).getId();
   }
+
+  public static void setEngineIdentifier(IndexAbstract index, int engineIdentifier) {
+    index.setEngineIdentifierForTest(engineIdentifier);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexEngineTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexEngineTestSupport.java
@@ -1,0 +1,38 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+
+/** Shared access to an index engine without reflecting on index handle fields. */
+public final class IndexEngineTestSupport {
+
+  private IndexEngineTestSupport() {
+  }
+
+  public static int externalIdentifier(Index index) {
+    return index.getIndexId();
+  }
+
+  public static int externalIdentifier(
+      DatabaseSessionEmbedded session, String indexName) {
+    return externalIdentifier(
+        session.getSharedContext().getIndexManager().getIndex(indexName));
+  }
+
+  public static BaseIndexEngine engine(
+      DatabaseSessionEmbedded session, String indexName) {
+    var storage = (AbstractStorage) session.getStorage();
+    try {
+      return storage.getIndexEngine(externalIdentifier(session, indexName));
+    } catch (InvalidIndexEngineIdException exception) {
+      throw new AssertionError("Index engine is not registered: " + indexName, exception);
+    }
+  }
+
+  public static int internalIdentifier(
+      DatabaseSessionEmbedded session, String indexName) {
+    return engine(session, indexName).getId();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
@@ -12,11 +12,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -66,6 +68,90 @@ public class IndexHandleStateTest {
     assertEquals(2, calls.get());
     assertEquals(7, used.engineIdentifier());
     assertTrue(used.engineReference() == reference);
+  }
+
+  @Test
+  public void neverBuiltAndDetachedCarriersFailBeforeStorageAccess() {
+    var storage = mock(AbstractStorage.class);
+    when(storage.getName()).thenReturn("carrier-test");
+    var index = namedIndex(storage);
+    var calls = new AtomicInteger();
+
+    var neverBuilt = assertThrows(
+        StaleIndexEngineException.class,
+        () -> index.runWithOwner(current -> {
+          calls.incrementAndGet();
+          return current;
+        }));
+    assertTrue(neverBuilt.getMessage().contains("has not built its engine"));
+    assertEquals(0, calls.get());
+
+    var owner = new RecordId(3, 4);
+    index.setHandleStateForTest(-1, owner);
+    var detached = assertThrows(
+        StaleIndexEngineException.class,
+        () -> index.runWithOwner(current -> {
+          calls.incrementAndGet();
+          return current;
+        }));
+    assertTrue(detached.getMessage().contains(owner.toString()));
+    assertEquals(0, calls.get());
+  }
+
+  @Test
+  public void ownerRecoveryRejectsHandleWithoutDurableIdentity() {
+    var storage = mock(AbstractStorage.class);
+    when(storage.getName()).thenReturn("carrier-test");
+    var index = namedIndex(storage);
+    index.setHandleStateForTest(99, null);
+
+    var exception = assertThrows(
+        StaleIndexEngineException.class,
+        () -> index.runWithOwner(current -> {
+          throw new InvalidIndexEngineIdException("stale fixture");
+        }));
+
+    assertTrue(exception.getMessage().contains("no durable owner"));
+  }
+
+  @Test
+  public void missingOwnerFailsClosedDuringRecovery() {
+    var storage = mock(AbstractStorage.class);
+    when(storage.getName()).thenReturn("carrier-test");
+    var owner = new RecordId(3, 4);
+    when(storage.resolveIndexEngineByOwner(owner))
+        .thenThrow(new StaleIndexEngineException("missing owner"));
+    var index = namedIndex(storage);
+    index.setHandleStateForTest(99, owner);
+
+    var exception = assertThrows(
+        StaleIndexEngineException.class,
+        () -> index.runWithOwner(current -> {
+          throw new InvalidIndexEngineIdException("stale fixture");
+        }));
+
+    assertTrue(exception.getMessage().contains(owner.toString()));
+    assertTrue(exception.getMessage().contains("no registered engine"));
+  }
+
+  @Test
+  public void durableIdentityCannotChangeWhileLifecycleIsAttached() throws Exception {
+    var storage = mock(AbstractStorage.class);
+    var cell = mock(IndexLifecycleCell.class);
+    var original = new RecordId(3, 4);
+    var replacement = new RecordId(3, 5);
+    var index = namedIndex(storage);
+    index.setHandleStateForTest(1, original);
+    when(storage.attachIndexEngineOwner(1, original, null)).thenReturn(null);
+    when(storage.getOrCreateIndexLifecycle(original)).thenReturn(cell);
+    index.attachDescriptorIdentity();
+
+    var exception = assertThrows(
+        IllegalStateException.class,
+        () -> invokeDescriptorPublication(index, replacement));
+    assertTrue(exception.getMessage().contains("cannot be replaced"));
+    assertEquals(original, index.state().descriptorIdentity());
+    assertTrue(index.state().lifecycleCell() == cell);
   }
 
   @Test
@@ -168,6 +254,30 @@ public class IndexHandleStateTest {
         Thread.currentThread().interrupt();
         throw new AssertionError(exception);
       }
+    }
+  }
+
+  private static TestIndex namedIndex(AbstractStorage storage) {
+    var index = new TestIndex(storage);
+    var metadata = mock(IndexMetadata.class);
+    when(metadata.getName()).thenReturn("carrier-index");
+    index.im = metadata;
+    return index;
+  }
+
+  private static void invokeDescriptorPublication(TestIndex index, RecordId identity)
+      throws Exception {
+    var method = IndexAbstract.class.getDeclaredMethod(
+        "publishDescriptorIdentity",
+        com.jetbrains.youtrackdb.internal.core.db.record.record.RID.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(index, identity);
+    } catch (InvocationTargetException exception) {
+      if (exception.getCause() instanceof Exception cause) {
+        throw cause;
+      }
+      throw exception;
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
@@ -1,0 +1,44 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
+import org.junit.Test;
+
+/** Verifies legal carrier shapes and the component invariants that reject torn states. */
+public class IndexHandleStateTest {
+
+  @Test
+  public void emptyAndEngineShapesExposeTheirDerivedState() {
+    assertFalse(IndexHandleState.EMPTY.hasEngine());
+    assertFalse(IndexHandleState.EMPTY.isDurablyIdentified());
+
+    var engine = new IndexHandleState(1, new IndexEngineReference(1, 0, 1), null, null);
+    assertTrue(engine.hasEngine());
+    assertFalse(engine.isDurablyIdentified());
+  }
+
+  @Test
+  public void absentEngineRejectsReference() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> new IndexHandleState(-1, new IndexEngineReference(1, 0, 1), null, null));
+  }
+
+  @Test
+  public void lifecycleCellRequiresDurableIdentity() {
+    var cell = mock(IndexLifecycleCell.class);
+    assertThrows(
+        IllegalStateException.class,
+        () -> new IndexHandleState(1, new IndexEngineReference(1, 0, 1), null, cell));
+
+    var durable = new IndexHandleState(
+        1, new IndexEngineReference(1, 0, 1), new RecordId(3, 4), cell);
+    assertTrue(durable.isDurablyIdentified());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
@@ -50,7 +50,7 @@ public class IndexHandleStateTest {
   @Test
   public void ownerRecoveryReusesTheResolvedCarrier() {
     var storage = mock(AbstractStorage.class);
-    var reference = new IndexEngineReference(7, 1, 2);
+    var reference = new IndexEngineReference(7, 0, 2);
     var owner = new RecordId(3, 4);
     when(storage.resolveIndexEngineByOwner(owner))
         .thenReturn(new AbstractStorage.ResolvedIndexEngine(7, reference));
@@ -231,6 +231,14 @@ public class IndexHandleStateTest {
 
     assertEquals(2, index.state().engineIdentifier());
     assertEquals(replacementIdentity, index.state().descriptorIdentity());
+  }
+
+  /** Carrier construction rejects identifier and reference pairs from different engine slots. */
+  @Test
+  public void engineIdentifierMustMatchReference() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> new IndexHandleState(1, new IndexEngineReference(2, 0, 1), null, null));
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexHandleStateTest.java
@@ -1,13 +1,28 @@
 package com.jetbrains.youtrackdb.internal.core.index;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycleCell;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import org.junit.Test;
 
 /** Verifies legal carrier shapes and the component invariants that reject torn states. */
@@ -31,6 +46,108 @@ public class IndexHandleStateTest {
   }
 
   @Test
+  public void ownerRecoveryReusesTheResolvedCarrier() {
+    var storage = mock(AbstractStorage.class);
+    var reference = new IndexEngineReference(7, 1, 2);
+    var owner = new RecordId(3, 4);
+    when(storage.resolveIndexEngineByOwner(owner))
+        .thenReturn(new AbstractStorage.ResolvedIndexEngine(7, reference));
+    var index = new TestIndex(storage);
+    index.setHandleStateForTest(99, owner);
+    var calls = new AtomicInteger();
+
+    var used = index.runWithOwner(current -> {
+      if (calls.getAndIncrement() == 0) {
+        throw new InvalidIndexEngineIdException("stale fixture");
+      }
+      return current;
+    });
+
+    assertEquals(2, calls.get());
+    assertEquals(7, used.engineIdentifier());
+    assertTrue(used.engineReference() == reference);
+  }
+
+  @Test
+  public void listenerConvergesAndAttachmentCancelsSubscription() throws Exception {
+    var storage = mock(AbstractStorage.class);
+    var lifecycleCell = mock(IndexLifecycleCell.class);
+    var pending = new ChangeableRecordId();
+    var index = new TestIndex(storage);
+    index.setHandleStateForTest(1, null);
+    when(storage.attachIndexEngineOwner(1, new RecordId(3, 4), null)).thenReturn(null);
+    when(storage.getOrCreateIndexLifecycle(new RecordId(3, 4))).thenReturn(lifecycleCell);
+
+    var publish = IndexAbstract.class.getDeclaredMethod(
+        "publishDescriptorIdentity",
+        com.jetbrains.youtrackdb.internal.core.db.record.record.RID.class);
+    publish.setAccessible(true);
+    publish.invoke(index, pending);
+    pending.setCollectionAndPosition(3, 4);
+
+    var converged = index.state();
+    assertTrue(converged.isDurablyIdentified());
+    assertNotSame(pending, converged.descriptorIdentity());
+    index.attachDescriptorIdentity();
+
+    var subscriptionField = IndexAbstract.class.getDeclaredField("identitySubscription");
+    subscriptionField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    var subscription = (AtomicReference<Object>) subscriptionField.get(index);
+    assertNull(subscription.get());
+  }
+
+  @Test
+  public void failedDropCleanupReleasesOnlyDetachedHandle() {
+    var storage = mock(AbstractStorage.class);
+    var identity = new RecordId(3, 4);
+    var index = new TestIndex(storage);
+    index.setHandleStateForTest(1, identity);
+
+    index.removeLifecycleRegistrationIfDetached();
+    verify(storage, never()).removeIndexLifecycle(identity);
+
+    index.setEngineIdentifierForTest(-1);
+    index.removeLifecycleRegistrationIfDetached();
+    verify(storage).removeIndexLifecycle(identity);
+    assertFalse(index.state().hasEngine());
+    assertNull(index.state().lifecycleCell());
+  }
+
+  @Test
+  public void competingPublishersRebaseAfterCompareAndSetLoss() throws Exception {
+    var index = new TestIndex(mock(AbstractStorage.class));
+    var originalIdentity = new RecordId(3, 4);
+    var replacementIdentity = new RecordId(3, 5);
+    index.setHandleStateForTest(1, originalIdentity);
+    var update = IndexAbstract.class.getDeclaredMethod("updateState", UnaryOperator.class);
+    update.setAccessible(true);
+    var bothDerived = new CountDownLatch(2);
+
+    UnaryOperator<IndexHandleState> engineUpdate = current -> {
+      awaitFirstDerivation(bothDerived);
+      return new IndexHandleState(
+          2, current.engineReference(), current.descriptorIdentity(), current.lifecycleCell());
+    };
+    UnaryOperator<IndexHandleState> identityUpdate = current -> {
+      awaitFirstDerivation(bothDerived);
+      return new IndexHandleState(
+          current.engineIdentifier(), current.engineReference(), replacementIdentity,
+          current.lifecycleCell());
+    };
+
+    try (var executor = Executors.newFixedThreadPool(2)) {
+      var engineFuture = executor.submit(() -> invokeUpdate(update, index, engineUpdate));
+      var identityFuture = executor.submit(() -> invokeUpdate(update, index, identityUpdate));
+      engineFuture.get(10, TimeUnit.SECONDS);
+      identityFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    assertEquals(2, index.state().engineIdentifier());
+    assertEquals(replacementIdentity, index.state().descriptorIdentity());
+  }
+
+  @Test
   public void lifecycleCellRequiresDurableIdentity() {
     var cell = mock(IndexLifecycleCell.class);
     assertThrows(
@@ -40,5 +157,38 @@ public class IndexHandleStateTest {
     var durable = new IndexHandleState(
         1, new IndexEngineReference(1, 0, 1), new RecordId(3, 4), cell);
     assertTrue(durable.isDurablyIdentified());
+  }
+
+  private static void awaitFirstDerivation(CountDownLatch bothDerived) {
+    if (bothDerived.getCount() > 0) {
+      bothDerived.countDown();
+      try {
+        assertTrue(bothDerived.await(10, TimeUnit.SECONDS));
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(exception);
+      }
+    }
+  }
+
+  private static void invokeUpdate(
+      java.lang.reflect.Method method, TestIndex index,
+      UnaryOperator<IndexHandleState> update) {
+    try {
+      method.invoke(index, update);
+    } catch (ReflectiveOperationException exception) {
+      throw new AssertionError(exception);
+    }
+  }
+
+  private static final class TestIndex extends IndexNotUnique {
+
+    private TestIndex(AbstractStorage storage) {
+      super(storage);
+    }
+
+    private IndexHandleState runWithOwner(StateOperation<IndexHandleState> operation) {
+      return withOwnedEngine(operation);
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -46,6 +48,31 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     cls.createProperty("val", PropertyType.INTEGER);
     cls.createProperty("name", PropertyType.STRING);
     cls.createIndex(IDX, SchemaClass.INDEX_TYPE.UNIQUE, "val");
+  }
+
+  /**
+   * Existing descriptors start usable, and a destructive manager reload attaches the replacement
+   * handle to the same storage-scoped lifecycle cell instead of resetting handle-local state.
+   */
+  @Test
+  public void reloadPreservesStorageScopedLifecycleCell() {
+    var manager = (IndexManagerEmbedded) session.getSharedContext().getIndexManager();
+    var original = (IndexAbstract) manager.getIndex(IDX);
+    var cell = original.getLifecycleCell();
+
+    assertNotNull("an existing descriptor must have a lifecycle cell", cell);
+    assertEquals("existing indexes default to usable", IndexLifecycle.USABLE, cell.get());
+    assertEquals("the engine must bind to the loaded descriptor", original.getIdentity(),
+        original.getEngineReference().ownerDescriptorIdentity());
+    cell.set(IndexLifecycle.INVALID);
+
+    manager.reload(session);
+
+    var replacement = (IndexAbstract) manager.getIndex(IDX);
+    assertTrue("reload must replace the Java handle", original != replacement);
+    assertSame("reload must retain the storage-scoped cell", cell, replacement.getLifecycleCell());
+    assertEquals("reload must not reset the lifecycle value", IndexLifecycle.INVALID,
+        replacement.getLifecycleCell().get());
   }
 
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -23,6 +23,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyTyp
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityResourceProperty;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
@@ -73,6 +74,23 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     assertSame("reload must retain the storage-scoped cell", cell, replacement.getLifecycleCell());
     assertEquals("reload must not reset the lifecycle value", IndexLifecycle.INVALID,
         replacement.getLifecycleCell().get());
+  }
+
+  /** A successful drop removes the descriptor's registry entry without mutating its retained cell. */
+  @Test
+  public void dropRemovesLifecycleRegistryEntry() {
+    var manager = (IndexManagerEmbedded) session.getSharedContext().getIndexManager();
+    var index = (IndexAbstract) manager.getIndex(IDX);
+    var descriptorIdentity = index.getIdentity();
+    var cell = index.getLifecycleCell();
+
+    manager.dropIndex(session, IDX);
+
+    var storage = (AbstractStorage) session.getStorage();
+    assertNull("the dropped descriptor must leave the storage registry",
+        storage.getIndexLifecycle(descriptorIdentity));
+    assertSame("an already retained cell remains valid for old holders", cell,
+        index.getLifecycleCell());
   }
 
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -118,7 +118,7 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
         replacement.getLifecycleCell().get());
   }
 
-  /** A successful drop removes the descriptor's registry entry without mutating its retained cell. */
+  /** A successful drop removes the registry entry and releases the handle's lifecycle cell. */
   @Test
   public void dropRemovesLifecycleRegistryEntry() {
     var manager = (IndexManagerEmbedded) session.getSharedContext().getIndexManager();
@@ -131,8 +131,8 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     var storage = (AbstractStorage) session.getStorage();
     assertNull("the dropped descriptor must leave the storage registry",
         storage.getIndexLifecycle(descriptorIdentity));
-    assertSame("an already retained cell remains valid for old holders", cell,
-        index.getLifecycleCell());
+    assertNull("the detached handle must release lifecycle ownership", index.getLifecycleCell());
+    assertNotNull("a previously retained cell remains a valid standalone object", cell);
   }
 
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
@@ -26,6 +27,8 @@ import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityResource
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
@@ -51,23 +54,43 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     cls.createIndex(IDX, SchemaClass.INDEX_TYPE.UNIQUE, "val");
   }
 
-  /** A foreign index implementation is rejected before the committed registry is mutated. */
+  /** A foreign index implementation is rejected before any registry or entity mutation. */
   @Test
   public void addIndexInternalNoLockRejectsForeignHandleBeforePublication() {
     var manager = (IndexManagerEmbedded) session.getSharedContext().getIndexManager();
     var foreignIndex = mock(Index.class);
     var foreignName = "foreign-index-handle";
+    var definition = mock(IndexDefinition.class);
     when(foreignIndex.getName()).thenReturn(foreignName);
+    when(foreignIndex.getIdentity()).thenReturn(mock(RID.class));
+    when(foreignIndex.getDefinition()).thenReturn(definition);
+    when(definition.getClassName()).thenReturn(CLS);
+    when(definition.getProperties()).thenReturn(List.of("val"));
+    when(definition.getParamCount()).thenReturn(1);
 
-    var exception = assertThrows(IllegalStateException.class,
-        () -> manager.addIndexInternalNoLock(foreignIndex, null, false));
+    session.begin();
+    try {
+      var transaction = session.getActiveTransaction();
+      var managerEntity = transaction.loadEntity(manager.indexManagerIdentity);
+      var linksBefore = new HashSet<>(managerEntity.getLinkSet(manager.CONFIG_INDEXES));
+      var propertyIndexesBefore = new HashMap<>(manager.classPropertyIndex);
 
-    assertTrue("the invariant failure must name the index",
-        exception.getMessage().contains(foreignName));
-    assertTrue("the invariant failure must name the unexpected type",
-        exception.getMessage().contains(foreignIndex.getClass().getName()));
-    assertFalse("the rejected handle must not enter the committed registry",
-        manager.indexes.containsKey(foreignName));
+      var exception = assertThrows(IllegalStateException.class,
+          () -> manager.addIndexInternalNoLock(foreignIndex, transaction, true));
+
+      assertTrue("the invariant failure must name the index",
+          exception.getMessage().contains(foreignName));
+      assertTrue("the invariant failure must name the unexpected type",
+          exception.getMessage().contains(foreignIndex.getClass().getName()));
+      assertFalse("the rejected handle must not enter the committed registry",
+          manager.indexes.containsKey(foreignName));
+      assertEquals("the rejected handle must not update the manager entity", linksBefore,
+          managerEntity.getLinkSet(manager.CONFIG_INDEXES));
+      assertEquals("the rejected handle must not update class property indexes",
+          propertyIndexesBefore, manager.classPropertyIndex);
+    } finally {
+      session.rollback();
+    }
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -51,6 +51,25 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     cls.createIndex(IDX, SchemaClass.INDEX_TYPE.UNIQUE, "val");
   }
 
+  /** A foreign index implementation is rejected before the committed registry is mutated. */
+  @Test
+  public void addIndexInternalNoLockRejectsForeignHandleBeforePublication() {
+    var manager = (IndexManagerEmbedded) session.getSharedContext().getIndexManager();
+    var foreignIndex = mock(Index.class);
+    var foreignName = "foreign-index-handle";
+    when(foreignIndex.getName()).thenReturn(foreignName);
+
+    var exception = assertThrows(IllegalStateException.class,
+        () -> manager.addIndexInternalNoLock(foreignIndex, null, false));
+
+    assertTrue("the invariant failure must name the index",
+        exception.getMessage().contains(foreignName));
+    assertTrue("the invariant failure must name the unexpected type",
+        exception.getMessage().contains(foreignIndex.getClass().getName()));
+    assertFalse("the rejected handle must not enter the committed registry",
+        manager.indexes.containsKey(foreignName));
+  }
+
   /**
    * Existing descriptors start usable, and a destructive manager reload attaches the replacement
    * handle to the same storage-scoped lifecycle cell instead of resetting handle-local state.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,26 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     cls.createProperty("val", PropertyType.INTEGER);
     cls.createProperty("name", PropertyType.STRING);
     cls.createIndex(IDX, SchemaClass.INDEX_TYPE.UNIQUE, "val");
+  }
+
+  /** Reserved metadata is rejected before index creation mutates durable or in-memory state. */
+  @Test
+  public void createRejectsReservedMetadataPrefix() {
+    var cls = session.getMetadata().getSchema().getClass(CLS);
+
+    var manager = session.getSharedContext().getIndexManager();
+    var definition = manager.getIndex(IDX).getDefinition();
+    assertThrows(IllegalArgumentException.class,
+        () -> manager.createIndex(
+            session,
+            CLS + ".reserved",
+            SchemaClass.INDEX_TYPE.NOTUNIQUE.toString(),
+            definition,
+            cls.getPolymorphicCollectionIds(),
+            null,
+            Map.<String, Object>of("__ytdb_state", "forged"),
+            null));
+    assertNull(session.getSharedContext().getIndexManager().getIndex(CLS + ".reserved"));
   }
 
   /** A foreign index implementation is rejected before any registry or entity mutation. */
@@ -94,8 +115,8 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
   }
 
   /**
-   * Existing descriptors start usable, and a destructive manager reload attaches the replacement
-   * handle to the same storage-scoped lifecycle cell instead of resetting handle-local state.
+   * Existing descriptors start at EXISTS. A manager reload attaches the replacement handle to the
+   * same storage-scoped lifecycle cell.
    */
   @Test
   public void reloadPreservesStorageScopedLifecycleCell() {
@@ -104,17 +125,16 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
     var cell = original.getLifecycleCell();
 
     assertNotNull("an existing descriptor must have a lifecycle cell", cell);
-    assertEquals("existing indexes default to usable", IndexLifecycle.USABLE, cell.get());
+    assertEquals("existing indexes start at exists", IndexLifecycle.EXISTS, cell.get());
     assertEquals("the engine must bind to the loaded descriptor", original.getIdentity(),
         original.getEngineReference().ownerDescriptorIdentity());
-    cell.set(IndexLifecycle.INVALID);
 
     manager.reload(session);
 
     var replacement = (IndexAbstract) manager.getIndex(IDX);
     assertTrue("reload must replace the Java handle", original != replacement);
     assertSame("reload must retain the storage-scoped cell", cell, replacement.getLifecycleCell());
-    assertEquals("reload must not reset the lifecycle value", IndexLifecycle.INVALID,
+    assertEquals("reload must retain the lifecycle value", IndexLifecycle.EXISTS,
         replacement.getLifecycleCell().get());
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMiscSmallClassesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMiscSmallClassesTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -140,6 +141,22 @@ public class IndexMiscSmallClassesTest {
     assertEquals("algorithm must match", "BTREE", im.getAlgorithm());
     assertEquals("version must match", 1, im.getVersion());
     assertEquals("metadata must match", meta, im.getMetadata());
+  }
+
+  /** Caller mutation after validation cannot change the metadata stored by an index. */
+  @Test
+  public void indexMetadata_copiesTheValidatedCallerMap() {
+    var callerMetadata = new HashMap<String, Object>();
+    callerMetadata.put("visible", true);
+    IndexMetadataValidator.validate(callerMetadata);
+
+    var metadata = new IndexMetadata(
+        "idx", null, new HashSet<>(), "NOTUNIQUE", "BTREE", 1, callerMetadata);
+    callerMetadata.put(IndexMetadataValidator.RESERVED_PREFIX + "state", "forged");
+
+    assertEquals(Map.of("visible", true), metadata.getMetadata());
+    assertFalse(metadata.getMetadata().containsKey(
+        IndexMetadataValidator.RESERVED_PREFIX + "state"));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValuesTxTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValuesTxTest.java
@@ -58,6 +58,23 @@ public class IndexMultiValuesTxTest extends DbTestBase {
     session.commit();
   }
 
+  /** A stale NOTUNIQUE engine identifier recovers only through the descriptor owner. */
+  @Test
+  public void getRids_staleEngineIdentifier_recoversByDescriptorOwner() {
+    session.begin();
+    var index = (IndexMultiValues) session.getSharedContext().getIndexManager().getIndex(IDX_NAME);
+    var expectedIdentifier = index.getIndexId();
+    index.indexId = expectedIdentifier | 1_000_000;
+
+    @SuppressWarnings("unchecked")
+    Collection<RID> result = (Collection<RID>) index.get(session, "alpha");
+    session.rollback();
+
+    assertEquals("owner-bound recovery must preserve both committed values", 2, result.size());
+    assertEquals("owner-bound recovery must install the packed identifier",
+        expectedIdentifier, index.getIndexId());
+  }
+
   // -----------------------------------------------------------------------
   //  getRids — no TX changes (null indexChanges path)
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValuesTxTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexMultiValuesTxTest.java
@@ -64,7 +64,8 @@ public class IndexMultiValuesTxTest extends DbTestBase {
     session.begin();
     var index = (IndexMultiValues) session.getSharedContext().getIndexManager().getIndex(IDX_NAME);
     var expectedIdentifier = index.getIndexId();
-    index.indexId = expectedIdentifier | 1_000_000;
+    index.setHandleStateForTest(
+        expectedIdentifier | 1_000_000, index.getIdentity());
 
     @SuppressWarnings("unchecked")
     Collection<RID> result = (Collection<RID>) index.get(session, "alpha");

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValueTxTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValueTxTest.java
@@ -66,7 +66,8 @@ public class IndexOneValueTxTest extends DbTestBase {
     session.begin();
     var index = (IndexOneValue) session.getSharedContext().getIndexManager().getIndex(IDX_NAME);
     var expectedIdentifier = index.getIndexId();
-    index.indexId = expectedIdentifier | 1_000_000;
+    index.setHandleStateForTest(
+        expectedIdentifier | 1_000_000, index.getIdentity());
 
     var result = index.get(session, "alpha");
     session.rollback();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValueTxTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexOneValueTxTest.java
@@ -60,6 +60,22 @@ public class IndexOneValueTxTest extends DbTestBase {
     session.commit();
   }
 
+  /** A stale UNIQUE engine identifier recovers only through the descriptor owner. */
+  @Test
+  public void getRids_staleEngineIdentifier_recoversByDescriptorOwner() {
+    session.begin();
+    var index = (IndexOneValue) session.getSharedContext().getIndexManager().getIndex(IDX_NAME);
+    var expectedIdentifier = index.getIndexId();
+    index.indexId = expectedIdentifier | 1_000_000;
+
+    var result = index.get(session, "alpha");
+    session.rollback();
+
+    assertNotNull("owner-bound recovery must preserve the committed lookup", result);
+    assertEquals("owner-bound recovery must install the packed identifier",
+        expectedIdentifier, index.getIndexId());
+  }
+
   // -----------------------------------------------------------------------
   //  get() — UNIQUE index return type is Object (RID or null)
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -61,7 +61,7 @@ public class IndexRecoveryPathsTest {
       assertEquals(
           path.name() + " must install the owner-resolved identifier before failing closed",
           VALID_IDENTIFIER,
-          fixture.index.indexId);
+          fixture.index.getIndexId());
       assertEquals(
           path.name() + " must resolve the owner exactly once",
           1,
@@ -145,7 +145,7 @@ public class IndexRecoveryPathsTest {
                 fixture -> fixture.index.analyzeHistogram(fixture.session)),
             path("onIndexEngineChange", "callIndexEngine",
                 fixture -> fixture.index.onIndexEngineChange(
-                    fixture.session, fixture.index.indexId))));
+                    fixture.session, fixture.index.state()))));
   }
 
   private static void verifyPaths(IndexFactory factory, List<RecoveryPath> paths) throws Exception {
@@ -153,10 +153,11 @@ public class IndexRecoveryPathsTest {
       var recoveringFixture = fixture(factory, path.storageMethod());
       path.operation().invoke(recoveringFixture);
       assertEquals(path.name() + " must install the owner-resolved identifier",
-          VALID_IDENTIFIER, recoveringFixture.index.indexId);
+          VALID_IDENTIFIER, recoveringFixture.index.getIndexId());
 
       var foreignFixture = fixture(factory, path.storageMethod());
-      foreignFixture.index.identity = FOREIGN_OWNER;
+      foreignFixture.index.setHandleStateForTest(
+          foreignFixture.index.getIndexId(), FOREIGN_OWNER);
       assertThrows(
           path.name() + " must reject a foreign owner",
           StaleIndexEngineException.class,
@@ -179,7 +180,7 @@ public class IndexRecoveryPathsTest {
       if (methodName.startsWith("resolveIndexEngineByOwner")) {
         var owner = invocation.getArgument(0);
         if (OWNER.equals(owner)) {
-          return VALID_IDENTIFIER;
+          return new AbstractStorage.ResolvedIndexEngine(VALID_IDENTIFIER, null);
         }
         throw new StaleIndexEngineException(
             "recovery-path-test", "No engine belongs to foreign owner " + owner);
@@ -219,8 +220,7 @@ public class IndexRecoveryPathsTest {
 
     var index = factory.create(storage);
     index.im = metadata;
-    index.identity = OWNER;
-    index.indexId = STALE_IDENTIFIER;
+    index.setHandleStateForTest(STALE_IDENTIFIER, OWNER);
     return new Fixture(index, session, transaction, atomicOperation, storage);
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -2,8 +2,10 @@ package com.jetbrains.youtrackdb.internal.core.index;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.collate.DefaultCollate;
@@ -32,28 +34,66 @@ public class IndexRecoveryPathsTest {
 
   @Test
   public void indexOneValueRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
-    verifyPaths(
-        IndexUnique::new,
-        List.of(
-            path("getRidsIgnoreTx", "getIndexValues",
-                fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
-            path("streamEntries", "getIndexValues",
-                fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
-                    .toList()),
-            path("streamEntriesBetween", "iterateIndexEntriesBetween",
-                fixture -> fixture.index.streamEntriesBetween(
-                    fixture.session, "a", true, "z", true, true).close()),
-            path("streamEntriesMajor", "iterateIndexEntriesMajor",
-                fixture -> fixture.index.streamEntriesMajor(
-                    fixture.session, "a", true, true).close()),
-            path("streamEntriesMinor", "iterateIndexEntriesMinor",
-                fixture -> fixture.index.streamEntriesMinor(
-                    fixture.session, "z", true, true).close()),
-            path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
-            path("stream", "getIndexStream",
-                fixture -> fixture.index.stream(fixture.session).close()),
-            path("descStream", "getIndexDescStream",
-                fixture -> fixture.index.descStream(fixture.session).close())));
+    verifyPaths(IndexUnique::new, indexOneValuePaths());
+  }
+
+  /**
+   * Every single-value read path permits one owner-bound retry. If the resolved engine is also
+   * stale, the path must stop after that retry and report the descriptor instead of looping.
+   */
+  @Test
+  public void indexOneValuePersistentStalenessFailsAfterSingleOwnerBoundRetry() throws Exception {
+    for (var path : indexOneValuePaths()) {
+      var fixture = fixture(IndexUnique::new, path.storageMethod(), true);
+
+      var exception =
+          assertThrows(
+              path.name() + " must fail after one owner-bound retry",
+              StaleIndexEngineException.class,
+              () -> path.operation().invoke(fixture));
+
+      assertTrue(
+          path.name() + " must explain the bounded retry",
+          exception.getMessage().contains("remained stale after owner-bound recovery"));
+      assertTrue(
+          path.name() + " must identify the descriptor owner",
+          exception.getMessage().contains(OWNER.toString()));
+      assertEquals(
+          path.name() + " must install the owner-resolved identifier before failing closed",
+          VALID_IDENTIFIER,
+          fixture.index.indexId);
+      assertEquals(
+          path.name() + " must resolve the owner exactly once",
+          1,
+          invocationCount(fixture.storage, "resolveIndexEngineByOwner"));
+      assertEquals(
+          path.name() + " must attempt the storage operation exactly twice",
+          2,
+          invocationCount(fixture.storage, path.storageMethod()));
+    }
+  }
+
+  private static List<RecoveryPath> indexOneValuePaths() {
+    return List.of(
+        path("getRidsIgnoreTx", "getIndexValues",
+            fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
+        path("streamEntries", "getIndexValues",
+            fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
+                .toList()),
+        path("streamEntriesBetween", "iterateIndexEntriesBetween",
+            fixture -> fixture.index.streamEntriesBetween(
+                fixture.session, "a", true, "z", true, true).close()),
+        path("streamEntriesMajor", "iterateIndexEntriesMajor",
+            fixture -> fixture.index.streamEntriesMajor(
+                fixture.session, "a", true, true).close()),
+        path("streamEntriesMinor", "iterateIndexEntriesMinor",
+            fixture -> fixture.index.streamEntriesMinor(
+                fixture.session, "z", true, true).close()),
+        path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
+        path("stream", "getIndexStream",
+            fixture -> fixture.index.stream(fixture.session).close()),
+        path("descStream", "getIndexDescStream",
+            fixture -> fixture.index.descStream(fixture.session).close()));
   }
 
   @Test
@@ -125,6 +165,11 @@ public class IndexRecoveryPathsTest {
   }
 
   private static Fixture fixture(IndexFactory factory, String staleStorageMethod) {
+    return fixture(factory, staleStorageMethod, false);
+  }
+
+  private static Fixture fixture(
+      IndexFactory factory, String staleStorageMethod, boolean persistentlyStale) {
     var engine = mock(BaseIndexEngine.class);
     var storage = mock(AbstractStorage.class, invocation -> {
       var methodName = invocation.getMethod().getName();
@@ -140,8 +185,9 @@ public class IndexRecoveryPathsTest {
             "recovery-path-test", "No engine belongs to foreign owner " + owner);
       }
       if (methodName.equals(staleStorageMethod)
-          && Stream.of(invocation.getArguments())
-              .anyMatch(argument -> Integer.valueOf(STALE_IDENTIFIER).equals(argument))) {
+          && (persistentlyStale
+              || Stream.of(invocation.getArguments())
+                  .anyMatch(argument -> Integer.valueOf(STALE_IDENTIFIER).equals(argument)))) {
         throw new InvalidIndexEngineIdException("stale identifier");
       }
       if (methodName.equals("getIndexEngine")
@@ -175,7 +221,13 @@ public class IndexRecoveryPathsTest {
     index.im = metadata;
     index.identity = OWNER;
     index.indexId = STALE_IDENTIFIER;
-    return new Fixture(index, session, transaction, atomicOperation);
+    return new Fixture(index, session, transaction, atomicOperation, storage);
+  }
+
+  private static int invocationCount(AbstractStorage storage, String methodName) {
+    return (int) mockingDetails(storage).getInvocations().stream()
+        .filter(invocation -> invocation.getMethod().getName().equals(methodName))
+        .count();
   }
 
   private static RecoveryPath path(
@@ -212,7 +264,8 @@ public class IndexRecoveryPathsTest {
       IndexAbstract index,
       DatabaseSessionEmbedded session,
       FrontendTransactionImpl transaction,
-      AtomicOperation atomicOperation) {
+      AtomicOperation atomicOperation,
+      AbstractStorage storage) {
   }
 
   private record RecoveryPath(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -96,9 +96,21 @@ public class IndexRecoveryPathsTest {
             fixture -> fixture.index.descStream(fixture.session).close()));
   }
 
+  /** Every single-value stream and range path reports a detached carrier as typed staleness. */
+  @Test
+  public void indexOneValueDetachedReadPathsFailWithTypedStaleness() throws Exception {
+    verifyDetachedPaths(IndexUnique::new, indexOneValuePaths());
+  }
+
   @Test
   public void indexMultiValuesRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
     verifyPaths(IndexNotUnique::new, indexMultiValuesPaths());
+  }
+
+  /** Every multi-value stream and range path reports a detached carrier as typed staleness. */
+  @Test
+  public void indexMultiValuesDetachedReadPathsFailWithTypedStaleness() throws Exception {
+    verifyDetachedPaths(IndexNotUnique::new, indexMultiValuesPaths());
   }
 
   /** Every multi-value read path stops after three persistently stale engine attempts. */
@@ -167,28 +179,42 @@ public class IndexRecoveryPathsTest {
 
   @Test
   public void indexAbstractRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
-    verifyPaths(
+    verifyPaths(IndexNotUnique::new, indexAbstractPaths());
+  }
+
+  /** Rebuild-tail helpers convert detached carriers before storage extracts an identifier. */
+  @Test
+  public void indexAbstractRebuildTailRejectsDetachedCarrierWithTypedStaleness()
+      throws Exception {
+    verifyDetachedPaths(
         IndexNotUnique::new,
-        List.of(
-            path("setBulkLoading", "getIndexEngine",
-                fixture -> invokePrivate(fixture.index, "setBulkLoading", boolean.class, true)),
-            path("buildHistogramAfterFill", "getIndexEngine",
-                fixture -> invokePrivate(fixture.index, "buildHistogramAfterFill")),
-            path("doDelete", "deleteIndexEngine",
-                fixture -> fixture.index.doDelete(fixture.transaction)),
-            path("keyStream", "getIndexKeyStream",
-                fixture -> fixture.index.keyStream(fixture.atomicOperation).close()),
-            path("acquireAtomicExclusiveLock", "getIndexEngineWithStateLock",
-                fixture -> fixture.index.acquireAtomicExclusiveLock(fixture.atomicOperation)),
-            path("getStatistics", "getIndexEngine",
-                fixture -> fixture.index.getStatistics(fixture.session)),
-            path("getHistogram", "getIndexEngine",
-                fixture -> fixture.index.getHistogram(fixture.session)),
-            path("analyzeHistogram", "getIndexEngine",
-                fixture -> fixture.index.analyzeHistogram(fixture.session)),
-            path("onIndexEngineChange", "callIndexEngine",
-                fixture -> fixture.index.onIndexEngineChange(
-                    fixture.session, fixture.index.state()))));
+        indexAbstractPaths().stream()
+            .filter(path -> path.name().equals("setBulkLoading")
+                || path.name().equals("buildHistogramAfterFill"))
+            .toList());
+  }
+
+  private static List<RecoveryPath> indexAbstractPaths() {
+    return List.of(
+        path("setBulkLoading", "getIndexEngine",
+            fixture -> invokePrivate(fixture.index, "setBulkLoading", boolean.class, true)),
+        path("buildHistogramAfterFill", "getIndexEngine",
+            fixture -> invokePrivate(fixture.index, "buildHistogramAfterFill")),
+        path("doDelete", "deleteIndexEngine",
+            fixture -> fixture.index.doDelete(fixture.transaction)),
+        path("keyStream", "getIndexKeyStream",
+            fixture -> fixture.index.keyStream(fixture.atomicOperation).close()),
+        path("acquireAtomicExclusiveLock", "getIndexEngineWithStateLock",
+            fixture -> fixture.index.acquireAtomicExclusiveLock(fixture.atomicOperation)),
+        path("getStatistics", "getIndexEngine",
+            fixture -> fixture.index.getStatistics(fixture.session)),
+        path("getHistogram", "getIndexEngine",
+            fixture -> fixture.index.getHistogram(fixture.session)),
+        path("analyzeHistogram", "getIndexEngine",
+            fixture -> fixture.index.analyzeHistogram(fixture.session)),
+        path("onIndexEngineChange", "callIndexEngine",
+            fixture -> fixture.index.onIndexEngineChange(
+                fixture.session, fixture.index.state())));
   }
 
   private static void verifyPaths(IndexFactory factory, List<RecoveryPath> paths) throws Exception {
@@ -206,6 +232,23 @@ public class IndexRecoveryPathsTest {
           path.name() + " must reject a foreign owner",
           StaleIndexEngineException.class,
           () -> path.operation().invoke(foreignFixture));
+    }
+  }
+
+  private static void verifyDetachedPaths(IndexFactory factory, List<RecoveryPath> paths)
+      throws Exception {
+    for (var path : paths) {
+      var fixture = fixture(factory, path.storageMethod());
+      fixture.index.setHandleStateForTest(-1, OWNER);
+
+      assertThrows(
+          path.name() + " must report detached carrier staleness",
+          StaleIndexEngineException.class,
+          () -> path.operation().invoke(fixture));
+      assertEquals(
+          path.name() + " must fail before unchecked storage identifier extraction",
+          0,
+          invocationCount(fixture.storage, path.storageMethod()));
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -1,0 +1,233 @@
+package com.jetbrains.youtrackdb.internal.core.index;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.collate.DefaultCollate;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.mockito.Answers;
+
+/** Covers owner-bound recovery for every converted index path with one table per index class. */
+public class IndexRecoveryPathsTest {
+
+  private static final int VALID_IDENTIFIER = 5;
+  private static final int STALE_IDENTIFIER = 1_000_005;
+  private static final RecordId OWNER = new RecordId(20, 1);
+  private static final RecordId FOREIGN_OWNER = new RecordId(20, 2);
+
+  @Test
+  public void indexOneValueRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
+    verifyPaths(
+        IndexUnique::new,
+        List.of(
+            path("getRidsIgnoreTx", "getIndexValues",
+                fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
+            path("streamEntries", "getIndexValues",
+                fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
+                    .toList()),
+            path("streamEntriesBetween", "iterateIndexEntriesBetween",
+                fixture -> fixture.index.streamEntriesBetween(
+                    fixture.session, "a", true, "z", true, true).close()),
+            path("streamEntriesMajor", "iterateIndexEntriesMajor",
+                fixture -> fixture.index.streamEntriesMajor(
+                    fixture.session, "a", true, true).close()),
+            path("streamEntriesMinor", "iterateIndexEntriesMinor",
+                fixture -> fixture.index.streamEntriesMinor(
+                    fixture.session, "z", true, true).close()),
+            path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
+            path("stream", "getIndexStream",
+                fixture -> fixture.index.stream(fixture.session).close()),
+            path("descStream", "getIndexDescStream",
+                fixture -> fixture.index.descStream(fixture.session).close())));
+  }
+
+  @Test
+  public void indexMultiValuesRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
+    verifyPaths(
+        IndexNotUnique::new,
+        List.of(
+            path("getRidsIgnoreTx", "getIndexValues",
+                fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
+            path("streamEntriesBetween", "iterateIndexEntriesBetween",
+                fixture -> fixture.index.streamEntriesBetween(
+                    fixture.session, "a", true, "z", true, true).close()),
+            path("streamEntriesMajor", "iterateIndexEntriesMajor",
+                fixture -> fixture.index.streamEntriesMajor(
+                    fixture.session, "a", true, true).close()),
+            path("streamEntriesMinor", "iterateIndexEntriesMinor",
+                fixture -> fixture.index.streamEntriesMinor(
+                    fixture.session, "z", true, true).close()),
+            path("streamForKey", "getIndexValues",
+                fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
+                    .toList()),
+            path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
+            path("stream", "getIndexStream",
+                fixture -> fixture.index.stream(fixture.session).close()),
+            path("descStream", "getIndexDescStream",
+                fixture -> fixture.index.descStream(fixture.session).close())));
+  }
+
+  @Test
+  public void indexAbstractRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
+    verifyPaths(
+        IndexNotUnique::new,
+        List.of(
+            path("setBulkLoading", "getIndexEngine",
+                fixture -> invokePrivate(fixture.index, "setBulkLoading", boolean.class, true)),
+            path("buildHistogramAfterFill", "getIndexEngine",
+                fixture -> invokePrivate(fixture.index, "buildHistogramAfterFill")),
+            path("doDelete", "deleteIndexEngine",
+                fixture -> fixture.index.doDelete(fixture.transaction)),
+            path("keyStream", "getIndexKeyStream",
+                fixture -> fixture.index.keyStream(fixture.atomicOperation).close()),
+            path("acquireAtomicExclusiveLock", "getIndexEngineWithStateLock",
+                fixture -> fixture.index.acquireAtomicExclusiveLock(fixture.atomicOperation)),
+            path("getStatistics", "getIndexEngine",
+                fixture -> fixture.index.getStatistics(fixture.session)),
+            path("getHistogram", "getIndexEngine",
+                fixture -> fixture.index.getHistogram(fixture.session)),
+            path("analyzeHistogram", "getIndexEngine",
+                fixture -> fixture.index.analyzeHistogram(fixture.session)),
+            path("onIndexEngineChange", "callIndexEngine",
+                fixture -> fixture.index.onIndexEngineChange(
+                    fixture.session, fixture.index.indexId))));
+  }
+
+  private static void verifyPaths(IndexFactory factory, List<RecoveryPath> paths) throws Exception {
+    for (var path : paths) {
+      var recoveringFixture = fixture(factory, path.storageMethod());
+      path.operation().invoke(recoveringFixture);
+      assertEquals(path.name() + " must install the owner-resolved identifier",
+          VALID_IDENTIFIER, recoveringFixture.index.indexId);
+
+      var foreignFixture = fixture(factory, path.storageMethod());
+      foreignFixture.index.identity = FOREIGN_OWNER;
+      assertThrows(
+          path.name() + " must reject a foreign owner",
+          StaleIndexEngineException.class,
+          () -> path.operation().invoke(foreignFixture));
+    }
+  }
+
+  private static Fixture fixture(IndexFactory factory, String staleStorageMethod) {
+    var engine = mock(BaseIndexEngine.class);
+    var storage = mock(AbstractStorage.class, invocation -> {
+      var methodName = invocation.getMethod().getName();
+      if (methodName.equals("getName")) {
+        return "recovery-path-test";
+      }
+      if (methodName.startsWith("resolveIndexEngineByOwner")) {
+        var owner = invocation.getArgument(0);
+        if (OWNER.equals(owner)) {
+          return VALID_IDENTIFIER;
+        }
+        throw new StaleIndexEngineException(
+            "recovery-path-test", "No engine belongs to foreign owner " + owner);
+      }
+      if (methodName.equals(staleStorageMethod)
+          && Stream.of(invocation.getArguments())
+              .anyMatch(argument -> Integer.valueOf(STALE_IDENTIFIER).equals(argument))) {
+        throw new InvalidIndexEngineIdException("stale identifier");
+      }
+      if (methodName.equals("getIndexEngine")
+          || methodName.equals("getIndexEngineWithStateLock")) {
+        return engine;
+      }
+      if (Stream.class.isAssignableFrom(invocation.getMethod().getReturnType())) {
+        return Stream.empty();
+      }
+      return Answers.RETURNS_DEFAULTS.answer(invocation);
+    });
+
+    var session = mock(DatabaseSessionEmbedded.class);
+    var transaction = mock(FrontendTransactionImpl.class);
+    var atomicOperation = mock(AtomicOperation.class);
+    var entity = mock(EntityImpl.class);
+    when(session.getActiveTransaction()).thenReturn(transaction);
+    when(session.getTransactionInternal()).thenReturn(transaction);
+    when(transaction.getDatabaseSession()).thenReturn(session);
+    when(transaction.getAtomicOperation()).thenReturn(atomicOperation);
+    when(transaction.loadEntity(any())).thenReturn(entity);
+
+    var metadata = mock(IndexMetadata.class);
+    var definition = mock(IndexDefinition.class);
+    when(metadata.getName()).thenReturn("recovery-index");
+    when(metadata.getIndexDefinition()).thenReturn(definition);
+    when(definition.getClassName()).thenReturn(null);
+    when(definition.getCollate()).thenReturn(new DefaultCollate());
+
+    var index = factory.create(storage);
+    index.im = metadata;
+    index.identity = OWNER;
+    index.indexId = STALE_IDENTIFIER;
+    return new Fixture(index, session, transaction, atomicOperation);
+  }
+
+  private static RecoveryPath path(
+      String name, String storageMethod, RecoveryOperation operation) {
+    return new RecoveryPath(name, storageMethod, operation);
+  }
+
+  private static void invokePrivate(IndexAbstract index, String methodName) throws Exception {
+    invokePrivate(index, methodName, null, null);
+  }
+
+  private static void invokePrivate(
+      IndexAbstract index, String methodName, Class<?> parameterType, Object argument)
+      throws Exception {
+    var method = parameterType == null
+        ? IndexAbstract.class.getDeclaredMethod(methodName)
+        : IndexAbstract.class.getDeclaredMethod(methodName, parameterType);
+    method.setAccessible(true);
+    try {
+      if (parameterType == null) {
+        method.invoke(index);
+      } else {
+        method.invoke(index, argument);
+      }
+    } catch (InvocationTargetException exception) {
+      if (exception.getCause() instanceof Exception cause) {
+        throw cause;
+      }
+      throw exception;
+    }
+  }
+
+  private record Fixture(
+      IndexAbstract index,
+      DatabaseSessionEmbedded session,
+      FrontendTransactionImpl transaction,
+      AtomicOperation atomicOperation) {
+  }
+
+  private record RecoveryPath(
+      String name, String storageMethod, RecoveryOperation operation) {
+  }
+
+  @FunctionalInterface
+  private interface IndexFactory {
+
+    IndexAbstract create(AbstractStorage storage);
+  }
+
+  @FunctionalInterface
+  private interface RecoveryOperation {
+
+    void invoke(Fixture fixture) throws Exception;
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -152,8 +152,9 @@ public class IndexRecoveryPathsTest {
     for (var path : paths) {
       var recoveringFixture = fixture(factory, path.storageMethod());
       path.operation().invoke(recoveringFixture);
-      assertEquals(path.name() + " must install the owner-resolved identifier",
-          VALID_IDENTIFIER, recoveringFixture.index.getIndexId());
+      final var expectedIdentifier = path.name().equals("doDelete") ? -1 : VALID_IDENTIFIER;
+      assertEquals(path.name() + " must publish its final carrier shape",
+          expectedIdentifier, recoveringFixture.index.getIndexId());
 
       var foreignFixture = fixture(factory, path.storageMethod());
       foreignFixture.index.setHandleStateForTest(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -41,7 +41,7 @@ public class IndexRecoveryPathsTest {
    * Every single-value read path permits one owner-bound retry. If the resolved engine is also
    * stale, the path must stop after that retry and report the descriptor instead of looping.
    */
-  @Test
+  @Test(timeout = 10_000)
   public void indexOneValuePersistentStalenessFailsAfterSingleOwnerBoundRetry() throws Exception {
     for (var path : indexOneValuePaths()) {
       var fixture = fixture(IndexUnique::new, path.storageMethod(), true);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -98,28 +98,71 @@ public class IndexRecoveryPathsTest {
 
   @Test
   public void indexMultiValuesRecoveryPathsUseOwnerAndRejectForeignOwner() throws Exception {
-    verifyPaths(
-        IndexNotUnique::new,
-        List.of(
-            path("getRidsIgnoreTx", "getIndexValues",
-                fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
-            path("streamEntriesBetween", "iterateIndexEntriesBetween",
-                fixture -> fixture.index.streamEntriesBetween(
-                    fixture.session, "a", true, "z", true, true).close()),
-            path("streamEntriesMajor", "iterateIndexEntriesMajor",
-                fixture -> fixture.index.streamEntriesMajor(
-                    fixture.session, "a", true, true).close()),
-            path("streamEntriesMinor", "iterateIndexEntriesMinor",
-                fixture -> fixture.index.streamEntriesMinor(
-                    fixture.session, "z", true, true).close()),
-            path("streamForKey", "getIndexValues",
-                fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
-                    .toList()),
-            path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
-            path("stream", "getIndexStream",
-                fixture -> fixture.index.stream(fixture.session).close()),
-            path("descStream", "getIndexDescStream",
-                fixture -> fixture.index.descStream(fixture.session).close())));
+    verifyPaths(IndexNotUnique::new, indexMultiValuesPaths());
+  }
+
+  /** Every multi-value read path stops after three persistently stale engine attempts. */
+  @Test(timeout = 10_000)
+  public void indexMultiValuesPersistentStalenessFailsAfterBoundedOwnerRecovery()
+      throws Exception {
+    for (var path : indexMultiValuesPaths()) {
+      var fixture = fixture(IndexNotUnique::new, path.storageMethod(), true);
+
+      var exception = assertThrows(
+          path.name() + " must fail after bounded owner recovery",
+          StaleIndexEngineException.class,
+          () -> path.operation().invoke(fixture));
+
+      assertTrue(path.name() + " must explain the bounded retry",
+          exception.getMessage().contains("remained stale after owner-bound recovery"));
+      assertTrue(path.name() + " must identify the descriptor owner",
+          exception.getMessage().contains(OWNER.toString()));
+      assertEquals(path.name() + " must retain the resolved identifier",
+          VALID_IDENTIFIER, fixture.index.getIndexId());
+      assertEquals(path.name() + " must resolve the owner exactly twice",
+          2, invocationCount(fixture.storage, "resolveIndexEngineByOwner"));
+      assertEquals(path.name() + " must attempt storage exactly three times",
+          3, invocationCount(fixture.storage, path.storageMethod()));
+    }
+  }
+
+  private static List<RecoveryPath> indexMultiValuesPaths() {
+    return List.of(
+        path("getRidsIgnoreTx", "getIndexValues",
+            fixture -> fixture.index.getRidsIgnoreTx(fixture.session, "key").close()),
+        path("streamEntriesBetween", "iterateIndexEntriesBetween",
+            fixture -> fixture.index.streamEntriesBetween(
+                fixture.session, "a", true, "z", true, true).close()),
+        path("streamEntriesMajor", "iterateIndexEntriesMajor",
+            fixture -> fixture.index.streamEntriesMajor(
+                fixture.session, "a", true, true).close()),
+        path("streamEntriesMinor", "iterateIndexEntriesMinor",
+            fixture -> fixture.index.streamEntriesMinor(
+                fixture.session, "z", true, true).close()),
+        path("streamForKey", "getIndexValues",
+            fixture -> fixture.index.streamEntries(fixture.session, List.of("key"), true)
+                .toList()),
+        path("size", "getIndexSize", fixture -> fixture.index.size(fixture.session)),
+        path("stream", "getIndexStream",
+            fixture -> fixture.index.stream(fixture.session).close()),
+        path("descStream", "getIndexDescStream",
+            fixture -> fixture.index.descStream(fixture.session).close()));
+  }
+
+  /** The state-lock form also exhausts after three persistent stale resolutions. */
+  @Test(timeout = 10_000)
+  public void stateLockRecoveryFailsAfterBoundedOwnerRecovery() {
+    var fixture = fixture(IndexNotUnique::new, "getIndexEngineWithStateLock", true);
+
+    var exception = assertThrows(
+        StaleIndexEngineException.class,
+        () -> fixture.index.acquireAtomicExclusiveLock(fixture.atomicOperation));
+
+    assertTrue(exception.getMessage().contains("remained stale after owner-bound recovery"));
+    assertEquals(2,
+        invocationCount(fixture.storage, "resolveIndexEngineByOwnerWithStateLock"));
+    assertEquals(3,
+        invocationCount(fixture.storage, "getIndexEngineWithStateLock"));
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexRecoveryPathsTest.java
@@ -38,17 +38,17 @@ public class IndexRecoveryPathsTest {
   }
 
   /**
-   * Every single-value read path permits one owner-bound retry. If the resolved engine is also
-   * stale, the path must stop after that retry and report the descriptor instead of looping.
+   * Every single-value read path permits two owner-bound retries. If both resolved engines are
+   * stale, the path must stop after three attempts and report the descriptor instead of looping.
    */
   @Test(timeout = 10_000)
-  public void indexOneValuePersistentStalenessFailsAfterSingleOwnerBoundRetry() throws Exception {
+  public void indexOneValuePersistentStalenessFailsAfterBoundedOwnerRecovery() throws Exception {
     for (var path : indexOneValuePaths()) {
       var fixture = fixture(IndexUnique::new, path.storageMethod(), true);
 
       var exception =
           assertThrows(
-              path.name() + " must fail after one owner-bound retry",
+              path.name() + " must fail after bounded owner recovery",
               StaleIndexEngineException.class,
               () -> path.operation().invoke(fixture));
 
@@ -63,12 +63,12 @@ public class IndexRecoveryPathsTest {
           VALID_IDENTIFIER,
           fixture.index.getIndexId());
       assertEquals(
-          path.name() + " must resolve the owner exactly once",
-          1,
+          path.name() + " must resolve the owner exactly twice",
+          2,
           invocationCount(fixture.storage, "resolveIndexEngineByOwner"));
       assertEquals(
-          path.name() + " must attempt the storage operation exactly twice",
-          2,
+          path.name() + " must attempt the storage operation exactly three times",
+          3,
           invocationCount(fixture.storage, path.storageMethod()));
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexesSnapshotClearTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexesSnapshotClearTest.java
@@ -127,9 +127,8 @@ public class IndexesSnapshotClearTest {
    */
   private IndexesSnapshot getSnapshotForIndex(String indexName)
       throws InvalidIndexEngineIdException {
-    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
     var storage = db.getStorage();
-    int internalId = storage.getIndexEngine(index.getIndexId()).getId();
+    int internalId = IndexEngineTestSupport.internalIdentifier(db, indexName);
     return storage.subIndexSnapshot(internalId);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexesTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.index;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
@@ -130,5 +131,20 @@ public class IndexesTest extends DbTestBase {
     assertNotNull("createIndexInstance must not return null for NOTUNIQUE/BTREE", idx);
     assertTrue("createIndexInstance(NOTUNIQUE/BTREE) must return IndexNotUnique",
         idx instanceof IndexNotUnique);
+  }
+
+  /** A service-loaded factory cannot return a handle outside the supported hierarchy. */
+  @Test
+  public void createIndexInstance_rejectsForeignFactoryHandle() {
+    var exception = assertThrows(IllegalStateException.class,
+        () -> Indexes.createIndexInstance(ForeignIndexFactory.INDEX_TYPE,
+            ForeignIndexFactory.ALGORITHM, session.getStorage()));
+
+    assertTrue("the invariant failure must name the index type",
+        exception.getMessage().contains(ForeignIndexFactory.INDEX_TYPE));
+    assertTrue("the invariant failure must name the algorithm",
+        exception.getMessage().contains(ForeignIndexFactory.ALGORITHM));
+    assertTrue("the invariant failure must name the unexpected concrete class",
+        exception.getMessage().contains(ForeignIndexFactory.foreignHandleClassName()));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/CheckpointFlushTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/CheckpointFlushTest.java
@@ -219,6 +219,49 @@ public class CheckpointFlushTest {
         75, fixture.manager.getDirtyMutations());
   }
 
+  /**
+   * The strict flush variant reports an input and output failure and restores the dirty count.
+   *
+   * <p>The durability barrier of storage birth uses the strict variant. The barrier must observe a
+   * failed write of the index statistics page, because the write-ahead log never carries index
+   * statistics data. The scenario runs the strict variant over a manager whose page write fails.
+   * The expected outcome has two parts. The strict variant reports the failure to the caller. The
+   * dirty-mutation count returns to the value before the flush, so the next flush retries.
+   */
+  @Test
+  public void flushIfDirtyOrFail_ioFailure_reachesTheCallerAndRestoresDirtyCount() {
+    var fixture = new ManagerFixtureWithFailingFlush();
+    setDirtyMutations(fixture.manager, 75);
+    setFileId(fixture.manager, 42);
+
+    var failure =
+        org.junit.Assert.assertThrows(
+            IOException.class, () -> fixture.manager.flushIfDirtyOrFail());
+
+    assertTrue("the reported failure must name the simulated page write failure, saw: "
+        + failure.getMessage(),
+        failure.getMessage().contains("simulated I/O failure"));
+    assertEquals("dirtyMutations must be restored on a reported flush failure",
+        75, fixture.manager.getDirtyMutations());
+  }
+
+  /**
+   * The strict flush variant reports nothing when the flush succeeds.
+   *
+   * <p>The scenario runs the strict variant over a manager without any cache entry, which is a
+   * successful no-op flush. The expected outcome is one call without any failure and a
+   * dirty-mutation count of zero.
+   */
+  @Test
+  public void flushIfDirtyOrFail_successResetsDirtyCount() throws IOException {
+    var fixture = new ManagerFixture();
+    setDirtyMutations(fixture.manager, 12);
+
+    fixture.manager.flushIfDirtyOrFail();
+
+    assertEquals(0, fixture.manager.getDirtyMutations());
+  }
+
   // ═══════════════════════════════════════════════════════════════════════
   // Fixtures
   // ═══════════════════════════════════════════════════════════════════════

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexEngineReferenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexEngineReferenceTest.java
@@ -1,0 +1,48 @@
+package com.jetbrains.youtrackdb.internal.core.index.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import org.junit.Test;
+
+public class IndexEngineReferenceTest {
+
+  /** A reference exposes its immutable slot identity and accepts one idempotent owner binding. */
+  @Test
+  public void bindsOwnerOnce() {
+    var reference = new IndexEngineReference(7, 1, 42);
+    var owner = new RecordId(3, 11);
+
+    reference.bindOwner(owner);
+    reference.bindOwner(owner);
+
+    assertThat(reference.slot()).isEqualTo(7);
+    assertThat(reference.apiVersion()).isEqualTo(1);
+    assertThat(reference.generation()).isEqualTo(42);
+    assertThat(reference.ownerDescriptorIdentity()).isEqualTo(owner);
+  }
+
+  /** Rebinding to another durable descriptor fails fast and reports both conflicting owners. */
+  @Test
+  public void rejectsRebindingToDifferentOwner() {
+    var reference = new IndexEngineReference(7, 1, 42);
+    var firstOwner = new RecordId(3, 11);
+    var secondOwner = new RecordId(3, 12);
+    reference.bindOwner(firstOwner);
+
+    assertThatThrownBy(() -> reference.bindOwner(secondOwner))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(firstOwner.toString())
+        .hasMessageContaining(secondOwner.toString());
+  }
+
+  /** Slots and generations use only valid local-engine identity ranges. */
+  @Test
+  public void rejectsInvalidIdentityParts() {
+    assertThatThrownBy(() -> new IndexEngineReference(-1, 1, 1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new IndexEngineReference(0, 1, 0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -1614,9 +1614,8 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
   private IndexHistogramManager getHistogramManager(String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storageField = IndexAbstract.class.getDeclaredField("storage");
       storageField.setAccessible(true);
       var storage = storageField.get(idx);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramDurabilityTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramDurabilityTest.java
@@ -562,10 +562,8 @@ public class IndexHistogramDurabilityTest {
     try {
       var idx = session.getSharedContext().getIndexManager()
           .getIndex(indexName);
-      var indexIdField = IndexAbstract.class
-          .getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storageField = IndexAbstract.class
           .getDeclaredField("storage");
       storageField.setAccessible(true);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramIntegrationTest.java
@@ -2577,9 +2577,8 @@ public class IndexHistogramIntegrationTest extends DbTestBase {
   private IndexHistogramManager getHistogramManager(String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storageField = IndexAbstract.class.getDeclaredField("storage");
       storageField.setAccessible(true);
       var storage = storageField.get(idx);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
@@ -31,45 +32,53 @@ public class IndexHistogramSlotReuseTest {
   @Test
   public void detachedManagerCannotPublishSmallBuild() throws Exception {
     var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
     var replacement = fixture.detachAndSeedReplacement();
 
     fixture.manager.buildHistogram(fixture.operation, Stream.empty(), 1, 0, 1);
 
     assertSame(replacement, fixture.cache.get(fixture.engineId));
+    verifyNoInteractions(fixture.operation);
   }
 
   /** U2 covers the counters-only build publication after an empty full-size scan. */
   @Test
   public void detachedManagerCannotPublishEmptyFullSizeBuild() throws Exception {
     var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
     var replacement = fixture.detachAndSeedReplacement();
 
     fixture.manager.buildHistogram(fixture.operation, Stream.empty(), 1_000, 0, 1);
 
     assertSame(replacement, fixture.cache.get(fixture.engineId));
+    verifyNoInteractions(fixture.operation);
   }
 
   /** U3 covers the complete histogram publication after a full key scan. */
   @Test
   public void detachedManagerCannotPublishCompleteBuild() throws Exception {
     var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
     var replacement = fixture.detachAndSeedReplacement();
     var keys = IntStream.range(0, 1_000).boxed().map(value -> (Object) value);
 
     fixture.manager.buildHistogram(fixture.operation, keys, 1_000, 0, 1);
 
     assertSame(replacement, fixture.cache.get(fixture.engineId));
+    verifyNoInteractions(fixture.operation);
   }
 
   /** U4 covers the empty snapshot publication used when an index is cleared. */
   @Test
   public void detachedManagerCannotPublishClearReset() throws Exception {
     var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
     var replacement = fixture.detachAndSeedReplacement();
 
     fixture.manager.resetOnClear(fixture.operation);
 
     assertSame(replacement, fixture.cache.get(fixture.engineId));
+    verifyNoInteractions(fixture.operation);
   }
 
   /** U5 detaches at the publication seam after synchronous analysis has scanned its stale keys. */
@@ -133,7 +142,7 @@ public class IndexHistogramSlotReuseTest {
   @Test
   public void detachedManagerCannotScheduleHistogramWork() {
     var fixture = new Fixture();
-    fixture.detachAndSeedReplacement();
+    fixture.detachAndSeedReplacement(Long.MAX_VALUE);
     var executor = mock(ExecutorService.class);
 
     fixture.manager.maybeScheduleHistogramWork(executor);
@@ -199,8 +208,12 @@ public class IndexHistogramSlotReuseTest {
     }
 
     private HistogramSnapshot detachAndSeedReplacement() {
+      return detachAndSeedReplacement(77);
+    }
+
+    private HistogramSnapshot detachAndSeedReplacement(long totalCount) {
       manager.detach();
-      var replacement = snapshot(77);
+      var replacement = snapshot(totalCount);
       cache.put(engineId, replacement);
       return replacement;
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
@@ -1,0 +1,216 @@
+package com.jetbrains.youtrackdb.internal.core.index.engine;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
+import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+/** Verifies that a detached histogram manager cannot publish into a reused engine slot. */
+public class IndexHistogramSlotReuseTest {
+
+  /** U1 covers the counters-only build publication after the early size exit. */
+  @Test
+  public void detachedManagerCannotPublishSmallBuild() throws Exception {
+    var fixture = new Fixture();
+    var replacement = fixture.detachAndSeedReplacement();
+
+    fixture.manager.buildHistogram(fixture.operation, Stream.empty(), 1, 0, 1);
+
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U2 covers the counters-only build publication after an empty full-size scan. */
+  @Test
+  public void detachedManagerCannotPublishEmptyFullSizeBuild() throws Exception {
+    var fixture = new Fixture();
+    var replacement = fixture.detachAndSeedReplacement();
+
+    fixture.manager.buildHistogram(fixture.operation, Stream.empty(), 1_000, 0, 1);
+
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U3 covers the complete histogram publication after a full key scan. */
+  @Test
+  public void detachedManagerCannotPublishCompleteBuild() throws Exception {
+    var fixture = new Fixture();
+    var replacement = fixture.detachAndSeedReplacement();
+    var keys = IntStream.range(0, 1_000).boxed().map(value -> (Object) value);
+
+    fixture.manager.buildHistogram(fixture.operation, keys, 1_000, 0, 1);
+
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U4 covers the empty snapshot publication used when an index is cleared. */
+  @Test
+  public void detachedManagerCannotPublishClearReset() throws Exception {
+    var fixture = new Fixture();
+    var replacement = fixture.detachAndSeedReplacement();
+
+    fixture.manager.resetOnClear(fixture.operation);
+
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U5 detaches at the publication seam after synchronous analysis has scanned its stale keys. */
+  @Test
+  public void detachAtPublicationPreventsRebalanceMerge() {
+    var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
+    fixture.cache.put(fixture.engineId, snapshot(8));
+    fixture.manager.setKeyStreamSupplier(
+        operation -> IntStream.range(0, 8).boxed().map(value -> (Object) value));
+    var replacement = snapshot(77);
+    fixture.installDetachAndSeedHook(replacement);
+
+    try {
+      assertSame(replacement, fixture.manager.analyzeIndex());
+    } finally {
+      fixture.manager.setPrePublicationTestHook(null);
+    }
+
+    assertTrue(fixture.manager.isDetached());
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U6 detaches at the publication seam before a stale transaction delta can merge. */
+  @Test
+  public void detachAtPublicationPreventsDeltaMerge() {
+    var fixture = new Fixture();
+    fixture.cache.put(fixture.engineId, snapshot(8));
+    var replacement = snapshot(77);
+    fixture.installDetachAndSeedHook(replacement);
+    var delta = new HistogramDelta();
+    delta.totalCountDelta = 1;
+    delta.mutationCount = 1;
+
+    try {
+      fixture.manager.applyDelta(delta);
+    } finally {
+      fixture.manager.setPrePublicationTestHook(null);
+    }
+
+    assertTrue(fixture.manager.isDetached());
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+  }
+
+  /** U7 proves a detached dirty manager does not open an operation to flush replacement state. */
+  @Test
+  public void detachedManagerCannotFlushReplacementSnapshot() throws Exception {
+    var fixture = new Fixture();
+    fixture.manager.setFileIdForTest(42);
+    var replacement = fixture.detachAndSeedReplacement();
+    fixture.manager.setDirtyMutationsForTest(1);
+
+    fixture.manager.flushIfDirty();
+    fixture.manager.flushIfDirty(fixture.operation);
+
+    assertSame(replacement, fixture.cache.get(fixture.engineId));
+    verify(fixture.atomicOperationsManager, never()).executeInsideAtomicOperation(any());
+  }
+
+  /** U8 proves detached managers cannot submit background histogram work. */
+  @Test
+  public void detachedManagerCannotScheduleHistogramWork() {
+    var fixture = new Fixture();
+    fixture.detachAndSeedReplacement();
+    var executor = mock(ExecutorService.class);
+
+    fixture.manager.maybeScheduleHistogramWork(executor);
+
+    verify(executor, never()).submit(any(Runnable.class));
+  }
+
+  /** U9 proves detached analysis returns before consulting the stale key supplier. */
+  @Test
+  public void detachedManagerCannotAnalyzeStaleKeys() {
+    var fixture = new Fixture();
+    fixture.detachAndSeedReplacement();
+    var scans = new AtomicInteger();
+    fixture.manager.setKeyStreamSupplier(operation -> {
+      scans.incrementAndGet();
+      return Stream.of(1);
+    });
+
+    assertNull(fixture.manager.analyzeIndex());
+    assertTrue("detached analysis must not scan keys", scans.get() == 0);
+  }
+
+  private static HistogramSnapshot snapshot(long totalCount) {
+    return new HistogramSnapshot(
+        new IndexStatistics(totalCount, totalCount, 0),
+        null,
+        0,
+        totalCount,
+        0,
+        false,
+        null,
+        false);
+  }
+
+  private static final class Fixture {
+    private final int engineId = 7;
+    private final ConcurrentHashMap<Integer, HistogramSnapshot> cache =
+        new ConcurrentHashMap<>();
+    private final AtomicOperation operation = mock(AtomicOperation.class);
+    private final AtomicOperationsManager atomicOperationsManager =
+        mock(AtomicOperationsManager.class);
+    private final IndexHistogramManager manager;
+
+    private Fixture() {
+      var storage = mock(AbstractStorage.class);
+      var factory = new CurrentStorageComponentsFactory(
+          BinarySerializerFactory.currentBinaryFormatVersion());
+      when(storage.getComponentsFactory()).thenReturn(factory);
+      when(storage.getAtomicOperationsManager()).thenReturn(atomicOperationsManager);
+      when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+      when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+      when(atomicOperationsManager.startAtomicOperation()).thenReturn(operation);
+      manager = new IndexHistogramManager(
+          storage,
+          "slot-reuse-test",
+          engineId,
+          true,
+          cache,
+          IntegerSerializer.INSTANCE,
+          BinarySerializerFactory.create(
+              BinarySerializerFactory.CURRENT_BINARY_FORMAT_VERSION),
+          IntegerSerializer.ID);
+    }
+
+    private HistogramSnapshot detachAndSeedReplacement() {
+      manager.detach();
+      var replacement = snapshot(77);
+      cache.put(engineId, replacement);
+      return replacement;
+    }
+
+    private void installDetachAndSeedHook(HistogramSnapshot replacement) {
+      manager.setPrePublicationTestHook(() -> {
+        manager.setPrePublicationTestHook(null);
+        manager.detach();
+        cache.put(engineId, replacement);
+      });
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramSlotReuseTest.java
@@ -142,7 +142,7 @@ public class IndexHistogramSlotReuseTest {
   @Test
   public void detachedManagerCannotScheduleHistogramWork() {
     var fixture = new Fixture();
-    fixture.detachAndSeedReplacement(Long.MAX_VALUE);
+    fixture.detachAndSeedInitialBuildReplacement();
     var executor = mock(ExecutorService.class);
 
     fixture.manager.maybeScheduleHistogramWork(executor);
@@ -216,6 +216,20 @@ public class IndexHistogramSlotReuseTest {
       var replacement = snapshot(totalCount);
       cache.put(engineId, replacement);
       return replacement;
+    }
+
+    private void detachAndSeedInitialBuildReplacement() {
+      manager.detach();
+      var replacement = new HistogramSnapshot(
+          new IndexStatistics(Long.MAX_VALUE, Long.MAX_VALUE, 0),
+          null,
+          0,
+          0,
+          0,
+          false,
+          null,
+          false);
+      cache.put(engineId, replacement);
     }
 
     private void installDetachAndSeedHook(HistogramSnapshot replacement) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeEnginePersistedCountIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeEnginePersistedCountIT.java
@@ -7,7 +7,6 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -705,9 +704,8 @@ public class BTreeEnginePersistedCountIT extends DbTestBase {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class
           .getMethod("getIndexEngine", int.class);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngineClearRollbackTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngineClearRollbackTest.java
@@ -7,7 +7,6 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -243,9 +242,8 @@ public class BTreeMultiValueIndexEngineClearRollbackTest {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class.getMethod("getIndexEngine", int.class);
       return (BTreeIndexEngine) getEngineMethod.invoke(storage, indexId);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngineClearRollbackTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngineClearRollbackTest.java
@@ -7,7 +7,6 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -246,9 +245,8 @@ public class BTreeSingleValueIndexEngineClearRollbackTest {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class.getMethod("getIndexEngine", int.class);
       return (BTreeIndexEngine) getEngineMethod.invoke(storage, indexId);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/IndexAbstractBuildHistogramRollbackTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/IndexAbstractBuildHistogramRollbackTest.java
@@ -15,7 +15,6 @@ import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDeltaHolder;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -815,9 +814,8 @@ public class IndexAbstractBuildHistogramRollbackTest {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class.getMethod("getIndexEngine", int.class);
       return (BTreeIndexEngine) getEngineMethod.invoke(storage, indexId);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStorageBackendTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStorageBackendTest.java
@@ -1,0 +1,227 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
+import java.util.ConcurrentModificationException;
+import java.util.UUID;
+import org.junit.Test;
+
+/** Covers lifecycle persistence through one durable descriptor link. */
+public class IndexBuildStateStorageBackendTest extends DbTestBase {
+
+  /** A descriptor link reads exactly the lifecycle record named by the link. */
+  @Test
+  public void descriptorLinkReadsOneDurableSnapshot() {
+    var descriptor = createDescriptor();
+    var store = session.getStorage().getIndexBuildStateStore();
+    var created = store.createInitial(descriptor, null);
+    writeLifecycleLink(descriptor, created.identity());
+
+    var read = store.read(descriptor, readLifecycleLink(descriptor));
+
+    assertEquals(created.snapshot(), read);
+    assertNotSame(created.snapshot(), read);
+    assertEquals(IndexLifecycle.EXISTS, read.lifecycle());
+    assertFalse(read.buildState().suspended());
+  }
+
+  /** A descriptor without a lifecycle link fails before any lifecycle record read. */
+  @Test
+  public void absentDescriptorLinkFailsClearly() {
+    var descriptor = createDescriptor();
+    var store = session.getStorage().getIndexBuildStateStore();
+
+    var failure =
+        assertThrows(IllegalStateException.class, () -> store.read(descriptor, null));
+
+    assertEquals("Index descriptor has no lifecycle record link", failure.getMessage());
+  }
+
+  /** A descriptor link to a deleted or unallocated record fails clearly. */
+  @Test
+  public void linkToMissingLifecycleRecordFailsClearly() {
+    var descriptor = createDescriptor();
+    var collectionId =
+        session
+            .getStorage()
+            .getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var missing = new RecordId(collectionId, Long.MAX_VALUE - 7);
+    session.disableLinkConsistencyCheck();
+    try {
+      writeLifecycleLink(descriptor, missing);
+    } finally {
+      session.enableLinkConsistencyCheck();
+    }
+
+    var failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> session
+                .getStorage()
+                .getIndexBuildStateStore()
+                .read(descriptor, readLifecycleLink(descriptor)));
+
+    assertEquals("Linked index build state record is missing", failure.getMessage());
+  }
+
+  /** A present descriptor link rejects creation of a second lifecycle record. */
+  @Test
+  public void presentDescriptorLinkRejectsSecondLifecycleRecord() {
+    var descriptor = createDescriptor();
+    var store = session.getStorage().getIndexBuildStateStore();
+    var created = store.createInitial(descriptor, null);
+    writeLifecycleLink(descriptor, created.identity());
+
+    var failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> store.createInitial(descriptor, readLifecycleLink(descriptor)));
+
+    assertEquals("Index descriptor already has a lifecycle record link", failure.getMessage());
+  }
+
+  /** Deletion removes the linked lifecycle record through the backend. */
+  @Test
+  public void deletionRemovesLifecycleRecord() {
+    var fixture = createLinkedState();
+
+    fixture.store().delete(fixture.lifecycle(), fixture.created().recordVersion());
+
+    var failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> fixture.store().read(fixture.descriptor(), fixture.lifecycle()));
+    assertEquals("Linked index build state record is missing", failure.getMessage());
+  }
+
+  /** Deletion rejects an expected revision older than the durable record. */
+  @Test
+  public void staleRevisionCannotDeleteLifecycleRecord() {
+    var fixture = createLinkedState();
+    var published =
+        fixture.store().publish(
+            fixture.descriptor(),
+            fixture.lifecycle(),
+            fixture.created(),
+            maintainedState(fixture.descriptor()));
+
+    assertThrows(
+        com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException.class,
+        () -> fixture.store().delete(fixture.lifecycle(), fixture.created().recordVersion()));
+    assertEquals(published, fixture.store().read(fixture.descriptor(), fixture.lifecycle()));
+  }
+
+  /** A rebuilt snapshot publishes under the value comparison that excludes owner epoch. */
+  @Test
+  public void ownerEpochExcludedValueComparisonPublishesRebuiltSnapshot() {
+    var fixture = createLinkedState();
+    var rebuiltExpected =
+        new IndexLifecycleSnapshot(fixture.created().buildState(),
+            fixture.created().recordVersion());
+
+    var published =
+        fixture.store().publish(
+            fixture.descriptor(),
+            fixture.lifecycle(),
+            rebuiltExpected,
+            maintainedState(fixture.descriptor()));
+
+    assertEquals(IndexLifecycle.MAINTAINED, published.lifecycle());
+    assertTrue(published.recordVersion() > fixture.created().recordVersion());
+    assertEquals(published, fixture.store().read(fixture.descriptor(), fixture.lifecycle()));
+  }
+
+  /** A publication naming another descriptor fails before durable data changes. */
+  @Test
+  public void publicationRejectsAnotherDescriptor() {
+    var fixture = createLinkedState();
+    var otherDescriptor = new RecordId(0, 42);
+
+    var failure =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> fixture.store().publish(
+                fixture.descriptor(),
+                fixture.lifecycle(),
+                fixture.created(),
+                maintainedState(otherDescriptor)));
+
+    assertEquals("Index build state belongs to another descriptor", failure.getMessage());
+    assertEquals(
+        fixture.created(), fixture.store().read(fixture.descriptor(), fixture.lifecycle()));
+  }
+
+  /** An older expected revision cannot replace a newer durable snapshot. */
+  @Test
+  public void olderExpectedRevisionCannotReplaceNewerSnapshot() {
+    var fixture = createLinkedState();
+    var published =
+        fixture.store().publish(
+            fixture.descriptor(),
+            fixture.lifecycle(),
+            fixture.created(),
+            maintainedState(fixture.descriptor()));
+
+    assertThrows(
+        ConcurrentModificationException.class,
+        () -> fixture.store().publish(
+            fixture.descriptor(),
+            fixture.lifecycle(),
+            fixture.created(),
+            maintainedState(fixture.descriptor())));
+    assertEquals(published, fixture.store().read(fixture.descriptor(), fixture.lifecycle()));
+  }
+
+  private RID createDescriptor() {
+    return session.computeInTx(transaction -> transaction.newEntity().getIdentity());
+  }
+
+  private void writeLifecycleLink(RID descriptor, RID lifecycle) {
+    session.executeInTx(
+        transaction -> transaction.loadEntity(descriptor).setLink(Index.LIFECYCLE_RECORD,
+            lifecycle));
+  }
+
+  private RID readLifecycleLink(RID descriptor) {
+    return session.computeInTx(
+        transaction -> transaction.loadEntity(descriptor).getLink(Index.LIFECYCLE_RECORD));
+  }
+
+  private LinkedState createLinkedState() {
+    var descriptor = createDescriptor();
+    var store = session.getStorage().getIndexBuildStateStore();
+    var created = store.createInitial(descriptor, null);
+    writeLifecycleLink(descriptor, created.identity());
+    return new LinkedState(descriptor, created.identity(), created.snapshot(), store);
+  }
+
+  private static IndexBuildState maintainedState(RID descriptor) {
+    return new IndexBuildState(
+        IndexBuildState.CURRENT_FORMAT_VERSION,
+        descriptor,
+        IndexLifecycle.MAINTAINED,
+        UUID.randomUUID(),
+        null,
+        null,
+        0,
+        false,
+        IndexBuildFailure.NONE,
+        null);
+  }
+
+  private record LinkedState(
+      RID descriptor,
+      RID lifecycle,
+      IndexLifecycleSnapshot created,
+      IndexBuildStateStore store) {
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStoreTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStoreTest.java
@@ -1,0 +1,208 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+
+/** Covers durable store serialization, transitions, recovery, and deletion. */
+public class IndexBuildStateStoreTest {
+
+  private static final RID DESCRIPTOR = new RecordId(7, 9);
+
+  /** Serialization preserves every durable field, including nullable fields. */
+  @Test
+  public void serializationRoundTripsCompleteState() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    var state = new IndexBuildState(
+        1, DESCRIPTOR, IndexLifecycle.MAINTAINED, UUID.randomUUID(), 4L, 17L, 23, true,
+        IndexBuildFailure.NONE, "paused");
+
+    var serialized = store.serialize(state);
+    assertFalse(serialized.containsKey("storageIdentity"));
+    assertFalse(serialized.containsKey("lineageIdentity"));
+    assertEquals(state, store.deserialize(serialized));
+  }
+
+  /** A stale version fails before an illegal lifecycle transition is inspected. */
+  @Test
+  public void expectedVersionCheckPrecedesTransitionCheck() {
+    var store = storeWithInitial();
+    var illegal = replacement(IndexLifecycle.USABLE, UUID.randomUUID(), null);
+
+    var failure = assertThrows(
+        ConcurrentModificationException.class, () -> store.update(DESCRIPTOR, 99, illegal));
+    assertTrue(failure.getMessage().contains("99"));
+  }
+
+  /** A current expected version cannot authorize an unapproved lifecycle transition. */
+  @Test
+  public void storeRejectsIllegalTransition() {
+    var store = storeWithInitial();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.update(
+            DESCRIPTOR, 0, replacement(IndexLifecycle.USABLE, UUID.randomUUID(), null)));
+  }
+
+  /** An update rejects state belonging to a different descriptor. */
+  @Test
+  public void updateRejectsReplacementForAnotherDescriptor() {
+    var store = storeWithInitial();
+    var otherDescriptor = new RecordId(7, 10);
+    var replacement = new IndexBuildState(
+        1,
+        otherDescriptor,
+        IndexLifecycle.MAINTAINED,
+        UUID.randomUUID(),
+        null,
+        null,
+        0,
+        false,
+        IndexBuildFailure.NONE,
+        null);
+
+    var failure = assertThrows(
+        IllegalArgumentException.class, () -> store.update(DESCRIPTOR, 0, replacement));
+    assertEquals("Index build state belongs to another descriptor", failure.getMessage());
+  }
+
+  /** A durable record rejects a negative storage version. */
+  @Test
+  public void versionedRecordRejectsNegativeVersion() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> new IndexBuildStateStore.VersionedRecord(Map.of(), -1));
+
+    assertEquals("The record version cannot be negative", failure.getMessage());
+  }
+
+  /** An invalid retry changes the build incarnation and clears the owner epoch. */
+  @Test
+  public void retryRequiresNewIncarnationAndClearedOwner() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    var invalid = invalidState();
+    store.create(invalid);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.update(
+            DESCRIPTOR, 0,
+            replacement(IndexLifecycle.MAINTAINED, invalid.buildIncarnation(), null)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store.update(
+            DESCRIPTOR, 0, replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), 5L)));
+
+    var retried = store.update(
+        DESCRIPTOR, 0, replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null));
+    assertNotEquals(invalid.buildIncarnation(), retried.buildState().buildIncarnation());
+    assertNull(retried.buildState().ownerEpoch());
+  }
+
+  /** Recovery publishes the durable record when the record is present. */
+  @Test
+  public void recoveryReturnsPresentRecord() {
+    var recovered = storeWithInitial().recover(DESCRIPTOR);
+
+    assertEquals(IndexLifecycle.EXISTS, recovered.lifecycle());
+    assertEquals(0, recovered.recordVersion());
+  }
+
+  /** Recovery creates an invalid quarantine when the durable record is missing. */
+  @Test
+  public void recoveryQuarantinesMissingRecord() {
+    var recovered = new IndexBuildStateStore(new MemoryBackend()).recover(DESCRIPTOR);
+
+    assertEquals(IndexLifecycle.INVALID, recovered.lifecycle());
+    assertEquals(IndexBuildFailure.INDEX_BUILD_STATE_MISSING, recovered.buildState().failure());
+  }
+
+  /** Deletion removes the durable record under its expected version. */
+  @Test
+  public void deletionRemovesStateRecord() {
+    var store = storeWithInitial();
+    store.delete(DESCRIPTOR, 0);
+    assertFalse(store.read(DESCRIPTOR).isPresent());
+  }
+
+  private static IndexBuildStateStore storeWithInitial() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    store.createInitial(DESCRIPTOR);
+    return store;
+  }
+
+  private static IndexBuildState replacement(
+      IndexLifecycle lifecycle, UUID incarnation, Long ownerEpoch) {
+    return new IndexBuildState(
+        1,
+        DESCRIPTOR,
+        lifecycle,
+        incarnation,
+        ownerEpoch,
+        null,
+        0,
+        false,
+        lifecycle == IndexLifecycle.INVALID
+            ? IndexBuildFailure.UNIQUE_KEY_CONFLICT
+            : IndexBuildFailure.NONE,
+        null);
+  }
+
+  private static IndexBuildState invalidState() {
+    return replacement(IndexLifecycle.INVALID, UUID.randomUUID(), 3L);
+  }
+
+  private static final class MemoryBackend implements IndexBuildStateStore.Backend {
+
+    private final Map<RID, IndexBuildStateStore.VersionedRecord> records = new HashMap<>();
+
+    @Override
+    public Optional<IndexBuildStateStore.VersionedRecord> read(RID descriptorIdentity) {
+      return Optional.ofNullable(records.get(descriptorIdentity));
+    }
+
+    @Override
+    public IndexBuildStateStore.VersionedRecord create(
+        RID descriptorIdentity, Map<String, Object> value) {
+      var created = new IndexBuildStateStore.VersionedRecord(value, 0);
+      if (records.putIfAbsent(descriptorIdentity, created) != null) {
+        throw new IllegalStateException("Index build state already exists");
+      }
+      return created;
+    }
+
+    @Override
+    public IndexBuildStateStore.VersionedRecord update(
+        RID descriptorIdentity, long expectedVersion, Map<String, Object> value) {
+      var current = records.get(descriptorIdentity);
+      if (current == null || current.version() != expectedVersion) {
+        throw new ConcurrentModificationException("Index build state version changed");
+      }
+      var replacement = new IndexBuildStateStore.VersionedRecord(value, expectedVersion + 1);
+      records.put(descriptorIdentity, replacement);
+      return replacement;
+    }
+
+    @Override
+    public void delete(RID descriptorIdentity, long expectedVersion) {
+      var current = records.get(descriptorIdentity);
+      if (current == null || current.version() != expectedVersion) {
+        throw new ConcurrentModificationException("Index build state version changed");
+      }
+      records.remove(descriptorIdentity);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStoreTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateStoreTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.junit.Test;
 
-/** Covers durable store serialization, transitions, recovery, and deletion. */
+/** Covers durable store serialization, transitions, linked reads, and deletion. */
 public class IndexBuildStateStoreTest {
 
   private static final RID DESCRIPTOR = new RecordId(7, 9);
@@ -25,66 +25,158 @@ public class IndexBuildStateStoreTest {
   @Test
   public void serializationRoundTripsCompleteState() {
     var store = new IndexBuildStateStore(new MemoryBackend());
-    var state = new IndexBuildState(
-        1, DESCRIPTOR, IndexLifecycle.MAINTAINED, UUID.randomUUID(), 4L, 17L, 23, true,
-        IndexBuildFailure.NONE, "paused");
+    var state =
+        new IndexBuildState(
+            1,
+            DESCRIPTOR,
+            IndexLifecycle.MAINTAINED,
+            UUID.randomUUID(),
+            4L,
+            17L,
+            23,
+            true,
+            IndexBuildFailure.NONE,
+            "paused");
 
     var serialized = store.serialize(state);
     assertFalse(serialized.containsKey("storageIdentity"));
     assertFalse(serialized.containsKey("lineageIdentity"));
+    assertFalse(serialized.containsKey("ownerLineage"));
     assertEquals(state, store.deserialize(serialized));
+  }
+
+  /** Every durable field rejects values with a different runtime type. */
+  @Test
+  public void decodingRejectsWrongTypeForEveryField() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    var valid = store.serialize(IndexBuildState.initial(DESCRIPTOR));
+    var fields =
+        new String[] {
+            "formatVersion",
+            "descriptorIdentity",
+            "lifecycle",
+            "buildIncarnation",
+            "ownerEpoch",
+            "completionCut",
+            "completedUnits",
+            "suspended",
+            "failure",
+            "failureMessage"
+        };
+
+    for (var field : fields) {
+      var malformed = new HashMap<>(valid);
+      malformed.put(field, wrongTypeFor(field));
+      assertThrows(
+          "The " + field + " field must reject a wrong type",
+          IllegalArgumentException.class,
+          () -> store.deserialize(malformed));
+    }
+  }
+
+  private static Object wrongTypeFor(String field) {
+    return switch (field) {
+      case "formatVersion" -> 4_294_967_297L;
+      case "ownerEpoch", "completionCut", "completedUnits" -> Integer.valueOf(1);
+      case "suspended" -> "false";
+      default -> Boolean.FALSE;
+    };
   }
 
   /** A stale version fails before an illegal lifecycle transition is inspected. */
   @Test
   public void expectedVersionCheckPrecedesTransitionCheck() {
-    var store = storeWithInitial();
+    var fixture = storeWithInitial();
     var illegal = replacement(IndexLifecycle.USABLE, UUID.randomUUID(), null);
+    var staleExpected = new IndexLifecycleSnapshot(IndexBuildState.initial(DESCRIPTOR), 99);
 
-    var failure = assertThrows(
-        ConcurrentModificationException.class, () -> store.update(DESCRIPTOR, 99, illegal));
+    var failure =
+        assertThrows(
+            ConcurrentModificationException.class,
+            () -> fixture.store().publish(DESCRIPTOR, fixture.link(), staleExpected, illegal));
+
     assertTrue(failure.getMessage().contains("99"));
   }
 
   /** A current expected version cannot authorize an unapproved lifecycle transition. */
   @Test
   public void storeRejectsIllegalTransition() {
-    var store = storeWithInitial();
+    var fixture = storeWithInitial();
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> store.update(
-            DESCRIPTOR, 0, replacement(IndexLifecycle.USABLE, UUID.randomUUID(), null)));
+        () -> fixture.store().publish(
+            DESCRIPTOR,
+            fixture.link(),
+            fixture.store().read(DESCRIPTOR, fixture.link()),
+            replacement(IndexLifecycle.USABLE, UUID.randomUUID(), null)));
   }
 
   /** An update rejects state belonging to a different descriptor. */
   @Test
   public void updateRejectsReplacementForAnotherDescriptor() {
-    var store = storeWithInitial();
+    var fixture = storeWithInitial();
     var otherDescriptor = new RecordId(7, 10);
-    var replacement = new IndexBuildState(
-        1,
-        otherDescriptor,
-        IndexLifecycle.MAINTAINED,
-        UUID.randomUUID(),
-        null,
-        null,
-        0,
-        false,
-        IndexBuildFailure.NONE,
-        null);
+    var replacement =
+        new IndexBuildState(
+            1,
+            otherDescriptor,
+            IndexLifecycle.MAINTAINED,
+            UUID.randomUUID(),
+            null,
+            null,
+            0,
+            false,
+            IndexBuildFailure.NONE,
+            null);
+
+    var failure =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> fixture.store().publish(
+                DESCRIPTOR,
+                fixture.link(),
+                fixture.store().read(DESCRIPTOR, fixture.link()),
+                replacement));
+
+    assertEquals("Index build state belongs to another descriptor", failure.getMessage());
+  }
+
+  /** A linked record for another descriptor fails ownership validation. */
+  @Test
+  public void linkedReadRejectsRecordForAnotherDescriptor() {
+    var backend = new MemoryBackend();
+    var store = new IndexBuildStateStore(backend);
+    var other = new RecordId(7, 10);
+    var created = store.createInitial(other, null);
+
+    var failure =
+        assertThrows(
+            IllegalArgumentException.class, () -> store.read(DESCRIPTOR, created.identity()));
+
+    assertEquals("Index build state belongs to another descriptor", failure.getMessage());
+  }
+
+  /** A missing linked record has a typed signal distinct from decode failures. */
+  @Test
+  public void linkedReadUsesTypedMissingRecordSignal() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    var missing = new RecordId(19, 77);
 
     var failure = assertThrows(
-        IllegalArgumentException.class, () -> store.update(DESCRIPTOR, 0, replacement));
-    assertEquals("Index build state belongs to another descriptor", failure.getMessage());
+        IndexBuildStateStore.MissingLinkedRecordException.class,
+        () -> store.read(DESCRIPTOR, missing));
+
+    assertEquals("Linked index build state record is missing", failure.getMessage());
   }
 
   /** A durable record rejects a negative storage version. */
   @Test
   public void versionedRecordRejectsNegativeVersion() {
-    var failure = assertThrows(
-        IllegalArgumentException.class,
-        () -> new IndexBuildStateStore.VersionedRecord(Map.of(), -1));
+    var failure =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new IndexBuildStateStore.VersionedRecord(Map.of(), -1));
 
     assertEquals("The record version cannot be negative", failure.getMessage());
   }
@@ -94,54 +186,143 @@ public class IndexBuildStateStoreTest {
   public void retryRequiresNewIncarnationAndClearedOwner() {
     var store = new IndexBuildStateStore(new MemoryBackend());
     var invalid = invalidState();
-    store.create(invalid);
+    var created = store.create(invalid, null);
 
     assertThrows(
         IllegalArgumentException.class,
-        () -> store.update(
-            DESCRIPTOR, 0,
+        () -> store.publish(
+            DESCRIPTOR,
+            created.identity(),
+            store.read(DESCRIPTOR, created.identity()),
             replacement(IndexLifecycle.MAINTAINED, invalid.buildIncarnation(), null)));
     assertThrows(
         IllegalArgumentException.class,
-        () -> store.update(
-            DESCRIPTOR, 0, replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), 5L)));
+        () -> store.publish(
+            DESCRIPTOR,
+            created.identity(),
+            store.read(DESCRIPTOR, created.identity()),
+            replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), 5L)));
 
-    var retried = store.update(
-        DESCRIPTOR, 0, replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null));
+    var retried =
+        store.publish(
+            DESCRIPTOR,
+            created.identity(),
+            store.read(DESCRIPTOR, created.identity()),
+            replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null));
     assertNotEquals(invalid.buildIncarnation(), retried.buildState().buildIncarnation());
     assertNull(retried.buildState().ownerEpoch());
   }
 
-  /** Recovery publishes the durable record when the record is present. */
+  /** An equal rebuilt snapshot publishes under the value comparison that excludes owner epoch. */
   @Test
-  public void recoveryReturnsPresentRecord() {
-    var recovered = storeWithInitial().recover(DESCRIPTOR);
+  public void ownerEpochExcludedValueComparisonAcceptsRebuiltSnapshot() {
+    var fixture = storeWithInitial();
+    var durable = fixture.store().read(DESCRIPTOR, fixture.link());
+    var rebuiltExpected =
+        new IndexLifecycleSnapshot(durable.buildState(), durable.recordVersion());
 
-    assertEquals(IndexLifecycle.EXISTS, recovered.lifecycle());
-    assertEquals(0, recovered.recordVersion());
+    var published =
+        fixture.store().publish(
+            DESCRIPTOR,
+            fixture.link(),
+            rebuiltExpected,
+            replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null));
+
+    assertEquals(IndexLifecycle.MAINTAINED, published.lifecycle());
+    assertEquals(1, published.recordVersion());
   }
 
-  /** Recovery creates an invalid quarantine when the durable record is missing. */
+  /** An owner-free expected snapshot authorizes publication against an owned durable value. */
   @Test
-  public void recoveryQuarantinesMissingRecord() {
-    var recovered = new IndexBuildStateStore(new MemoryBackend()).recover(DESCRIPTOR);
+  public void publicationIgnoresOwnerEpochDifference() {
+    var store = new IndexBuildStateStore(new MemoryBackend());
+    var owned = replacement(IndexLifecycle.EXISTS, UUID.randomUUID(), 71L);
+    var created = store.create(owned, null);
+    var expected =
+        new IndexLifecycleSnapshot(
+            owned.withoutProcessOwnership(), created.snapshot().recordVersion());
 
-    assertEquals(IndexLifecycle.INVALID, recovered.lifecycle());
-    assertEquals(IndexBuildFailure.INDEX_BUILD_STATE_MISSING, recovered.buildState().failure());
+    var published =
+        store.publish(
+            DESCRIPTOR,
+            created.identity(),
+            expected,
+            replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null));
+
+    assertEquals(IndexLifecycle.MAINTAINED, published.lifecycle());
+    assertEquals(1, published.recordVersion());
+  }
+
+  /** Same-revision lifecycle, progress, and failure differences still reject publication. */
+  @Test
+  public void publicationRejectsSameRevisionChangesOutsideOwnerEpoch() {
+    var fixture = storeWithInitial();
+    var durable = fixture.store().read(DESCRIPTOR, fixture.link());
+    var state = durable.buildState();
+    var divergentStates =
+        new IndexBuildState[] {
+            new IndexBuildState(
+                state.formatVersion(),
+                state.descriptorIdentity(),
+                IndexLifecycle.MAINTAINED,
+                state.buildIncarnation(),
+                state.ownerEpoch(),
+                state.completionCut(),
+                state.completedUnits(),
+                state.suspended(),
+                state.failure(),
+                state.failureMessage()),
+            new IndexBuildState(
+                state.formatVersion(),
+                state.descriptorIdentity(),
+                state.lifecycle(),
+                state.buildIncarnation(),
+                state.ownerEpoch(),
+                state.completionCut(),
+                1,
+                state.suspended(),
+                state.failure(),
+                state.failureMessage()),
+            new IndexBuildState(
+                state.formatVersion(),
+                state.descriptorIdentity(),
+                state.lifecycle(),
+                state.buildIncarnation(),
+                state.ownerEpoch(),
+                state.completionCut(),
+                state.completedUnits(),
+                state.suspended(),
+                state.failure(),
+                "different failure detail")
+        };
+
+    for (var divergentState : divergentStates) {
+      var expected =
+          new IndexLifecycleSnapshot(divergentState, durable.recordVersion());
+      assertThrows(
+          ConcurrentModificationException.class,
+          () -> fixture.store().publish(
+              DESCRIPTOR,
+              fixture.link(),
+              expected,
+              replacement(IndexLifecycle.MAINTAINED, UUID.randomUUID(), null)));
+      assertEquals(durable, fixture.store().read(DESCRIPTOR, fixture.link()));
+    }
   }
 
   /** Deletion removes the durable record under its expected version. */
   @Test
   public void deletionRemovesStateRecord() {
-    var store = storeWithInitial();
-    store.delete(DESCRIPTOR, 0);
-    assertFalse(store.read(DESCRIPTOR).isPresent());
+    var fixture = storeWithInitial();
+    fixture.store().delete(fixture.link(), 0);
+    assertFalse(fixture.backend().read(fixture.link()).isPresent());
   }
 
-  private static IndexBuildStateStore storeWithInitial() {
-    var store = new IndexBuildStateStore(new MemoryBackend());
-    store.createInitial(DESCRIPTOR);
-    return store;
+  private static StoreFixture storeWithInitial() {
+    var backend = new MemoryBackend();
+    var store = new IndexBuildStateStore(backend);
+    var created = store.createInitial(DESCRIPTOR, null);
+    return new StoreFixture(store, backend, created.identity());
   }
 
   private static IndexBuildState replacement(
@@ -165,44 +346,46 @@ public class IndexBuildStateStoreTest {
     return replacement(IndexLifecycle.INVALID, UUID.randomUUID(), 3L);
   }
 
+  private record StoreFixture(IndexBuildStateStore store, MemoryBackend backend, RID link) {
+  }
+
   private static final class MemoryBackend implements IndexBuildStateStore.Backend {
 
     private final Map<RID, IndexBuildStateStore.VersionedRecord> records = new HashMap<>();
+    private long nextPosition;
 
     @Override
-    public Optional<IndexBuildStateStore.VersionedRecord> read(RID descriptorIdentity) {
-      return Optional.ofNullable(records.get(descriptorIdentity));
+    public Optional<IndexBuildStateStore.VersionedRecord> read(RID recordIdentity) {
+      return Optional.ofNullable(records.get(recordIdentity));
     }
 
     @Override
-    public IndexBuildStateStore.VersionedRecord create(
-        RID descriptorIdentity, Map<String, Object> value) {
+    public IndexBuildStateStore.CreatedRecord create(Map<String, Object> value) {
+      var identity = new RecordId(19, nextPosition++);
       var created = new IndexBuildStateStore.VersionedRecord(value, 0);
-      if (records.putIfAbsent(descriptorIdentity, created) != null) {
-        throw new IllegalStateException("Index build state already exists");
-      }
-      return created;
+      records.put(identity, created);
+      return new IndexBuildStateStore.CreatedRecord(identity, created);
     }
 
     @Override
     public IndexBuildStateStore.VersionedRecord update(
-        RID descriptorIdentity, long expectedVersion, Map<String, Object> value) {
-      var current = records.get(descriptorIdentity);
+        RID recordIdentity, long expectedVersion, Map<String, Object> value) {
+      var current = records.get(recordIdentity);
       if (current == null || current.version() != expectedVersion) {
         throw new ConcurrentModificationException("Index build state version changed");
       }
       var replacement = new IndexBuildStateStore.VersionedRecord(value, expectedVersion + 1);
-      records.put(descriptorIdentity, replacement);
+      records.put(recordIdentity, replacement);
       return replacement;
     }
 
     @Override
-    public void delete(RID descriptorIdentity, long expectedVersion) {
-      var current = records.get(descriptorIdentity);
+    public void delete(RID recordIdentity, long expectedVersion) {
+      var current = records.get(recordIdentity);
       if (current == null || current.version() != expectedVersion) {
         throw new ConcurrentModificationException("Index build state version changed");
       }
-      records.remove(descriptorIdentity);
+      records.remove(recordIdentity);
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateTest.java
@@ -1,0 +1,217 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import java.util.UUID;
+import org.junit.Test;
+
+/** Covers lifecycle transition legality and durable value invariants. */
+public class IndexBuildStateTest {
+
+  /** Exactly the four approved state changes are legal. */
+  @Test
+  public void onlyApprovedLifecycleTransitionsAreLegal() {
+    for (var current : IndexLifecycle.values()) {
+      for (var replacement : IndexLifecycle.values()) {
+        var expected =
+            (current == IndexLifecycle.EXISTS && replacement == IndexLifecycle.MAINTAINED)
+                || (current == IndexLifecycle.MAINTAINED
+                    && replacement == IndexLifecycle.USABLE)
+                || (current == IndexLifecycle.MAINTAINED
+                    && replacement == IndexLifecycle.INVALID)
+                || (current == IndexLifecycle.INVALID
+                    && replacement == IndexLifecycle.MAINTAINED);
+        assertTrue(expected == IndexBuildState.isLegalTransition(current, replacement));
+      }
+    }
+  }
+
+  /** Initial durable state contains no storage or lineage identity. */
+  @Test
+  public void initialStateStartsWithoutCompletedWork() {
+    var state = IndexBuildState.initial(new RecordId(7, 9));
+
+    assertTrue(state.lifecycle() == IndexLifecycle.EXISTS);
+    assertTrue(state.failure() == IndexBuildFailure.NONE);
+    assertTrue(state.completedUnits() == 0);
+    assertFalse(state.suspended());
+  }
+
+  /** Compare-and-set publishes one complete newer snapshot. */
+  @Test
+  public void compareAndSetPublishesNewerSnapshot() {
+    var current =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var replacement =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 2);
+    var cell = new IndexLifecycleCell(current);
+
+    assertTrue(cell.compareAndSet(current, replacement));
+    assertSame(replacement, cell.snapshot());
+  }
+
+  /** The expected snapshot controls publication when another update already won. */
+  @Test
+  public void compareAndSetRejectsStaleExpectedSnapshot() {
+    var current =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var next =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 2);
+    var cell = new IndexLifecycleCell(current);
+    assertTrue(cell.compareAndSet(current, next));
+
+    assertFalse(cell.compareAndSet(current, next));
+    assertSame(next, cell.snapshot());
+  }
+
+  /** An unsupported durable format reports the rejected version. */
+  @Test
+  public void formatVersionMustBeCurrent() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> state(2, new RecordId(7, 9), null, null, 0));
+
+    assertEquals("Unsupported index build state format 2", failure.getMessage());
+  }
+
+  /** A transient descriptor identity is rejected before publication. */
+  @Test
+  public void descriptorIdentityMustBePersistent() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> state(1, new RecordId(-1, -1), null, null, 0));
+
+    assertEquals("The index descriptor identity must be persistent", failure.getMessage());
+  }
+
+  /** A negative owner epoch is rejected before publication. */
+  @Test
+  public void ownerEpochCannotBeNegative() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> state(1, new RecordId(7, 9), -1L, null, 0));
+
+    assertEquals("The owner epoch cannot be negative", failure.getMessage());
+  }
+
+  /** A negative completion cut is rejected before publication. */
+  @Test
+  public void completionCutCannotBeNegative() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> state(1, new RecordId(7, 9), null, -1L, 0));
+
+    assertEquals("The completion cut cannot be negative", failure.getMessage());
+  }
+
+  /** A negative completed-unit count is rejected before publication. */
+  @Test
+  public void completedUnitsCannotBeNegative() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> state(1, new RecordId(7, 9), null, null, -1));
+
+    assertEquals("Completed units cannot be negative", failure.getMessage());
+  }
+
+  /** An older snapshot cannot replace a newer expected snapshot. */
+  @Test
+  public void compareAndSetRejectsOlderReplacementVersion() {
+    var expected =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 2);
+    var replacement =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 1);
+    var cell = new IndexLifecycleCell(expected);
+
+    var failure = assertThrows(
+        IllegalArgumentException.class, () -> cell.compareAndSet(expected, replacement));
+    assertEquals("A lifecycle snapshot cannot move to an older version", failure.getMessage());
+    assertSame(expected, cell.snapshot());
+  }
+
+  /** A retired cell rejects compare-and-set publication. */
+  @Test
+  public void compareAndSetRejectsRetiredCell() {
+    var expected =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var replacement =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 2);
+    var cell = new IndexLifecycleCell(expected);
+    cell.retire();
+
+    var failure = assertThrows(
+        IllegalStateException.class, () -> cell.compareAndSet(expected, replacement));
+    assertEquals(
+        "The lifecycle cell belongs to a retired storage lineage", failure.getMessage());
+  }
+
+  /** A snapshot rejects a negative durable record version. */
+  @Test
+  public void snapshotRecordVersionCannotBeNegative() {
+    var failure = assertThrows(
+        IllegalArgumentException.class,
+        () -> new IndexLifecycleSnapshot(
+            state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), -1));
+
+    assertEquals("The record version cannot be negative", failure.getMessage());
+  }
+
+  /** An invalid state requires a machine-readable failure reason. */
+  @Test
+  public void invalidStateRequiresFailureCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> state(IndexLifecycle.INVALID, IndexBuildFailure.NONE));
+  }
+
+  /** Missing-state quarantine belongs only to an invalid lifecycle. */
+  @Test
+  public void missingStateFailureRequiresInvalidLifecycle() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> state(IndexLifecycle.EXISTS, IndexBuildFailure.INDEX_BUILD_STATE_MISSING));
+  }
+
+  private static IndexBuildState state(IndexLifecycle lifecycle, IndexBuildFailure failure) {
+    return state(1, new RecordId(7, 9), null, null, 0, lifecycle, failure);
+  }
+
+  private static IndexBuildState state(
+      int formatVersion, RecordId descriptor, Long ownerEpoch, Long completionCut,
+      long completedUnits) {
+    return state(
+        formatVersion,
+        descriptor,
+        ownerEpoch,
+        completionCut,
+        completedUnits,
+        IndexLifecycle.EXISTS,
+        IndexBuildFailure.NONE);
+  }
+
+  private static IndexBuildState state(
+      int formatVersion,
+      RecordId descriptor,
+      Long ownerEpoch,
+      Long completionCut,
+      long completedUnits,
+      IndexLifecycle lifecycle,
+      IndexBuildFailure failure) {
+    return new IndexBuildState(
+        formatVersion,
+        descriptor,
+        lifecycle,
+        UUID.randomUUID(),
+        ownerEpoch,
+        completionCut,
+        completedUnits,
+        false,
+        failure,
+        null);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexBuildStateTest.java
@@ -134,6 +134,38 @@ public class IndexBuildStateTest {
     assertSame(expected, cell.snapshot());
   }
 
+  /** A value-equal expected snapshot authorizes publication. */
+  @Test
+  public void compareAndSetMatchesExpectedSnapshotByValue() {
+    var current =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var rebuiltExpected =
+        new IndexLifecycleSnapshot(current.buildState(), current.recordVersion());
+    var replacement =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 2);
+    var cell = new IndexLifecycleCell(current);
+
+    assertTrue(cell.compareAndSet(rebuiltExpected, replacement));
+    assertSame(replacement, cell.snapshot());
+  }
+
+  /** A publication cannot replace a snapshot for another descriptor. */
+  @Test
+  public void compareAndSetRejectsAnotherDescriptor() {
+    var expected =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var otherState =
+        state(1, new RecordId(7, 10), null, null, 0, IndexLifecycle.MAINTAINED,
+            IndexBuildFailure.NONE);
+    var replacement = new IndexLifecycleSnapshot(otherState, 2);
+    var cell = new IndexLifecycleCell(expected);
+
+    var failure = assertThrows(
+        IllegalArgumentException.class, () -> cell.compareAndSet(expected, replacement));
+    assertEquals("The lifecycle snapshot belongs to another descriptor", failure.getMessage());
+    assertSame(expected, cell.snapshot());
+  }
+
   /** A retired cell rejects compare-and-set publication. */
   @Test
   public void compareAndSetRejectsRetiredCell() {
@@ -148,6 +180,20 @@ public class IndexBuildStateTest {
         IllegalStateException.class, () -> cell.compareAndSet(expected, replacement));
     assertEquals(
         "The lifecycle cell belongs to a retired storage lineage", failure.getMessage());
+  }
+
+  /** Recovery cannot replace a newer snapshot with an older durable revision. */
+  @Test
+  public void recoveryKeepsNewerPublishedSnapshot() {
+    var newer =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.MAINTAINED, IndexBuildFailure.NONE), 2);
+    var older =
+        new IndexLifecycleSnapshot(state(IndexLifecycle.EXISTS, IndexBuildFailure.NONE), 1);
+    var cell = new IndexLifecycleCell(newer);
+
+    cell.recover(older);
+
+    assertSame(newer, cell.snapshot());
   }
 
   /** A snapshot rejects a negative durable record version. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistryTest.java
@@ -1,0 +1,105 @@
+package com.jetbrains.youtrackdb.internal.core.index.lifecycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/** Covers registry fencing against the current storage lineage. */
+public class IndexLifecycleRegistryTest {
+
+  /** Every lookup drops a cell created under a stale lineage. */
+  @Test
+  public void lookupDropsStaleCellAfterLineageRotation() {
+    var lineage = new AtomicReference<>(StorageLineageIdentity.random());
+    var registry = new IndexLifecycleRegistry(lineage::get);
+    var descriptor = new RecordId(7, 9);
+    var first = registry.getOrCreate(descriptor, snapshot(descriptor));
+
+    assertSame(first, registry.get(descriptor));
+    lineage.set(StorageLineageIdentity.random());
+    assertNull(registry.get(descriptor));
+    assertThrows(IllegalStateException.class, first::get);
+
+    var replacement = registry.getOrCreate(descriptor, snapshot(descriptor));
+    assertNotSame(first, replacement);
+  }
+
+  /** Restore cleanup removes every cell carrying an outdated lineage. */
+  @Test
+  public void dropStaleRemovesCellsAfterLineageRotation() {
+    var lineage = new AtomicReference<>(StorageLineageIdentity.random());
+    var registry = new IndexLifecycleRegistry(lineage::get);
+    var descriptor = new RecordId(7, 9);
+    var stale = registry.getOrCreate(descriptor, snapshot(descriptor));
+
+    lineage.set(StorageLineageIdentity.random());
+    registry.dropStale();
+
+    assertNull(registry.get(descriptor));
+    assertThrows(IllegalStateException.class, stale::snapshot);
+  }
+
+  /** Registration retries when lineage rotates between creation and publication. */
+  @Test
+  public void registrationRetriesAfterLineageRotatesDuringPublication() {
+    var firstLineage = StorageLineageIdentity.random();
+    var currentLineage = StorageLineageIdentity.random();
+    var lineageReads = new AtomicInteger();
+    var registry = new IndexLifecycleRegistry(
+        () -> lineageReads.getAndIncrement() == 0 ? firstLineage : currentLineage);
+    var descriptor = new RecordId(7, 9);
+    var initial = snapshot(descriptor);
+
+    var cell = registry.getOrCreate(descriptor, initial);
+
+    assertEquals(4, lineageReads.get());
+    assertSame(initial, cell.snapshot());
+    assertSame(cell, registry.get(descriptor));
+  }
+
+  /** Stale cleanup retains the holder belonging to the current lineage. */
+  @Test
+  public void dropStaleKeepsCurrentLineageCell() {
+    var lineage = new AtomicReference<>(StorageLineageIdentity.random());
+    var registry = new IndexLifecycleRegistry(lineage::get);
+    var descriptor = new RecordId(7, 9);
+    var current = registry.getOrCreate(descriptor, snapshot(descriptor));
+
+    registry.dropStale();
+
+    assertSame(current, registry.get(descriptor));
+    assertSame(IndexLifecycle.EXISTS, current.get());
+  }
+
+  /** A stale registration request cannot replace the holder serving the current lineage. */
+  @Test
+  public void staleRegistrationRequestKeepsCurrentLineageHolder() {
+    var lineage = new AtomicReference<>(StorageLineageIdentity.random());
+    var registry = new IndexLifecycleRegistry(lineage::get);
+    var descriptor = new RecordId(7, 9);
+    var staleRequest = snapshot(descriptor);
+    var previous = registry.getOrCreate(descriptor, staleRequest);
+
+    lineage.set(StorageLineageIdentity.random());
+    var currentRequest = snapshot(descriptor);
+    var current = registry.getOrCreate(descriptor, currentRequest);
+    var staleCallerResult = registry.getOrCreate(descriptor, staleRequest);
+
+    assertSame(current, staleCallerResult);
+    assertSame(current, registry.get(descriptor));
+    assertSame(currentRequest, current.snapshot());
+    assertThrows(IllegalStateException.class, previous::get);
+  }
+
+  private static IndexLifecycleSnapshot snapshot(RecordId descriptor) {
+    return new IndexLifecycleSnapshot(IndexBuildState.initial(descriptor), 0);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/lifecycle/IndexLifecycleRegistryTest.java
@@ -65,6 +65,41 @@ public class IndexLifecycleRegistryTest {
     assertSame(cell, registry.get(descriptor));
   }
 
+  /** Recovery retries when the storage lineage rotates during publication. */
+  @Test
+  public void recoveryRetriesAfterLineageRotatesDuringPublication() {
+    var firstLineage = StorageLineageIdentity.random();
+    var currentLineage = StorageLineageIdentity.random();
+    var lineageReads = new AtomicInteger();
+    var registry = new IndexLifecycleRegistry(
+        () -> lineageReads.getAndIncrement() == 0 ? firstLineage : currentLineage);
+    var descriptor = new RecordId(7, 9);
+    var recovered = snapshot(descriptor);
+
+    var cell = registry.recover(descriptor, recovered);
+
+    assertEquals(4, lineageReads.get());
+    assertSame(recovered, cell.snapshot());
+    assertSame(cell, registry.get(descriptor));
+  }
+
+  /** Recovery keeps a current-lineage cell and rejects its stale snapshot. */
+  @Test
+  public void recoveryPreservesCurrentLineageCellAndNewerPublication() {
+    var lineage = new AtomicReference<>(StorageLineageIdentity.random());
+    var registry = new IndexLifecycleRegistry(lineage::get);
+    var descriptor = new RecordId(7, 9);
+    var older = snapshot(descriptor, 1);
+    var newer = snapshot(descriptor, 2);
+    var current = registry.getOrCreate(descriptor, newer);
+
+    var recovered = registry.recover(descriptor, older);
+
+    assertSame(current, recovered);
+    assertSame(current, registry.get(descriptor));
+    assertSame(newer, recovered.snapshot());
+  }
+
   /** Stale cleanup retains the holder belonging to the current lineage. */
   @Test
   public void dropStaleKeepsCurrentLineageCell() {
@@ -100,6 +135,10 @@ public class IndexLifecycleRegistryTest {
   }
 
   private static IndexLifecycleSnapshot snapshot(RecordId descriptor) {
-    return new IndexLifecycleSnapshot(IndexBuildState.initial(descriptor), 0);
+    return snapshot(descriptor, 0);
+  }
+
+  private static IndexLifecycleSnapshot snapshot(RecordId descriptor, int recordVersion) {
+    return new IndexLifecycleSnapshot(IndexBuildState.initial(descriptor), recordVersion);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
@@ -1,6 +1,10 @@
 package com.jetbrains.youtrackdb.internal.core.metadata.security;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.exception.SecurityException;
+import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
+import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +25,52 @@ public class SecuritySharedTest extends DbTestBase {
     if (session != null && !session.isClosed() && session.isTxActive()) {
       session.rollback();
     }
+  }
+
+  /** The default writer cannot update a durable index lifecycle record. */
+  @Test
+  public void defaultWriterCannotWriteIndexBuildStateCollection() {
+    var lifecycleIdentity = lifecycleIdentity();
+    createLifecycleWriter();
+
+    session.close();
+    session = openDatabase("lifecycleWriter", "password");
+    session.begin();
+    var record = (RecordAbstract) session.loadBlob(lifecycleIdentity);
+    record.setDirty();
+
+    Assert.assertThrows(SecurityException.class, session::commit);
+    session.rollback();
+  }
+
+  /** The default writer cannot drop the index build state collection by name. */
+  @Test
+  public void defaultWriterCannotDropIndexBuildStateCollection() {
+    createLifecycleWriter();
+
+    session.close();
+    session = openDatabase("lifecycleWriter", "password");
+
+    Assert.assertThrows(
+        SecurityException.class,
+        () -> session.dropCollection(
+            MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME.toUpperCase(java.util.Locale.ROOT)));
+    Assert.assertTrue(
+        session.existsCollection(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME));
+  }
+
+  private com.jetbrains.youtrackdb.internal.core.db.record.record.RID lifecycleIdentity() {
+    var index = session.getSharedContext().getIndexManager().getIndex("OUser.name");
+    return session.computeInTx(
+        transaction -> transaction.loadEntity(index.getIdentity()).getLink(Index.LIFECYCLE_RECORD));
+  }
+
+  private void createLifecycleWriter() {
+    var security = session.getSharedContext().getSecurity();
+    session.begin();
+    var writerRole = security.getRole(session, "writer");
+    security.createUser(session, "lifecycleWriter", "password", new Role[] {writerRole});
+    session.commit();
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/ScheduledEventTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/ScheduledEventTest.java
@@ -33,7 +33,10 @@ import static org.junit.Assert.fail;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.tool.DatabaseExportException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.metadata.function.Function;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.schedule.Scheduler.STATUS;
@@ -481,6 +484,45 @@ public class ScheduledEventTest extends DbTestBase {
   }
 
   // ---------------------------------------------------------------------------
+  // Completion logging summaries
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void completionMessageIncludesDetachedScalarFields() {
+    assertEquals(
+        "Scheduled event 'event' executionId=7 completed with result: java.lang.String",
+        ScheduledEvent.completionMessage("event", 7, "java.lang.String"));
+  }
+
+  @Test
+  public void resultSummaryUsesNullPlaceholder() {
+    assertEquals("<null>", ScheduledEvent.summarizeResult(null));
+  }
+
+  @Test
+  public void resultSummaryUsesPlainObjectClassName() {
+    assertEquals(
+        Object.class.getName(), ScheduledEvent.summarizeResult(new Object()));
+  }
+
+  @Test
+  public void resultSummaryUsesIdentifiableClassAndIdentity() {
+    var identifiable = new SummaryIdentifiable(new RecordId(3, 9));
+
+    assertEquals(
+        SummaryIdentifiable.class.getName() + " rid=#3:9",
+        ScheduledEvent.summarizeResult(identifiable));
+  }
+
+  @Test
+  public void resultSummaryUsesUnavailablePlaceholderWhenIdentityReadFails() {
+    var identifiable = new SummaryIdentifiable(null);
+
+    assertEquals(
+        "<unavailable>", ScheduledEvent.summarizeResult(identifiable));
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
@@ -494,5 +536,27 @@ public class ScheduledEventTest extends DbTestBase {
   private ScheduledEvent buildEvent(String name, String rule, Function function,
       Map<Object, Object> args) {
     return SchedulerTestFixtures.buildEvent(session, name, rule, function, args);
+  }
+
+  private static final class SummaryIdentifiable implements Identifiable {
+
+    private final RID identity;
+
+    private SummaryIdentifiable(RID identity) {
+      this.identity = identity;
+    }
+
+    @Override
+    public RID getIdentity() {
+      if (identity == null) {
+        throw new IllegalStateException("identity unavailable");
+      }
+      return identity;
+    }
+
+    @Override
+    public int compareTo(Identifiable other) {
+      return identity.compareTo(other.getIdentity());
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerImplTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerImplTest.java
@@ -39,12 +39,17 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -369,6 +374,44 @@ public class SchedulerImplTest extends DbTestBase {
         first, firstRegistered);
     assertNotSame("dual-instance: builder-returned 'second' must differ from registered",
         second, secondRegistered);
+  }
+
+  @Test
+  public void updatedEventMessageIncludesDetachedNameAndIdentity() {
+    var function = SchedulerTestFixtures.createTrivialFunction(session, "fnUpdateMessage");
+    var event = buildEvent("evt-update-message", FAR_FUTURE_RULE, function, Map.of());
+
+    assertEquals(
+        "Updated scheduled event 'evt-update-message' rid=" + event.getIdentity() + "...",
+        SchedulerImpl.updatedEventMessage(event));
+  }
+
+  /** The update call site emits exactly the detached message built for the updated event. */
+  @Test
+  public void updateEventLogsDetachedMessage() {
+    var function = SchedulerTestFixtures.createTrivialFunction(session, "fnUpdateLog");
+    var event = buildEvent("evt-update-log", FAR_FUTURE_RULE, function, Map.of());
+    var impl = session.getSharedContext().getScheduler();
+    var logger = Logger.getLogger(SchedulerImpl.class.getName());
+    var previousLevel = logger.getLevel();
+    var handler = new CapturingHandler();
+    handler.setLevel(Level.ALL);
+    logger.addHandler(handler);
+    logger.setLevel(Level.ALL);
+    try {
+      impl.updateEvent(session, event);
+    } finally {
+      logger.removeHandler(handler);
+      logger.setLevel(previousLevel);
+    }
+
+    var messages =
+        handler.records.stream()
+            .map(LogRecord::getMessage)
+            .filter(message -> message.startsWith("Updated scheduled event"))
+            .toList();
+    assertEquals(1, messages.size());
+    assertEquals(SchedulerImpl.updatedEventMessage(event), messages.getFirst());
   }
 
   @Test
@@ -1092,6 +1135,24 @@ public class SchedulerImplTest extends DbTestBase {
   private ScheduledEvent buildEvent(String name, String rule, Function function,
       Map<Object, Object> args) {
     return SchedulerTestFixtures.buildEvent(session, name, rule, function, args);
+  }
+
+  private static final class CapturingHandler extends Handler {
+
+    private final CopyOnWriteArrayList<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
   }
 
   private static ScheduledFuture<?> readTimerField(ScheduledEvent event) throws Exception {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/schedule/SchedulerTest.java
@@ -7,6 +7,7 @@ import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
 import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.concur.NeedRetryException;
@@ -15,11 +16,17 @@ import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseThreadLocalFactory;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.metadata.function.Function;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import io.netty.util.internal.ThreadLocalRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.apache.commons.configuration2.BaseConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,6 +39,8 @@ import org.junit.experimental.categories.Category;
 public class SchedulerTest {
 
   private static final String NEW_ADMIN_PASSWORD = "adminpwd";
+  private static final String FORMATTING_WARNING =
+      "Scheduled result was formatted after transaction completion";
 
   @Test
   public void scheduleSQLFunction() throws Exception {
@@ -46,6 +55,63 @@ public class SchedulerTest {
             var count = getLogCounter(db);
             Assert.assertTrue(count >= 2 && count <= 3);
           });
+    }
+  }
+
+  /** Full logging must not format a scheduled function result after its transaction ends. */
+  @Test
+  public void scheduledResultIsNotFormattedAfterTransactionCompletion() throws Exception {
+    var enginesManager = YouTrackDBEnginesManager.instance();
+    var previousFactory = enginesManager.getDatabaseThreadFactory();
+    try (var logs = CapturedLogs.install();
+        var context = createContext()) {
+      var db = context.cachedPool("test", "admin", NEW_ADMIN_PASSWORD).acquire();
+      runWithEventCleanup(
+          context,
+          "safe-result",
+          () -> {
+            var result = new WarnWhenFormatted();
+            createResultEvent(db, "safe-result", "safeResultFunction", result);
+
+            DbTestBase.assertWithTimeout(
+                db,
+                () -> assertThat(logs.completionRecords("safe-result"))
+                    .anyMatch(
+                        record -> record.getMessage().contains(WarnWhenFormatted.class.getName())));
+            assertThat(logs.warningRecords(FORMATTING_WARNING)).isEmpty();
+          });
+    } finally {
+      enginesManager.registerThreadDatabaseFactory(previousFactory);
+    }
+  }
+
+  /** The safe completion message retains the scheduled event name and execution identifier. */
+  @Test
+  public void completionLogRetainsEventNameAndExecutionIdentifier() throws Exception {
+    var enginesManager = YouTrackDBEnginesManager.instance();
+    var previousFactory = enginesManager.getDatabaseThreadFactory();
+    try (var logs = CapturedLogs.install();
+        var context = createContext()) {
+      var db = context.cachedPool("test", "admin", NEW_ADMIN_PASSWORD).acquire();
+      runWithEventCleanup(
+          context,
+          "useful-completion",
+          () -> {
+            createResultEvent(db, "useful-completion", "usefulCompletionFunction", "done");
+
+            DbTestBase.assertWithTimeout(
+                db,
+                () -> assertThat(logs.completionRecords("useful-completion"))
+                    .anyMatch(record -> record.getMessage().contains("executionId=1")));
+            assertThat(logs.completionRecords("useful-completion"))
+                .anyMatch(
+                    record -> record
+                        .getMessage()
+                        .contains(
+                            "Scheduled event 'useful-completion' executionId=1 completed with result:"));
+          });
+    } finally {
+      enginesManager.registerThreadDatabaseFactory(previousFactory);
     }
   }
 
@@ -253,6 +319,87 @@ public class SchedulerTest {
     });
   }
 
+  private static void runWithEventCleanup(
+      YouTrackDBImpl context, String eventName, TestBody body) throws Exception {
+    Throwable bodyFailure = null;
+    try {
+      body.run();
+    } catch (Exception | Error failure) {
+      bodyFailure = failure;
+      throw failure;
+    } finally {
+      try {
+        removeEventInFreshSession(context, eventName);
+      } catch (RuntimeException | Error cleanupFailure) {
+        if (bodyFailure == null) {
+          throw cleanupFailure;
+        }
+        bodyFailure.addSuppressed(cleanupFailure);
+      }
+    }
+  }
+
+  private static void removeEventInFreshSession(YouTrackDBImpl context, String eventName) {
+    try {
+      removeReloadedEvent(context, eventName);
+    } catch (ConcurrentModificationException versionConflict) {
+      // The timer can advance the stored version between reload and deletion. Retry once with
+      // another reload. A second conflict and every other failure still fail the test.
+      removeReloadedEvent(context, eventName);
+    }
+  }
+
+  private static void removeReloadedEvent(YouTrackDBImpl context, String eventName) {
+    try (var cleanupDb = context.open("test", "admin", NEW_ADMIN_PASSWORD)) {
+      var reloadedEvent =
+          cleanupDb.computeInTx(
+              transaction -> {
+                try (var result =
+                    transaction.query(
+                        "select from " + ScheduledEvent.CLASS_NAME + " where name = ?",
+                        eventName)) {
+                  var eventEntity =
+                      (EntityImpl) result.stream().findFirst().orElseThrow().asEntity();
+                  return new ScheduledEvent(eventEntity, cleanupDb);
+                }
+              });
+      cleanupDb.getSharedContext().getScheduler().removeEventInternal(eventName);
+      cleanupDb.executeInTx(transaction -> reloadedEvent.delete(cleanupDb));
+    }
+  }
+
+  @FunctionalInterface
+  private interface TestBody {
+
+    void run() throws Exception;
+  }
+
+  private static void createResultEvent(
+      DatabaseSessionEmbedded db, String eventName, String functionName, Object result) {
+    var function =
+        db.computeInTx(
+            transaction -> {
+              var created = db.getMetadata().getFunctionLibrary().createFunction(functionName);
+              created.setLanguage("SQL");
+              created.setCode("select 1");
+              created.setParameters(List.of());
+              created.save(db);
+              return created;
+            });
+    db.executeInTx(
+        transaction -> new ScheduledEventBuilder()
+            .setName(eventName)
+            .setRule("0/1 * * * * ?")
+            .setFunction(function)
+            .setArguments(Map.of())
+            .build(db));
+    db.getMetadata()
+        .getScheduler()
+        .getEvent(eventName)
+        .getFunction()
+        .setCallback(arguments -> result);
+  }
+
   private static Function createFunction(DatabaseSessionEmbedded db) {
     db.getMetadata().getSchema().createClass("scheduler_log");
 
@@ -278,6 +425,76 @@ public class SchedulerTest {
       resultSet.close();
       return count;
     });
+  }
+
+  private static final class WarnWhenFormatted {
+
+    @Override
+    public String toString() {
+      Logger.getLogger(WarnWhenFormatted.class.getName()).warning(FORMATTING_WARNING);
+      return "unsafe-result";
+    }
+  }
+
+  private static final class CapturedLogs implements AutoCloseable {
+
+    private final Logger rootLogger;
+    private final Level previousLevel;
+    private final CapturingHandler handler;
+
+    private CapturedLogs(Logger rootLogger, Level previousLevel, CapturingHandler handler) {
+      this.rootLogger = rootLogger;
+      this.previousLevel = previousLevel;
+      this.handler = handler;
+    }
+
+    private static CapturedLogs install() {
+      var rootLogger = Logger.getLogger("");
+      var handler = new CapturingHandler();
+      handler.setLevel(Level.ALL);
+      var previousLevel = rootLogger.getLevel();
+      rootLogger.addHandler(handler);
+      rootLogger.setLevel(Level.ALL);
+      return new CapturedLogs(rootLogger, previousLevel, handler);
+    }
+
+    private List<LogRecord> completionRecords(String eventName) {
+      return handler.records.stream()
+          .filter(record -> record.getMessage().contains("Scheduled event '" + eventName + "'"))
+          .filter(record -> record.getMessage().contains("completed with result:"))
+          .toList();
+    }
+
+    private List<LogRecord> warningRecords(String marker) {
+      return handler.records.stream()
+          .filter(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+          .filter(record -> record.getMessage().contains(marker))
+          .toList();
+    }
+
+    @Override
+    public void close() {
+      rootLogger.removeHandler(handler);
+      rootLogger.setLevel(previousLevel);
+    }
+  }
+
+  private static final class CapturingHandler extends Handler {
+
+    private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
   }
 
   private static class TestScheduleDatabaseFactory implements DatabaseThreadLocalFactory {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/AnalyzeIndexStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/AnalyzeIndexStatementExecutionTest.java
@@ -235,9 +235,8 @@ public class AnalyzeIndexStatementExecutionTest extends DbTestBase {
     // Get the histogram manager via reflection to simulate a background
     // rebalance in progress
     var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-    var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-    indexIdField.setAccessible(true);
-    int indexId = indexIdField.getInt(idx);
+    int indexId =
+        com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport.externalIdentifier(idx);
     var storageField = IndexAbstract.class.getDeclaredField("storage");
     storageField.setAccessible(true);
     var storage = storageField.get(idx);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
@@ -12,7 +12,8 @@ import com.jetbrains.youtrackdb.api.YourTracks;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
-import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildState;
 import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.BootstrapMetadataTestSupport;
@@ -98,38 +99,65 @@ public class DiskStorageBootstrapWiringTest {
     }
   }
 
-  /** A real restore rotates lineage and removes every registered stale lifecycle holder. */
+  /** Restore adopts stored progress without rewriting the lifecycle record. */
   @Test
-  public void restoreRotatesLineageAndDropsStaleLifecycleHolders() throws Exception {
+  public void restoreAdoptsProgressWithoutLifecycleRewrite() throws Exception {
     var backupDirectory = Files.createDirectory(directory.resolve("backup"));
     try (var youTrackDB = createDatabase();
         var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
       var storage = (AbstractStorage) session.getStorage();
-      var firstDescriptor = new RecordId(42, 1);
-      var secondDescriptor = new RecordId(42, 2);
-      var firstHolder = storage.getOrCreateIndexLifecycle(firstDescriptor);
-      var secondHolder = storage.getOrCreateIndexLifecycle(secondDescriptor);
-      assertEquals(IndexLifecycle.EXISTS, firstHolder.get());
-      assertEquals(IndexLifecycle.EXISTS, secondHolder.get());
+      var manager = session.getSharedContext().getIndexManager();
+      var index = manager.getIndex("OUser.name");
+      var lifecycle =
+          session.computeInTx(
+              tx -> tx.loadEntity(index.getIdentity()).getLink(Index.LIFECYCLE_RECORD));
+      var store = storage.getIndexBuildStateStore();
+      var initial = store.read(index.getIdentity(), lifecycle);
+      var state = initial.buildState();
+      var backedUpState = lifecycleState(state, 31, 77L);
+      var backedUp = store.publish(index.getIdentity(), lifecycle, initial, backedUpState);
+      var firstHolder = storage.getIndexLifecycle(index.getIdentity());
 
       var storageIdentity = storage.getStorageIdentity();
       var lineageIdentity = storage.getStorageLineageIdentity();
       storage.backup(backupDirectory);
+      store.publish(
+          index.getIdentity(), lifecycle, backedUp, lifecycleState(backedUpState, 99, null));
       storage.restoreFromBackup(backupDirectory, null);
+      manager.reload(session);
 
       assertEquals(storageIdentity, storage.getStorageIdentity());
       assertNotEquals(lineageIdentity, storage.getStorageLineageIdentity());
       assertThrows(IllegalStateException.class, firstHolder::get);
-      assertThrows(IllegalStateException.class, secondHolder::get);
-      var currentFirstHolder = storage.getOrCreateIndexLifecycle(firstDescriptor);
-      var currentSecondHolder = storage.getOrCreateIndexLifecycle(secondDescriptor);
-      assertNotSame(firstHolder, currentFirstHolder);
-      assertNotSame(secondHolder, currentSecondHolder);
-      assertEquals(IndexLifecycle.EXISTS, currentFirstHolder.get());
-      assertEquals(IndexLifecycle.EXISTS, currentSecondHolder.get());
-      assertEquals(storage.getStorageLineageIdentity(), authority().readActiveRequired()
-          .lineageIdentity());
+      var restoredIndex = manager.getIndex("OUser.name");
+      var restored = storage.getIndexLifecycle(restoredIndex.getIdentity()).snapshot();
+      assertNotSame(firstHolder, storage.getIndexLifecycle(restoredIndex.getIdentity()));
+      assertEquals(IndexLifecycle.EXISTS, restored.lifecycle());
+      assertEquals(31, restored.buildState().completedUnits());
+      assertEquals(null, restored.buildState().ownerEpoch());
+      var durable = store.read(restoredIndex.getIdentity(), lifecycle);
+      assertEquals(31, durable.buildState().completedUnits());
+      assertEquals(Long.valueOf(77), durable.buildState().ownerEpoch());
+      assertEquals(backedUp.recordVersion(), durable.recordVersion());
+      assertEquals(
+          storage.getStorageLineageIdentity(),
+          authority().readActiveRequired().lineageIdentity());
     }
+  }
+
+  private static IndexBuildState lifecycleState(
+      IndexBuildState state, long completedUnits, Long ownerEpoch) {
+    return new IndexBuildState(
+        state.formatVersion(),
+        state.descriptorIdentity(),
+        state.lifecycle(),
+        state.buildIncarnation(),
+        ownerEpoch,
+        state.completionCut(),
+        completedUnits,
+        state.suspended(),
+        state.failure(),
+        state.failureMessage());
   }
 
   /** Activation wraps an authority read failure with the creation context. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
@@ -72,16 +72,26 @@ public class DiskStorageBootstrapWiringTest {
     }
   }
 
-  /** Open rejects a disk storage whose authority files are absent. */
+  /**
+   * Open reports the missing-record reason for a directory without any bootstrap artifact.
+   *
+   * <p>The scenario removes every authority copy and also removes the authority lock file, so the
+   * directory holds content files only. The expected outcome is one open failure whose cause names
+   * the missing-record reason. The scenario keeps the lock file out on purpose, because a
+   * remaining lock file would turn the directory into birth residue.
+   */
   @Test
   public void openRejectsAbsentAuthority() throws Exception {
     try (var ignored = createDatabase()) {
       // Closing the manager leaves a complete disk image for the open attempt.
     }
     deleteAuthorityFiles();
+    Files.delete(directory.resolve(DATABASE).resolve("storage-bootstrap.bsml"));
 
     try (var youTrackDB = openManager()) {
-      assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+      var failure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+      assertTrue(hasCauseMessage(failure, "AUTHORITY_MISSING"));
     }
   }
 
@@ -96,6 +106,44 @@ public class DiskStorageBootstrapWiringTest {
 
     try (var youTrackDB = openManager()) {
       assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+    }
+  }
+
+  /**
+   * Open reports the named interrupted-birth reason for a directory with lock-file residue.
+   *
+   * <p>The scenario keeps only the authority lock file of a complete image. The expected outcome is
+   * a storage failure whose message names the interrupted-birth admission reason.
+   */
+  @Test
+  public void openReportsInterruptedBirthForLockFileResidue() throws Exception {
+    try (var ignored = createDatabase()) {
+      // Closing the manager leaves a complete disk image for the residue construction.
+    }
+    deleteAuthorityFiles();
+    assertTrue(Files.exists(directory.resolve(DATABASE).resolve("storage-bootstrap.bsml")));
+
+    try (var youTrackDB = openManager()) {
+      var failure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+      assertTrue(hasCauseMessage(failure, "INTERRUPTED_BIRTH"));
+    }
+  }
+
+  /**
+   * The directory scanner lists a database directory that holds only birth residue.
+   *
+   * <p>The scenario creates a directory with the authority lock file alone. The expected outcome is
+   * one listing entry, so the listing agrees with the existence probe.
+   */
+  @Test
+  public void directoryScannerListsBirthResidueDirectory() throws Exception {
+    var residueDirectory = Files.createDirectory(directory.resolve("residueOnly"));
+    Files.createFile(residueDirectory.resolve("storage-bootstrap.bsml"));
+
+    try (var youTrackDB = openManager()) {
+      assertTrue(youTrackDB.listDatabases().contains("residueOnly"));
+      assertTrue(youTrackDB.exists("residueOnly"));
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageBootstrapWiringTest.java
@@ -1,0 +1,246 @@
+package com.jetbrains.youtrackdb.internal.core.storage.disk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexLifecycle;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.BootstrapMetadataTestSupport;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Covers disk storage bootstrap creation and open wiring. */
+public class DiskStorageBootstrapWiringTest {
+
+  private static final String DATABASE = "bootstrapWiring";
+  private static final String ADMIN = "admin";
+
+  private Path directory;
+
+  @Before
+  public void createDirectory() throws Exception {
+    directory = Files.createTempDirectory("disk-bootstrap-wiring-");
+  }
+
+  @After
+  public void deleteDirectory() {
+    FileUtils.deleteRecursively(directory.toFile());
+  }
+
+  /** Creation publishes active format one and open reloads the same identities. */
+  @Test
+  public void creationPublishesActiveAuthorityAndOpenReloadsIdentity() throws Exception {
+    StorageIdentity storageIdentity;
+    StorageLineageIdentity lineageIdentity;
+    try (var youTrackDB = createDatabase()) {
+      try (var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+        var storage = (AbstractStorage) session.getStorage();
+        storageIdentity = storage.getStorageIdentity();
+        lineageIdentity = storage.getStorageLineageIdentity();
+      }
+    }
+
+    var authority = authority();
+    var active = authority.readActiveRequired();
+    assertEquals(1, active.format().version());
+    assertEquals(storageIdentity, active.storageIdentity());
+    assertEquals(lineageIdentity, active.lineageIdentity());
+
+    try (var youTrackDB = openManager();
+        var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+      var storage = (AbstractStorage) session.getStorage();
+      assertEquals(storageIdentity, storage.getStorageIdentity());
+      assertEquals(lineageIdentity, storage.getStorageLineageIdentity());
+    }
+  }
+
+  /** Open rejects a disk storage whose authority files are absent. */
+  @Test
+  public void openRejectsAbsentAuthority() throws Exception {
+    try (var ignored = createDatabase()) {
+      // Closing the manager leaves a complete disk image for the open attempt.
+    }
+    deleteAuthorityFiles();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+    }
+  }
+
+  /** Open rejects a disk storage carrying an interrupted birth record. */
+  @Test
+  public void openRejectsInterruptedBirth() throws Exception {
+    try (var ignored = createDatabase()) {
+      // Closing the manager leaves a complete disk image for authority replacement.
+    }
+    deleteAuthorityFiles();
+    authority().createBirth(StorageIdentity.random(), StorageLineageIdentity.random());
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+    }
+  }
+
+  /** A real restore rotates lineage and removes every registered stale lifecycle holder. */
+  @Test
+  public void restoreRotatesLineageAndDropsStaleLifecycleHolders() throws Exception {
+    var backupDirectory = Files.createDirectory(directory.resolve("backup"));
+    try (var youTrackDB = createDatabase();
+        var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+      var storage = (AbstractStorage) session.getStorage();
+      var firstDescriptor = new RecordId(42, 1);
+      var secondDescriptor = new RecordId(42, 2);
+      var firstHolder = storage.getOrCreateIndexLifecycle(firstDescriptor);
+      var secondHolder = storage.getOrCreateIndexLifecycle(secondDescriptor);
+      assertEquals(IndexLifecycle.EXISTS, firstHolder.get());
+      assertEquals(IndexLifecycle.EXISTS, secondHolder.get());
+
+      var storageIdentity = storage.getStorageIdentity();
+      var lineageIdentity = storage.getStorageLineageIdentity();
+      storage.backup(backupDirectory);
+      storage.restoreFromBackup(backupDirectory, null);
+
+      assertEquals(storageIdentity, storage.getStorageIdentity());
+      assertNotEquals(lineageIdentity, storage.getStorageLineageIdentity());
+      assertThrows(IllegalStateException.class, firstHolder::get);
+      assertThrows(IllegalStateException.class, secondHolder::get);
+      var currentFirstHolder = storage.getOrCreateIndexLifecycle(firstDescriptor);
+      var currentSecondHolder = storage.getOrCreateIndexLifecycle(secondDescriptor);
+      assertNotSame(firstHolder, currentFirstHolder);
+      assertNotSame(secondHolder, currentSecondHolder);
+      assertEquals(IndexLifecycle.EXISTS, currentFirstHolder.get());
+      assertEquals(IndexLifecycle.EXISTS, currentSecondHolder.get());
+      assertEquals(storage.getStorageLineageIdentity(), authority().readActiveRequired()
+          .lineageIdentity());
+    }
+  }
+
+  /** Activation wraps an authority read failure with the creation context. */
+  @Test
+  public void activationWrapsBootstrapAuthorityFailure() throws Exception {
+    try (var youTrackDB = createDatabase();
+        var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+      var storage = (DiskStorage) session.getStorage();
+      deleteAuthorityFiles();
+      var failure = assertThrows(
+          StorageException.class,
+          () -> storage.activateBootstrapSnapshot(
+              "Cannot activate the storage bootstrap birth"));
+
+      assertEquals(
+          "Cannot activate the storage bootstrap birth\r\n\tDB Name=\"bootstrapWiring\"",
+          failure.getMessage());
+    }
+  }
+
+  /** Restore publication wraps an authority read failure with the restore context. */
+  @Test
+  public void lineageReplacementWrapsBootstrapAuthorityFailure() throws Exception {
+    try (var youTrackDB = createDatabase();
+        var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+      var storage = (DiskStorage) session.getStorage();
+      deleteAuthorityFiles();
+      var failure = assertThrows(StorageException.class, storage::beginLineageReplacement);
+
+      assertEquals(
+          "Cannot publish the storage restore authority\r\n\tDB Name=\"bootstrapWiring\"",
+          failure.getMessage());
+    }
+  }
+
+  /** Drop removes bootstrap authority and permits creating the same database name again. */
+  @Test
+  public void dropThenCreateWithSameNameSucceeds() throws Exception {
+    try (var youTrackDB = createDatabase()) {
+      youTrackDB.drop(DATABASE);
+      assertFalse(Files.exists(directory.resolve(DATABASE)));
+
+      youTrackDB.create(DATABASE, DatabaseType.DISK, ADMIN, ADMIN, ADMIN);
+      try (var session = youTrackDB.open(DATABASE, ADMIN, ADMIN)) {
+        assertEquals(DATABASE, session.getDatabaseName());
+      }
+    }
+  }
+
+  /** Real creation reports a failed durable birth move and leaves no openable storage. */
+  @Test
+  public void failedBirthPublicationLeavesNoActiveAuthority() throws Exception {
+    var storageDirectory = directory.resolve(DATABASE);
+    try (var failedPublication = BootstrapMetadataTestSupport.failNextPublication();
+        var youTrackDB = openManager()) {
+      var failure = assertThrows(
+          RuntimeException.class,
+          () -> youTrackDB.create(DATABASE, DatabaseType.DISK, ADMIN, ADMIN, ADMIN));
+
+      assertTrue(hasCauseMessage(failure, "Cannot publish the storage bootstrap birth"));
+      assertTrue(hasCauseMessage(failure, "injected birth publication failure"));
+      assertTrue(failedPublication.candidateObserved().get());
+    }
+
+    assertFalse(hasActiveAuthorityFile(storageDirectory));
+    try (var youTrackDB = openManager()) {
+      assertThrows(RuntimeException.class, () -> youTrackDB.open(DATABASE, ADMIN, ADMIN));
+    }
+  }
+
+  private YouTrackDBImpl createDatabase() {
+    var youTrackDB = openManager();
+    youTrackDB.create(DATABASE, DatabaseType.DISK, ADMIN, ADMIN, ADMIN);
+    return youTrackDB;
+  }
+
+  private YouTrackDBImpl openManager() {
+    return (YouTrackDBImpl) YourTracks.instance(directory.toString());
+  }
+
+  private StorageBootstrapMetadata authority() throws Exception {
+    return new StorageBootstrapMetadata(
+        directory.resolve(DATABASE), new FeatureFormatIdentity(1));
+  }
+
+  private void deleteAuthorityFiles() throws Exception {
+    try (var paths = Files.list(directory.resolve(DATABASE))) {
+      for (var path : paths.filter(
+          candidate -> candidate.getFileName().toString().startsWith("storage-bootstrap-"))
+          .toList()) {
+        Files.delete(path);
+      }
+    }
+  }
+
+  private static boolean hasCauseMessage(Throwable failure, String expectedMessage) {
+    for (var current = failure; current != null; current = current.getCause()) {
+      if (current.getMessage() != null && current.getMessage().contains(expectedMessage)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasActiveAuthorityFile(Path storageDirectory) throws Exception {
+    if (!Files.exists(storageDirectory)) {
+      return false;
+    }
+    try (var paths = Files.list(storageDirectory)) {
+      return paths.anyMatch(path -> path.getFileName().toString().matches(
+          "storage-bootstrap-[0-2]\\.bsm"));
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageStaticHelpersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageStaticHelpersTest.java
@@ -2,9 +2,12 @@ package com.jetbrains.youtrackdb.internal.core.storage.disk;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.jetbrains.youtrackdb.internal.core.config.StorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -130,6 +133,42 @@ public class DiskStorageStaticHelpersTest {
     Files.createFile(testDir.resolve("somefile.txt"));
     Files.createFile(testDir.resolve("data.bin"));
     assertFalse(DiskStorage.exists(testDir));
+  }
+
+  /**
+   * Verifies that the existence probe recognizes one bootstrap authority copy.
+   *
+   * <p>The scenario creates the first authority copy alone. The expected outcome is an existing
+   * storage image, so an interrupted storage birth stays visible.
+   */
+  @Test
+  public void testExistsReturnsTrueWhenAuthorityCopyPresent() throws IOException {
+    Files.createFile(testDir.resolve("storage-bootstrap-0.bsm"));
+    assertTrue(DiskStorage.exists(testDir));
+  }
+
+  /**
+   * Verifies that the existence probe recognizes the authority lock file.
+   *
+   * <p>The scenario creates the authority lock file alone. The expected outcome is an existing
+   * storage image, because an interrupted storage birth can leave only that file.
+   */
+  @Test
+  public void testExistsReturnsTrueWhenAuthorityLockFilePresent() throws IOException {
+    Files.createFile(testDir.resolve("storage-bootstrap.bsml"));
+    assertTrue(DiskStorage.exists(testDir));
+  }
+
+  /**
+   * Verifies that the existence probe recognizes an unfinished record candidate.
+   *
+   * <p>The scenario creates one candidate file alone. The expected outcome is an existing storage
+   * image, because a candidate file is a bootstrap authority artifact.
+   */
+  @Test
+  public void testExistsReturnsTrueWhenRecordCandidatePresent() throws IOException {
+    Files.createFile(testDir.resolve("storage-bootstrap-2.bsm.tmp"));
+    assertTrue(DiskStorage.exists(testDir));
   }
 
   // -----------------------------------------------------------------------
@@ -403,5 +442,74 @@ public class DiskStorageStaticHelpersTest {
 
     // close — does not throw.
     xxOut.close();
+  }
+
+  /**
+   * The restore validation accepts the storage layout version of this build.
+   *
+   * <p>The storage layout version is the version of the on-disk storage layout. The scenario
+   * validates the supported storage layout version. The expected outcome is one call without any
+   * failure.
+   */
+  @Test
+  public void restoredStorageLayoutVersionOfThisBuildIsAccepted() {
+    DiskStorage.validateRestoredStorageLayoutVersion(
+        "acceptedLayout", StorageConfiguration.CURRENT_VERSION);
+  }
+
+  /**
+   * The restore validation refuses a restored storage layout version of another build.
+   *
+   * <p>The scenario validates the storage layout version of an older build. The expected outcome
+   * is one refusal that names both versions, names the database, and prescribes the drop of that
+   * database.
+   */
+  @Test
+  public void restoredStorageLayoutVersionOfAnotherBuildIsRefused() {
+    var refusal =
+        assertThrows(
+            StorageException.class,
+            () -> DiskStorage.validateRestoredStorageLayoutVersion(
+                "refusedLayout", StorageConfiguration.CURRENT_VERSION - 1));
+
+    assertTrue(
+        "the refusal must name the restored storage layout version, saw: " + refusal.getMessage(),
+        refusal.getMessage()
+            .contains("storage layout version " + (StorageConfiguration.CURRENT_VERSION - 1)));
+    assertTrue(
+        "the refusal must prescribe the drop of the named database, saw: " + refusal.getMessage(),
+        refusal.getMessage().contains("Drop database 'refusedLayout'"));
+  }
+
+  /**
+   * The restore validation accepts restored content with a set genesis marker.
+   *
+   * <p>The genesis marker is the durable property that records a finished genesis. Genesis is the
+   * creation of the initial database metadata. The scenario validates the set marker value. The
+   * expected outcome is one call without any failure.
+   */
+  @Test
+  public void restoredGenesisMarkerOfCompleteContentIsAccepted() {
+    DiskStorage.validateRestoredGenesisMarker("acceptedMarker", "true");
+  }
+
+  /**
+   * The restore validation refuses restored content without a set genesis marker.
+   *
+   * <p>The scenario validates an absent marker value and a cleared marker value. The expected
+   * outcome is one refusal per value, and each refusal names the missing marker.
+   */
+  @Test
+  public void restoredGenesisMarkerOfIncompleteContentIsRefused() {
+    for (var markerValue : new String[] {null, "false"}) {
+      var refusal =
+          assertThrows(
+              StorageException.class,
+              () -> DiskStorage.validateRestoredGenesisMarker("refusedMarker", markerValue));
+      assertTrue(
+          "the refusal must name the missing genesis completion marker, saw: "
+              + refusal.getMessage(),
+          refusal.getMessage().contains("no genesis completion marker"));
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -82,6 +82,33 @@ public class AbstractStorageCommitPrimitivesTest {
 
   // ---- Public-wrapper behavior preservation ----
 
+  /** A transaction-created engine receives a fresh generation when it reuses a dropped slot. */
+  @Test
+  public void reusedIndexEngineSlotReceivesNewGeneration() throws Exception {
+    var cls = db.createVertexClass("GenerationReuse");
+    cls.createProperty("name", PropertyType.STRING);
+    var firstName = "GenerationReuse.first";
+    cls.createIndex(firstName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var firstReference = findEngineByName(storage, firstName).getEngineReference();
+    assertThat(firstReference).isNotNull();
+
+    var indexManager = db.getSharedContext().getIndexManager();
+    db.executeInTx(tx -> indexManager.dropIndex(db, firstName));
+
+    var secondName = "GenerationReuse.second";
+    db.begin();
+    db.getMetadata().getSchema().getClass("GenerationReuse")
+        .createIndex(secondName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    db.commit();
+
+    var secondReference = findEngineByName(storage, secondName).getEngineReference();
+    assertThat(secondReference).isNotNull();
+    assertThat(secondReference.slot()).isEqualTo(firstReference.slot());
+    assertThat(secondReference.generation()).isGreaterThan(firstReference.generation());
+  }
+
   // The public addIndexEngine wrapper (now allocate-id + doAddIndexEngine + publish) must
   // still register the engine so that getIndexEngine resolves it by id and the registry
   // carries it by name. Creating a UNIQUE index drives addIndexEngine internally.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -152,12 +152,30 @@ public class AbstractStorageCommitPrimitivesTest {
     assertThat(secondReference).isNotNull();
     assertThat(secondReference.slot()).isEqualTo(firstReference.slot());
     assertThat(secondReference.generation()).isGreaterThan(firstReference.generation());
+    var engines = indexEngines(storage);
+    var registered = engines.get(secondReference.slot());
+    var unboundReplacement = new IndexEngineReference(
+        secondReference.slot(), secondReference.apiVersion(), secondReference.generation() + 1);
+    var unboundEngine = Mockito.mock(BaseIndexEngine.class);
+    Mockito.when(unboundEngine.getEngineReference()).thenReturn(unboundReplacement);
+    engines.set(secondReference.slot(), unboundEngine);
+    try {
+      assertThatThrownBy(() -> storage.attachIndexEngineOwner(
+          firstIndexId, firstIndex.getIdentity(), firstReference))
+          .as("an older carrier must not claim an unbound replacement generation")
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("reference changed");
+      assertThat(unboundReplacement.ownerDescriptorIdentity()).isNull();
+    } finally {
+      engines.set(secondReference.slot(), registered);
+    }
+
     var futureReference = new IndexEngineReference(
         secondReference.slot(), secondReference.apiVersion(), secondReference.generation() + 1);
     assertThatThrownBy(() -> storage.attachIndexEngineOwner(
         firstIndexId, firstIndex.getIdentity(), futureReference))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("non-monotonically");
+        .hasMessageContaining("reference changed");
   }
 
   // The public addIndexEngine wrapper (now allocate-id + doAddIndexEngine + publish) must
@@ -324,6 +342,50 @@ public class AbstractStorageCommitPrimitivesTest {
                 });
         assertThat(writerEntered.get(10, TimeUnit.SECONDS))
             .as("engine resolution must not release the commit's outer state read lock")
+            .isFalse();
+      }
+    } finally {
+      storage.stateLock.readLock().unlock();
+      db.rollback();
+    }
+  }
+
+  /** Owner recovery during a data write must not release the commit's outer state read lock. */
+  @Test(timeout = 30_000)
+  public void staleDataWriteRecoveryRetainsOuterStateReadLock() throws Exception {
+    db.activateOnCurrentThread();
+    var cls = db.createVertexClass("StaleDataWriteLock");
+    cls.createProperty("value", PropertyType.STRING);
+    cls.createIndex("StaleDataWriteLock_value", SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager()
+        .getIndex("StaleDataWriteLock_value");
+    db.begin();
+
+    storage.stateLock.readLock().lock();
+    try {
+      var snapshot = index.engineSnapshot();
+      var staleIdentifier =
+          snapshot.engineReference().apiVersion() << (Integer.SIZE - 5) | 0x7_FF_FF_FF;
+      IndexEngineTestSupport.setEngineIdentifier(index, staleIdentifier);
+      assertThatThrownBy(() -> index.doPut(
+          db, storage, "key", new RecordId(cls.getCollectionIds()[0], 42)))
+          .hasMessageContaining("Atomic operation is not committed yet");
+      assertThat(index.getIndexId()).isEqualTo(snapshot.engineIdentifier());
+      try (var executor = Executors.newSingleThreadExecutor()) {
+        var writerEntered = executor.submit(() -> {
+          if (!storage.stateLock.writeLock().tryLock()) {
+            return false;
+          }
+          try {
+            return true;
+          } finally {
+            storage.stateLock.writeLock().unlock();
+          }
+        });
+        assertThat(writerEntered.get(10, TimeUnit.SECONDS))
+            .as("owner recovery must retain the commit's outer state read lock")
             .isFalse();
       }
     } finally {
@@ -1039,7 +1101,7 @@ public class AbstractStorageCommitPrimitivesTest {
     assertThatThrownBy(() -> storage.attachIndexEngineOwner(
         snapshot.engineIdentifier(), owner, foreignSlot))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("non-monotonically");
+        .hasMessageContaining("reference changed");
 
     var engines = indexEngines(storage);
     var registered = engines.get(live.slot());

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -15,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -146,10 +147,12 @@ public class AbstractStorageCommitPrimitivesTest {
     assertThat(secondReference).isNotNull();
     assertThat(secondReference.slot()).isEqualTo(firstReference.slot());
     assertThat(secondReference.generation()).isGreaterThan(firstReference.generation());
-    assertThatThrownBy(() -> storage.bindIndexEngineToDescriptor(
-        firstIndexId, firstIndex.getIdentity(), firstReference))
+    var futureReference = new IndexEngineReference(
+        secondReference.slot(), secondReference.apiVersion(), secondReference.generation() + 1);
+    assertThatThrownBy(() -> storage.attachIndexEngineOwner(
+        firstIndexId, firstIndex.getIdentity(), futureReference))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("reference changed");
+        .hasMessageContaining("non-monotonically");
   }
 
   // The public addIndexEngine wrapper (now allocate-id + doAddIndexEngine + publish) must
@@ -777,7 +780,7 @@ public class AbstractStorageCommitPrimitivesTest {
     var engine = findEngineByName(storage, indexName);
 
     assertThat(engine.getId()).isGreaterThan(0);
-    assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+    assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()).engineIdentifier())
         .isEqualTo(externalIdOf(engine));
   }
 
@@ -798,7 +801,7 @@ public class AbstractStorageCommitPrimitivesTest {
 
     engines.set(original.getId(), replacement);
     try {
-      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()).engineIdentifier())
           .isEqualTo(externalIdOf(replacement));
     } finally {
       engines.set(original.getId(), original);
@@ -887,7 +890,7 @@ public class AbstractStorageCommitPrimitivesTest {
 
     engines.add(null);
     try {
-      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()).engineIdentifier())
           .isEqualTo(externalIdOf(engine));
     } finally {
       engines.remove(engines.size() - 1);
@@ -908,7 +911,7 @@ public class AbstractStorageCommitPrimitivesTest {
     var engines = indexEngines(storage);
     engines.add(Mockito.mock(BaseIndexEngine.class));
     try {
-      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()).engineIdentifier())
           .isEqualTo(externalIdOf(expectedEngine));
     } finally {
       engines.remove(engines.size() - 1);
@@ -966,7 +969,7 @@ public class AbstractStorageCommitPrimitivesTest {
 
     assertThat(engines.get(slot)).isSameAs(engine);
     assertThat(storage.loadIndexEngine(engineName)).isGreaterThanOrEqualTo(0);
-    assertThat(storage.resolveIndexEngineByOwner(unrelatedIndex.getIdentity()))
+    assertThat(storage.resolveIndexEngineByOwner(unrelatedIndex.getIdentity()).engineIdentifier())
         .isEqualTo(externalIdOf(unrelatedEngine));
   }
 
@@ -999,7 +1002,7 @@ public class AbstractStorageCommitPrimitivesTest {
     try {
       storage.enterCommitWindow();
       try {
-        assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+        assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()).engineIdentifier())
             .isEqualTo(externalIdOf(engine));
       } finally {
         storage.exitCommitWindow();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -13,6 +13,7 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
@@ -82,6 +83,39 @@ public class AbstractStorageCommitPrimitivesTest {
 
   // ---- Public-wrapper behavior preservation ----
 
+  /** Reading an attached identifier never nests or releases the caller's storage state read lock. */
+  @Test
+  public void indexIdentifierAccessorDoesNotTouchStorageStateLock() {
+    var cls = db.createVertexClass("PureIndexIdentifier");
+    cls.createProperty("name", PropertyType.STRING);
+    var indexName = "PureIndexIdentifier.name";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    var index = db.getSharedContext().getIndexManager().getIndex(indexName);
+    var storage = (AbstractStorage) db.getStorage();
+
+    storage.stateLock.readLock().lock();
+    try {
+      assertThat(index.getIndexId()).isGreaterThanOrEqualTo(0);
+      assertThat(storage.stateLock.isReadLockedByCurrentThread()).isTrue();
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+  }
+
+  /** Older engine constructors also allocate unique process-local generations through storage. */
+  @Test
+  public void olderEngineConstructorAllocatesUniqueGenerations() {
+    var storage = (AbstractStorage) db.getStorage();
+
+    var first = new BTreeSingleValueIndexEngine(7, 101, "legacy-first", storage, 4);
+    var second = new BTreeSingleValueIndexEngine(7, 102, "legacy-second", storage, 4);
+
+    assertThat(first.getEngineReference().slot()).isEqualTo(7);
+    assertThat(second.getEngineReference().slot()).isEqualTo(7);
+    assertThat(second.getEngineReference().generation())
+        .isGreaterThan(first.getEngineReference().generation());
+  }
+
   /** A transaction-created engine receives a fresh generation when it reuses a dropped slot. */
   @Test
   public void reusedIndexEngineSlotReceivesNewGeneration() throws Exception {
@@ -93,6 +127,8 @@ public class AbstractStorageCommitPrimitivesTest {
     var storage = (AbstractStorage) db.getStorage();
     var firstReference = findEngineByName(storage, firstName).getEngineReference();
     assertThat(firstReference).isNotNull();
+    var firstIndex = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(firstName);
+    var firstIndexId = firstIndex.getIndexId();
 
     var indexManager = db.getSharedContext().getIndexManager();
     db.executeInTx(tx -> indexManager.dropIndex(db, firstName));
@@ -107,6 +143,10 @@ public class AbstractStorageCommitPrimitivesTest {
     assertThat(secondReference).isNotNull();
     assertThat(secondReference.slot()).isEqualTo(firstReference.slot());
     assertThat(secondReference.generation()).isGreaterThan(firstReference.generation());
+    assertThatThrownBy(() -> storage.bindIndexEngineToDescriptor(
+        firstIndexId, firstIndex.getIdentity(), firstReference))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("reference changed");
   }
 
   // The public addIndexEngine wrapper (now allocate-id + doAddIndexEngine + publish) must

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -8,6 +8,8 @@ import com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
@@ -29,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * White-box tests for the lock-free commit-window primitives extracted out of the public
@@ -759,18 +762,219 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
+  /** The public resolver finds one owner in a non-zero slot and returns its packed identifier. */
+  @Test
+  public void ownerResolverReturnsPackedIdentifierForExactOwner() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionExact");
+    cls.createProperty("first", PropertyType.STRING);
+    cls.createProperty("second", PropertyType.STRING);
+    cls.createIndex("OwnerResolutionExact.first", SchemaClass.INDEX_TYPE.UNIQUE, "first");
+    var indexName = "OwnerResolutionExact.second";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "second");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engine = findEngineByName(storage, indexName);
+
+    assertThat(engine.getId()).isGreaterThan(0);
+    assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+        .isEqualTo(externalIdOf(engine));
+  }
+
+  /** A replacement object in the same slot remains resolvable after binding the same owner. */
+  @Test
+  public void ownerResolverFindsSameOwnerReplacementInSameSlot() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionReplacement");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionReplacement.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engines = indexEngines(storage);
+    var original = (BTreeSingleValueIndexEngine) findEngineByName(storage, indexName);
+    var replacement = replacementEngine(storage, original, "same-owner");
+    replacement.getEngineReference().bindOwner(index.getIdentity());
+
+    engines.set(original.getId(), replacement);
+    try {
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+          .isEqualTo(externalIdOf(replacement));
+    } finally {
+      engines.set(original.getId(), original);
+    }
+  }
+
+  /** A descriptor with no registered owner fails closed without poisoning the storage. */
+  @Test
+  public void ownerResolverRejectsMissingOwnerWithoutStoragePoisoning() {
+    var storage = (AbstractStorage) db.getStorage();
+    var missingOwner = new RecordId(91, 17);
+
+    assertThatThrownBy(() -> storage.resolveIndexEngineByOwner(missingOwner))
+        .isInstanceOf(StaleIndexEngineException.class)
+        .hasMessageContaining(missingOwner.toString())
+        .hasMessageContaining("no registered engine");
+    assertThat(storage.getStatus().name()).isEqualTo("OPEN");
+  }
+
+  /** A same-slot engine bound to another descriptor cannot satisfy resolution for the old owner. */
+  @Test
+  public void ownerResolverRejectsForeignOwnerInSameSlot() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionForeign");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionForeign.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engines = indexEngines(storage);
+    var original = (BTreeSingleValueIndexEngine) findEngineByName(storage, indexName);
+    var replacement = replacementEngine(storage, original, "foreign-owner");
+    var foreignOwner = new RecordId(92, 18);
+    replacement.getEngineReference().bindOwner(foreignOwner);
+
+    engines.set(original.getId(), replacement);
+    try {
+      assertThatThrownBy(() -> storage.resolveIndexEngineByOwner(index.getIdentity()))
+          .isInstanceOf(StaleIndexEngineException.class)
+          .hasMessageContaining(index.getIdentity().toString())
+          .hasMessageContaining("no registered engine");
+    } finally {
+      engines.set(original.getId(), original);
+    }
+  }
+
+  /** Two registered engines carrying one owner violate the storage ownership invariant. */
+  @Test
+  public void ownerResolverRejectsDuplicateOwner() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionDuplicate");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionDuplicate.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var original = (BTreeSingleValueIndexEngine) findEngineByName(storage, indexName);
+    var engines = indexEngines(storage);
+    var duplicate = new BTreeSingleValueIndexEngine(
+        engines.size(), original.getFileBaseId() + 10_000, "duplicate-owner", storage, 4);
+    duplicate.getEngineReference().bindOwner(index.getIdentity());
+
+    engines.add(duplicate);
+    try {
+      assertThatThrownBy(() -> storage.resolveIndexEngineByOwner(index.getIdentity()))
+          .isInstanceOf(StorageException.class)
+          .hasMessageContaining(index.getIdentity().toString())
+          .hasMessageContaining("Multiple registered index engines");
+    } finally {
+      engines.remove(engines.size() - 1);
+    }
+  }
+
+  /** Null registry slots are ignored while the resolver checks every possible duplicate owner. */
+  @Test
+  public void ownerResolverSkipsNullEngineSlots() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionNullSlot");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionNullSlot.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engine = findEngineByName(storage, indexName);
+    var engines = indexEngines(storage);
+
+    engines.add(null);
+    try {
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+          .isEqualTo(externalIdOf(engine));
+    } finally {
+      engines.remove(engines.size() - 1);
+    }
+  }
+
+  /** Every non-null local registry entry must expose a process-local engine reference. */
+  @Test
+  public void ownerResolverRejectsRegisteredEngineWithoutReference() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+    var engines = indexEngines(storage);
+    var referenceLessEngine = Mockito.mock(BaseIndexEngine.class);
+    engines.add(referenceLessEngine);
+    try {
+      assertThatThrownBy(() -> storage.resolveIndexEngineByOwner(new RecordId(93, 19)))
+          .isInstanceOf(StorageException.class)
+          .hasMessageContaining("has no process-local reference");
+    } finally {
+      engines.remove(engines.size() - 1);
+    }
+  }
+
+  /** The lock-held owner resolver rejects a caller without a state lock or commit window. */
+  @Test
+  public void ownerResolverWithStateLockRejectsUnlockedCaller() {
+    var storage = (AbstractStorage) db.getStorage();
+
+    assertThatThrownBy(
+        () -> storage.resolveIndexEngineByOwnerWithStateLock(new RecordId(94, 20)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("state lock")
+        .hasMessageContaining("commit window");
+  }
+
+  /** The public owner resolver self-routes under a commit-window write lock without deadlocking. */
+  @Test(timeout = 30_000)
+  public void publicOwnerResolverRoutesThroughCommitWindow() throws Exception {
+    db.activateOnCurrentThread();
+    var cls = db.createVertexClass("OwnerResolutionCommitWindow");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionCommitWindow.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engine = findEngineByName(storage, indexName);
+
+    storage.stateLock.writeLock().lock();
+    try {
+      storage.enterCommitWindow();
+      try {
+        assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+            .isEqualTo(externalIdOf(engine));
+      } finally {
+        storage.exitCommitWindow();
+      }
+    } finally {
+      storage.stateLock.writeLock().unlock();
+    }
+  }
+
   // ---- Helpers ----
 
   /**
    * Reads the {@code private} {@code indexEngines} registry on the storage and returns the
    * engine registered under {@code name}, or {@code null} if no live engine carries it.
    */
+  private static BTreeSingleValueIndexEngine replacementEngine(
+      AbstractStorage storage, BTreeSingleValueIndexEngine original, String suffix) {
+    return new BTreeSingleValueIndexEngine(
+        original.getId(),
+        original.getFileBaseId(),
+        original.getName() + "-" + suffix,
+        storage,
+        4);
+  }
+
   @SuppressWarnings("unchecked")
-  private static BaseIndexEngine findEngineByName(AbstractStorage storage, String name)
-      throws Exception {
+  private static List<BaseIndexEngine> indexEngines(AbstractStorage storage) throws Exception {
     var field = AbstractStorage.class.getDeclaredField("indexEngines");
     field.setAccessible(true);
-    var engines = (List<BaseIndexEngine>) field.get(storage);
+    return (List<BaseIndexEngine>) field.get(storage);
+  }
+
+  private static BaseIndexEngine findEngineByName(AbstractStorage storage, String name)
+      throws Exception {
+    var engines = indexEngines(storage);
     for (var engine : engines) {
       if (engine != null && name.equals(engine.getName())) {
         return engine;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -11,6 +11,7 @@ import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
+import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -30,14 +31,14 @@ import org.junit.Test;
 
 /**
  * White-box tests for the lock-free commit-window primitives extracted out of the public
- * structural methods on {@link AbstractStorage}: {@code doGetIndexEngine},
+ * structural methods on {@link AbstractStorage}: {@code getIndexEngineWithStateLock},
  * {@code doAddIndexEngine} / {@code publishIndexEngine}, {@code doDeleteIndexEngine}, and
  * the {@code doCreateCollection} / {@code registerCollection} create/publish split.
  *
  * <p>Two properties are pinned. First, the public {@code addIndexEngine} /
  * {@code deleteIndexEngine} / {@code addCollection} wrappers still create, register, and
  * drop structures exactly as before the extraction (behavior preservation). Second — the
- * load-bearing one — {@code doGetIndexEngine} resolves an engine by id while the calling
+ * load-bearing one — {@code getIndexEngineWithStateLock} resolves an engine by id while the calling
  * thread holds {@code stateLock.writeLock()}, the situation a schema-carrying commit is in
  * once it takes the write lock from the start. The public {@code getIndexEngine} would
  * busy-spin forever there because it re-acquires {@code stateLock.readLock()} on the
@@ -57,7 +58,7 @@ import org.junit.Test;
  * <p>The test lives in the storage package so it can read {@code storage.stateLock} for
  * white-box lock-holding, and uses reflection only for the {@code private} members it
  * must reach directly: the {@code indexEngines} registry (to find an engine's internal id),
- * {@code doGetIndexEngine(int)}, and {@code isCommitWindowActive()} (the window predicate).
+ * {@code getIndexEngineWithStateLock(int)}, and {@code isCommitWindowActive()} (the window predicate).
  */
 public class AbstractStorageCommitPrimitivesTest {
 
@@ -253,6 +254,61 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
+  /** A stale engine identifier reloads without re-entering either held state-lock mode. */
+  @Test(timeout = 30_000)
+  public void staleIndexLockResolutionRetainsCallerStateLock() throws Exception {
+    db.activateOnCurrentThread();
+    SchemaClass cls = db.createVertexClass("StaleIndexedCommitLock");
+    cls.createProperty("value", PropertyType.STRING);
+    cls.createIndex("StaleIndexedCommitLock_value", SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = db.getSharedContext().getIndexManager().getIndex("StaleIndexedCommitLock_value");
+    var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
+    indexIdField.setAccessible(true);
+    db.begin();
+    var operation = db.getActiveTransaction().getAtomicOperation();
+
+    storage.stateLock.readLock().lock();
+    try {
+      indexIdField.setInt(index, Integer.MAX_VALUE);
+      index.acquireAtomicExclusiveLock(operation);
+      try (var executor = Executors.newSingleThreadExecutor()) {
+        var writerEntered =
+            executor.submit(
+                () -> {
+                  if (!storage.stateLock.writeLock().tryLock()) {
+                    return false;
+                  }
+                  try {
+                    return true;
+                  } finally {
+                    storage.stateLock.writeLock().unlock();
+                  }
+                });
+        assertThat(writerEntered.get(10, TimeUnit.SECONDS))
+            .as("stale-id reload must retain the outer state read lock")
+            .isFalse();
+      }
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    storage.stateLock.writeLock().lock();
+    try {
+      storage.enterCommitWindow();
+      try {
+        indexIdField.setInt(index, Integer.MAX_VALUE);
+        index.acquireAtomicExclusiveLock(operation);
+      } finally {
+        storage.exitCommitWindow();
+      }
+    } finally {
+      storage.stateLock.writeLock().unlock();
+      db.rollback();
+    }
+  }
+
   /** Caller-owned create and update operations persist versions without nested transactions. */
   @Test
   public void callerOwnedRecordCreateAndUpdateUseExpectedVersion() throws Exception {
@@ -347,6 +403,41 @@ public class AbstractStorageCommitPrimitivesTest {
             .getAtomicOperationsManager()
             .calculateInsideAtomicOperation(operation -> storage.readRecord(rid, operation));
     assertThat(((RawBuffer) stored).buffer()).isEqualTo(durableContent);
+  }
+
+  /** Caller-owned record primitives fail before taking a second collection lock. */
+  @Test
+  public void callerOwnedRecordWritesRejectSecondCollection() {
+    var firstClass = db.createVertexClass("PrimitiveFirstCollection");
+    var secondClass = db.createVertexClass("PrimitiveSecondCollection");
+    var firstRid =
+        new ChangeableRecordId(
+            firstClass.getCollectionIds()[0], RecordIdInternal.COLLECTION_POS_INVALID);
+    var secondRid =
+        new ChangeableRecordId(
+            secondClass.getCollectionIds()[0], RecordIdInternal.COLLECTION_POS_INVALID);
+    var storage = (AbstractStorage) db.getStorage();
+
+    storage.stateLock.readLock().lock();
+    try {
+      assertThatThrownBy(
+          () -> storage
+              .getAtomicOperationsManager()
+              .executeInsideAtomicOperation(
+                  operation -> {
+                    storage.createRecordInsideAtomicOperation(
+                        operation, firstRid, new byte[] {1}, RecordBytes.RECORD_TYPE);
+                    storage.createRecordInsideAtomicOperation(
+                        operation, secondRid, new byte[] {2}, RecordBytes.RECORD_TYPE);
+                  }))
+          .isInstanceOf(com.jetbrains.youtrackdb.internal.core.exception.StorageException.class)
+          .hasRootCauseInstanceOf(IllegalStateException.class)
+          .rootCause()
+          .hasMessageContaining("one collection")
+          .hasMessageContaining("ascending identifier order");
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
   }
 
   // ---- The load-bearing property: record reads resolve lock-free in the commit window ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -894,26 +894,65 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
-  /** Every non-null local registry entry must expose a process-local engine reference. */
+  /** A reference-less engine is skipped while another engine resolves for the requested owner. */
   @Test
-  public void ownerResolverRejectsRegisteredEngineWithoutReference() throws Exception {
+  public void ownerResolverSkipsReferenceLessEngineAndFindsRequestedOwner() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionReferenceLessPeer");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionReferenceLessPeer.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
     var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var expectedEngine = findEngineByName(storage, indexName);
     var engines = indexEngines(storage);
-    var referenceLessEngine = Mockito.mock(BaseIndexEngine.class);
-    engines.add(referenceLessEngine);
+    engines.add(Mockito.mock(BaseIndexEngine.class));
     try {
-      assertThatThrownBy(() -> storage.resolveIndexEngineByOwner(new RecordId(93, 19)))
-          .isInstanceOf(StorageException.class)
-          .hasMessageContaining("has no process-local reference");
+      assertThat(storage.resolveIndexEngineByOwner(index.getIdentity()))
+          .isEqualTo(externalIdOf(expectedEngine));
     } finally {
       engines.remove(engines.size() - 1);
     }
   }
 
-  /** A restored reference-less engine remains published even though its owner cannot be bound. */
+  /** A stale handle for a reference-less engine fails closed with the typed stale exception. */
   @Test
-  public void restoredReferenceLessEngineIsPublishedWithoutOwnerBinding() throws Exception {
+  public void referenceLessEngineHandleFailsClosedWithStaleException() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionReferenceLessHandle");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionReferenceLessHandle.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
     var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engines = indexEngines(storage);
+    var original = findEngineByName(storage, indexName);
+    var referenceLessEngine = Mockito.mock(BaseIndexEngine.class);
+    Mockito.when(referenceLessEngine.getId()).thenReturn(original.getId());
+    Mockito.when(referenceLessEngine.getName()).thenReturn(indexName);
+    engines.set(original.getId(), referenceLessEngine);
+    setIndexIdentifier(index, index.getIndexId() | 1_000_000);
+    try {
+      assertThatThrownBy(() -> index.getStatistics(db))
+          .isExactlyInstanceOf(StaleIndexEngineException.class)
+          .hasMessageContaining(index.getIdentity().toString());
+    } finally {
+      engines.set(original.getId(), original);
+    }
+  }
+
+  /** A restored reference-less engine cannot poison owner resolution for another index. */
+  @Test
+  public void restoredReferenceLessEngineDoesNotPoisonUnrelatedOwnerResolution() throws Exception {
+    var cls = db.createVertexClass("OwnerResolutionAfterReferenceLessRestore");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "OwnerResolutionAfterReferenceLessRestore.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var unrelatedIndex =
+        (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var unrelatedEngine = findEngineByName(storage, indexName);
     var engines = indexEngines(storage);
     var engine = Mockito.mock(BaseIndexEngine.class);
     var engineName = "restored-reference-less";
@@ -927,6 +966,8 @@ public class AbstractStorageCommitPrimitivesTest {
 
     assertThat(engines.get(slot)).isSameAs(engine);
     assertThat(storage.loadIndexEngine(engineName)).isGreaterThanOrEqualTo(0);
+    assertThat(storage.resolveIndexEngineByOwner(unrelatedIndex.getIdentity()))
+        .isEqualTo(externalIdOf(unrelatedEngine));
   }
 
   /** The lock-held owner resolver rejects a caller without a state lock or commit window. */
@@ -989,6 +1030,13 @@ public class AbstractStorageCommitPrimitivesTest {
     var field = AbstractStorage.class.getDeclaredField("indexEngines");
     field.setAccessible(true);
     return (List<BaseIndexEngine>) field.get(storage);
+  }
+
+  private static void setIndexIdentifier(IndexAbstract index, int indexIdentifier)
+      throws Exception {
+    var field = IndexAbstract.class.getDeclaredField("indexId");
+    field.setAccessible(true);
+    field.setInt(index, indexIdentifier);
   }
 
   private static BaseIndexEngine findEngineByName(AbstractStorage storage, String name)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -14,6 +14,7 @@ import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
+import com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
@@ -343,7 +344,7 @@ public class AbstractStorageCommitPrimitivesTest {
 
     storage.stateLock.readLock().lock();
     try {
-      index.setEngineIdentifierForTest(Integer.MAX_VALUE);
+      IndexEngineTestSupport.setEngineIdentifier(index, Integer.MAX_VALUE);
       index.acquireAtomicExclusiveLock(operation);
       try (var executor = Executors.newSingleThreadExecutor()) {
         var writerEntered =
@@ -370,7 +371,7 @@ public class AbstractStorageCommitPrimitivesTest {
     try {
       storage.enterCommitWindow();
       try {
-        index.setEngineIdentifierForTest(Integer.MAX_VALUE);
+        IndexEngineTestSupport.setEngineIdentifier(index, Integer.MAX_VALUE);
         index.acquireAtomicExclusiveLock(operation);
       } finally {
         storage.exitCommitWindow();
@@ -1011,6 +1012,45 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
+  /** A reference-aware size call keeps the validated engine when its slot changes mid-call. */
+  @Test
+  public void referenceAwareSizeUsesOneResolvedEngine() throws Exception {
+    var cls = db.createVertexClass("FusedReferenceSize");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "FusedReferenceSize.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var engines = indexEngines(storage);
+    var slot = engines.get(index.getIndexId() & 0x7_FF_FF_FF).getId();
+    var expectedReference = index.engineSnapshot().engineReference();
+    var original = Mockito.mock(BaseIndexEngine.class);
+    var replacement = Mockito.mock(BaseIndexEngine.class);
+    Mockito.when(original.getId()).thenReturn(slot);
+    Mockito.when(original.getEngineReference()).thenAnswer(invocation -> {
+      engines.set(slot, replacement);
+      return expectedReference;
+    });
+    Mockito.when(original.size(Mockito.any(), Mockito.isNull(), Mockito.any())).thenReturn(11L);
+    Mockito.when(replacement.getId()).thenReturn(slot);
+    Mockito.when(replacement.size(Mockito.any(), Mockito.isNull(), Mockito.any())).thenReturn(22L);
+
+    var registered = engines.set(slot, original);
+    db.begin();
+    try {
+      var operation = db.getActiveTransaction().getAtomicOperation();
+      assertThat(storage.getIndexSize(
+          index.getIndexId(), expectedReference, null, operation)).isEqualTo(11L);
+      Mockito.verify(original).size(storage, null, operation);
+      Mockito.verify(replacement, Mockito.never())
+          .size(Mockito.any(), Mockito.any(), Mockito.any());
+    } finally {
+      engines.set(slot, registered);
+      db.rollback();
+    }
+  }
+
   // ---- Helpers ----
 
   /**
@@ -1035,7 +1075,7 @@ public class AbstractStorageCommitPrimitivesTest {
   }
 
   private static void setIndexIdentifier(IndexAbstract index, int indexIdentifier) {
-    index.setEngineIdentifierForTest(indexIdentifier);
+    IndexEngineTestSupport.setEngineIdentifier(index, indexIdentifier);
   }
 
   private static BaseIndexEngine findEngineByName(AbstractStorage storage, String name)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -1,15 +1,20 @@
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import java.lang.reflect.Method;
@@ -161,9 +166,7 @@ public class AbstractStorageCommitPrimitivesTest {
   // clean TestTimedOutException naming this method, matching the ScalableRWLockTest convention
   // in this package.
   @Test(timeout = 30_000)
-  public void doGetIndexEngineResolvesWhileWriteLockHeld() throws Exception {
-    // @Test(timeout) runs this body on a JUnit watchdog thread; the session is thread-bound
-    // (a ThreadLocal activation flag), so re-activate it on this thread before touching the db.
+  public void heldStateLockResolverWorksForReadLockAndCommitWindow() throws Exception {
     db.activateOnCurrentThread();
 
     SchemaClass cls = db.createVertexClass("PersonLockFree");
@@ -173,22 +176,177 @@ public class AbstractStorageCommitPrimitivesTest {
     var storage = (AbstractStorage) db.getStorage();
     var engine = findEngineByName(storage, "PersonLockFree_email");
     assertThat(engine).as("precondition: the engine is registered").isNotNull();
-    int internalId = engine.getId();
+    int externalId = externalIdOf(engine);
 
-    Method doGet =
-        AbstractStorage.class.getDeclaredMethod("doGetIndexEngine", int.class);
-    doGet.setAccessible(true);
+    storage.stateLock.readLock().lock();
+    try {
+      assertThat(storage.getIndexEngineWithStateLock(externalId)).isSameAs(engine);
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
 
-    // Take the write lock on this thread, exactly as a schema-carrying commit does at entry.
     storage.stateLock.writeLock().lock();
     try {
-      var resolved = (BaseIndexEngine) doGet.invoke(storage, internalId);
-      assertThat(resolved)
-          .as("doGetIndexEngine must resolve the engine under the held write lock")
-          .isSameAs(engine);
+      storage.enterCommitWindow();
+      try {
+        assertThat(storage.getIndexEngineWithStateLock(externalId)).isSameAs(engine);
+      } finally {
+        storage.exitCommitWindow();
+      }
     } finally {
       storage.stateLock.writeLock().unlock();
     }
+  }
+
+  /** The lock-free resolver rejects callers that provide neither supported state-lock proof. */
+  @Test
+  public void heldStateLockResolverRejectsUnlockedCaller() throws Exception {
+    SchemaClass cls = db.createVertexClass("ResolverPrecondition");
+    cls.createProperty("value", PropertyType.STRING);
+    cls.createIndex("ResolverPrecondition_value", SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var engine = findEngineByName(storage, "ResolverPrecondition_value");
+
+    assertThatThrownBy(() -> storage.getIndexEngineWithStateLock(externalIdOf(engine)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("state lock")
+        .hasMessageContaining("commit window");
+  }
+
+  /** Indexed data commits must retain their outer state read lock through engine resolution. */
+  @Test(timeout = 30_000)
+  public void indexLockResolutionDoesNotDropOuterStateReadLock() throws Exception {
+    db.activateOnCurrentThread();
+    SchemaClass cls = db.createVertexClass("IndexedCommitLock");
+    cls.createProperty("value", PropertyType.STRING);
+    cls.createIndex("IndexedCommitLock_value", SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = db.getSharedContext().getIndexManager().getIndex("IndexedCommitLock_value");
+    db.begin();
+    var operation = db.getActiveTransaction().getAtomicOperation();
+
+    storage.stateLock.readLock().lock();
+    try {
+      index.acquireAtomicExclusiveLock(operation);
+      try (var executor = Executors.newSingleThreadExecutor()) {
+        var writerEntered =
+            executor.submit(
+                () -> {
+                  if (!storage.stateLock.writeLock().tryLock()) {
+                    return false;
+                  }
+                  try {
+                    return true;
+                  } finally {
+                    storage.stateLock.writeLock().unlock();
+                  }
+                });
+        assertThat(writerEntered.get(10, TimeUnit.SECONDS))
+            .as("engine resolution must not release the commit's outer state read lock")
+            .isFalse();
+      }
+    } finally {
+      storage.stateLock.readLock().unlock();
+      db.rollback();
+    }
+  }
+
+  /** Caller-owned create and update operations persist versions without nested transactions. */
+  @Test
+  public void callerOwnedRecordCreateAndUpdateUseExpectedVersion() throws Exception {
+    var cls = db.createVertexClass("PrimitiveRecords");
+    int collectionId = cls.getCollectionIds()[0];
+    var storage = (AbstractStorage) db.getStorage();
+    var rid = new ChangeableRecordId(collectionId, RecordIdInternal.COLLECTION_POS_INVALID);
+    byte[] initialContent = new byte[] {1, 2, 3};
+
+    long initialVersion;
+    storage.stateLock.readLock().lock();
+    try {
+      initialVersion =
+          storage
+              .getAtomicOperationsManager()
+              .calculateInsideAtomicOperation(
+                  operation -> storage.createRecordInsideAtomicOperation(
+                      operation, rid, initialContent, RecordBytes.RECORD_TYPE));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    assertThat(rid.isPersistent()).isTrue();
+    assertThat(initialVersion).isGreaterThanOrEqualTo(0);
+
+    byte[] updatedContent = new byte[] {4, 5, 6};
+    long updatedVersion;
+    storage.stateLock.readLock().lock();
+    try {
+      updatedVersion =
+          storage
+              .getAtomicOperationsManager()
+              .calculateInsideAtomicOperation(
+                  operation -> storage.updateRecordInsideAtomicOperation(
+                      operation,
+                      rid,
+                      updatedContent,
+                      initialVersion,
+                      RecordBytes.RECORD_TYPE));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    assertThat(updatedVersion).isGreaterThan(initialVersion);
+    var stored =
+        storage
+            .getAtomicOperationsManager()
+            .calculateInsideAtomicOperation(operation -> storage.readRecord(rid, operation));
+    assertThat(((RawBuffer) stored).buffer()).isEqualTo(updatedContent);
+  }
+
+  /** A stale caller-owned update rolls back and preserves the last durable record bytes. */
+  @Test
+  public void callerOwnedRecordUpdateRejectsStaleExpectedVersion() throws Exception {
+    var cls = db.createVertexClass("PrimitiveVersionConflict");
+    var storage = (AbstractStorage) db.getStorage();
+    var rid =
+        new ChangeableRecordId(
+            cls.getCollectionIds()[0], RecordIdInternal.COLLECTION_POS_INVALID);
+    byte[] durableContent = new byte[] {7, 8};
+
+    storage.stateLock.readLock().lock();
+    try {
+      storage
+          .getAtomicOperationsManager()
+          .calculateInsideAtomicOperation(
+              operation -> storage.createRecordInsideAtomicOperation(
+                  operation, rid, durableContent, RecordBytes.RECORD_TYPE));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    storage.stateLock.readLock().lock();
+    try {
+      assertThatThrownBy(
+          () -> storage
+              .getAtomicOperationsManager()
+              .calculateInsideAtomicOperation(
+                  operation -> storage.updateRecordInsideAtomicOperation(
+                      operation,
+                      new RecordId(rid),
+                      new byte[] {9},
+                      Long.MIN_VALUE,
+                      RecordBytes.RECORD_TYPE)))
+          .isInstanceOf(ConcurrentModificationException.class);
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    var stored =
+        storage
+            .getAtomicOperationsManager()
+            .calculateInsideAtomicOperation(operation -> storage.readRecord(rid, operation));
+    assertThat(((RawBuffer) stored).buffer()).isEqualTo(durableContent);
   }
 
   // ---- The load-bearing property: record reads resolve lock-free in the commit window ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -8,6 +8,7 @@ import com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.exception.IndexEngineReplacedException;
 import com.jetbrains.youtrackdb.internal.core.exception.StaleIndexEngineException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
@@ -17,12 +18,14 @@ import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport;
 import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
+import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValidator;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +33,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1012,6 +1016,92 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
+  /** Attachment rejects every torn reference shape and tolerates reference-less engines. */
+  @Test
+  public void attachIndexEngineOwnerRejectsTornCarrierShapes() throws Exception {
+    var cls = db.createVertexClass("AttachmentShapes");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "AttachmentShapes.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.UNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var snapshot = index.engineSnapshot();
+    var live = snapshot.engineReference();
+    var owner = index.getIdentity();
+
+    assertThatThrownBy(() -> storage.attachIndexEngineOwner(
+        snapshot.engineIdentifier(), owner, null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("unexpectedly gained");
+    var foreignSlot = new IndexEngineReference(
+        live.slot() + 1, live.apiVersion(), live.generation() + 1);
+    assertThatThrownBy(() -> storage.attachIndexEngineOwner(
+        snapshot.engineIdentifier(), owner, foreignSlot))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("non-monotonically");
+
+    var engines = indexEngines(storage);
+    var registered = engines.get(live.slot());
+    var referenceLess = Mockito.mock(BaseIndexEngine.class);
+    Mockito.when(referenceLess.getId()).thenReturn(live.slot());
+    Mockito.when(referenceLess.getEngineReference()).thenReturn(null);
+    engines.set(live.slot(), referenceLess);
+    try {
+      assertThatThrownBy(() -> storage.attachIndexEngineOwner(
+          snapshot.engineIdentifier(), owner, live))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("lost its process-local reference");
+      assertThat(storage.attachIndexEngineOwner(
+          snapshot.engineIdentifier(), owner, null)).isNull();
+    } finally {
+      engines.set(live.slot(), registered);
+    }
+  }
+
+  /** Reference lookup wrappers preserve runtime failures and errors from the registry engine. */
+  @Test
+  public void referenceLookupPreservesEngineReferenceFailures() throws Exception {
+    assertReferenceLookupFailurePreserved(new IllegalStateException("reference runtime"));
+    assertReferenceLookupFailurePreserved(new AssertionError("reference error"));
+    assertReferenceLookupFailurePreserved(new IOException("reference checked failure"));
+  }
+
+  private void assertReferenceLookupFailurePreserved(Throwable failure) throws Exception {
+    var clsName = "ReferenceLookup" + failure.getClass().getSimpleName();
+    var cls = db.createVertexClass(clsName);
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = clsName + ".value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var snapshot = index.engineSnapshot();
+    var slot = snapshot.engineReference().slot();
+    var engines = indexEngines(storage);
+    var throwing = Mockito.mock(BaseIndexEngine.class);
+    Mockito.when(throwing.getId()).thenReturn(slot);
+    Mockito.when(throwing.getEngineReference()).thenAnswer(invocation -> {
+      throw failure;
+    });
+    var registered = engines.set(slot, throwing);
+
+    db.begin();
+    try {
+      var operation = db.getActiveTransaction().getAtomicOperation();
+      assertForwardedFailure(
+          () -> storage.getIndexEngine(snapshot.engineIdentifier(), snapshot.engineReference()),
+          failure);
+      assertForwardedFailure(
+          () -> storage.getIndexValues(
+              snapshot.engineIdentifier(), snapshot.engineReference(), "key", operation),
+          failure);
+    } finally {
+      engines.set(slot, registered);
+      db.rollback();
+    }
+  }
+
   /** A reference-aware size call keeps the validated engine when its slot changes mid-call. */
   @Test
   public void referenceAwareSizeUsesOneResolvedEngine() throws Exception {
@@ -1048,6 +1138,160 @@ public class AbstractStorageCommitPrimitivesTest {
     } finally {
       engines.set(slot, registered);
       db.rollback();
+    }
+  }
+
+  /** Every reference-aware storage API rejects a different engine before any operation runs. */
+  @Test
+  public void referenceAwareIndexApisRejectReplacedEngine() throws Exception {
+    var cls = db.createVertexClass("ReferenceApiMismatch");
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = "ReferenceApiMismatch.value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var snapshot = index.engineSnapshot();
+    var live = snapshot.engineReference();
+    var wrong = new IndexEngineReference(live.slot(), live.apiVersion(), live.generation() + 1);
+    var rid = new RecordId(7, 42);
+    @SuppressWarnings("unchecked")
+    var validator = (IndexEngineValidator<Object,
+        com.jetbrains.youtrackdb.internal.core.db.record.record.RID>) Mockito
+            .mock(IndexEngineValidator.class);
+
+    db.begin();
+    try {
+      var operation = db.getActiveTransaction().getAtomicOperation();
+      List<ThrowingCallable> calls = List.of(
+          () -> storage.getIndexValues(
+              snapshot.engineIdentifier(), wrong, "key", operation),
+          () -> storage.getIndexEngine(snapshot.engineIdentifier(), wrong),
+          () -> storage.removeKeyFromIndex(
+              snapshot.engineIdentifier(), wrong, "key", operation),
+          () -> storage.putRidIndexEntry(
+              snapshot.engineIdentifier(), wrong, "key", rid, operation),
+          () -> storage.removeRidIndexEntry(
+              snapshot.engineIdentifier(), wrong, "key", rid, operation),
+          () -> storage.validatedPutIndexValue(
+              snapshot.engineIdentifier(), wrong, "key", rid, validator, operation),
+          () -> storage.callIndexEngine(
+              false, snapshot.engineIdentifier(), wrong, engine -> null),
+          () -> storage.iterateIndexEntriesBetween(
+              snapshot.engineIdentifier(), wrong, "a", true, "z", true, true, null, operation),
+          () -> storage.iterateIndexEntriesMajor(
+              snapshot.engineIdentifier(), wrong, "a", true, true, null, operation),
+          () -> storage.iterateIndexEntriesMinor(
+              snapshot.engineIdentifier(), wrong, "z", true, true, null, operation),
+          () -> storage.getIndexStream(snapshot.engineIdentifier(), wrong, null, operation),
+          () -> storage.getIndexDescStream(snapshot.engineIdentifier(), wrong, null, operation),
+          () -> storage.getIndexKeyStream(snapshot.engineIdentifier(), wrong, operation),
+          () -> storage.getIndexSize(snapshot.engineIdentifier(), wrong, null, operation),
+          () -> storage.deleteIndexEngine(snapshot.engineIdentifier(), wrong));
+
+      for (var call : calls) {
+        assertThatThrownBy(call).isExactlyInstanceOf(IndexEngineReplacedException.class);
+      }
+      assertThatThrownBy(() -> storage.clearIndex(snapshot.engineIdentifier(), wrong))
+          .isExactlyInstanceOf(StaleIndexEngineException.class)
+          .hasCauseInstanceOf(IndexEngineReplacedException.class);
+
+      storage.stateLock.readLock().lock();
+      try {
+        assertThatThrownBy(() -> storage.getIndexEngineWithStateLock(
+            snapshot.engineIdentifier(), wrong))
+            .isExactlyInstanceOf(IndexEngineReplacedException.class);
+      } finally {
+        storage.stateLock.readLock().unlock();
+      }
+
+      storage.stateLock.writeLock().lock();
+      try {
+        storage.enterCommitWindow();
+        try {
+          assertThatThrownBy(() -> storage.deleteIndexEngineInCommitWindow(
+              snapshot.engineIdentifier(), wrong, operation))
+              .isExactlyInstanceOf(IndexEngineReplacedException.class);
+        } finally {
+          storage.exitCommitWindow();
+        }
+      } finally {
+        storage.stateLock.writeLock().unlock();
+      }
+
+      assertThat(storage.loadIndexEngine(indexName)).isEqualTo(snapshot.engineIdentifier());
+    } finally {
+      db.rollback();
+    }
+  }
+
+  /** Query wrappers preserve runtime failures and errors raised by the resolved engine. */
+  @Test
+  public void referenceAwareQueryApisPreserveEngineFailures() throws Exception {
+    assertReferenceAwareQueryFailurePreserved(new IllegalStateException("runtime failure"));
+    assertReferenceAwareQueryFailurePreserved(new AssertionError("error failure"));
+    assertReferenceAwareQueryFailurePreserved(new IOException("checked failure"));
+  }
+
+  private void assertReferenceAwareQueryFailurePreserved(Throwable failure) throws Exception {
+    var clsName = "ReferenceFailure" + failure.getClass().getSimpleName();
+    var cls = db.createVertexClass(clsName);
+    cls.createProperty("value", PropertyType.STRING);
+    var indexName = clsName + ".value";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+    var storage = (AbstractStorage) db.getStorage();
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
+    var snapshot = index.engineSnapshot();
+    var engines = indexEngines(storage);
+    var slot = snapshot.engineReference().slot();
+    var throwing = Mockito.mock(BaseIndexEngine.class, invocation -> {
+      return switch (invocation.getMethod().getName()) {
+        case "getId" -> slot;
+        case "getEngineReference" -> snapshot.engineReference();
+        default -> throw failure;
+      };
+    });
+    var registered = engines.set(slot, throwing);
+
+    db.begin();
+    try {
+      var operation = db.getActiveTransaction().getAtomicOperation();
+      List<ThrowingCallable> calls = List.of(
+          () -> storage.iterateIndexEntriesBetween(
+              snapshot.engineIdentifier(), snapshot.engineReference(),
+              "a", true, "z", true, true, null, operation),
+          () -> storage.iterateIndexEntriesMajor(
+              snapshot.engineIdentifier(), snapshot.engineReference(),
+              "a", true, true, null, operation),
+          () -> storage.iterateIndexEntriesMinor(
+              snapshot.engineIdentifier(), snapshot.engineReference(),
+              "z", true, true, null, operation),
+          () -> storage.getIndexStream(
+              snapshot.engineIdentifier(), snapshot.engineReference(), null, operation),
+          () -> storage.getIndexDescStream(
+              snapshot.engineIdentifier(), snapshot.engineReference(), null, operation),
+          () -> storage.getIndexKeyStream(
+              snapshot.engineIdentifier(), snapshot.engineReference(), operation),
+          () -> storage.getIndexSize(
+              snapshot.engineIdentifier(), snapshot.engineReference(), null, operation));
+
+      for (var call : calls) {
+        assertForwardedFailure(call, failure);
+      }
+    } finally {
+      engines.set(slot, registered);
+      db.rollback();
+    }
+  }
+
+  private static void assertForwardedFailure(ThrowingCallable call, Throwable failure) {
+    if (failure instanceof RuntimeException || failure instanceof Error) {
+      assertThatThrownBy(call).isSameAs(failure);
+    } else {
+      assertThatThrownBy(call)
+          .isInstanceOf(RuntimeException.class)
+          .hasCause(failure);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -336,15 +336,14 @@ public class AbstractStorageCommitPrimitivesTest {
     cls.createIndex("StaleIndexedCommitLock_value", SchemaClass.INDEX_TYPE.UNIQUE, "value");
 
     var storage = (AbstractStorage) db.getStorage();
-    var index = db.getSharedContext().getIndexManager().getIndex("StaleIndexedCommitLock_value");
-    var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-    indexIdField.setAccessible(true);
+    var index = (IndexAbstract) db.getSharedContext().getIndexManager()
+        .getIndex("StaleIndexedCommitLock_value");
     db.begin();
     var operation = db.getActiveTransaction().getAtomicOperation();
 
     storage.stateLock.readLock().lock();
     try {
-      indexIdField.setInt(index, Integer.MAX_VALUE);
+      index.setEngineIdentifierForTest(Integer.MAX_VALUE);
       index.acquireAtomicExclusiveLock(operation);
       try (var executor = Executors.newSingleThreadExecutor()) {
         var writerEntered =
@@ -371,7 +370,7 @@ public class AbstractStorageCommitPrimitivesTest {
     try {
       storage.enterCommitWindow();
       try {
-        indexIdField.setInt(index, Integer.MAX_VALUE);
+        index.setEngineIdentifierForTest(Integer.MAX_VALUE);
         index.acquireAtomicExclusiveLock(operation);
       } finally {
         storage.exitCommitWindow();
@@ -1035,11 +1034,8 @@ public class AbstractStorageCommitPrimitivesTest {
     return (List<BaseIndexEngine>) field.get(storage);
   }
 
-  private static void setIndexIdentifier(IndexAbstract index, int indexIdentifier)
-      throws Exception {
-    var field = IndexAbstract.class.getDeclaredField("indexId");
-    field.setAccessible(true);
-    field.setInt(index, indexIdentifier);
+  private static void setIndexIdentifier(IndexAbstract index, int indexIdentifier) {
+    index.setEngineIdentifierForTest(indexIdentifier);
   }
 
   private static BaseIndexEngine findEngineByName(AbstractStorage storage, String name)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -153,9 +153,9 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
-  // ---- The load-bearing property: doGetIndexEngine resolves under a held write lock ----
+  // ---- The load-bearing property: getIndexEngineWithStateLock resolves under a held write lock ----
 
-  // doGetIndexEngine must resolve an engine by internal id without taking stateLock, so a
+  // getIndexEngineWithStateLock must resolve an engine by internal id without taking stateLock, so a
   // schema-carrying commit holding stateLock.writeLock() can reach engines during the
   // index-apply path without the non-reentrant self-deadlock the public getIndexEngine
   // would cause. The test holds the write lock on the calling thread, then resolves.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -910,6 +910,25 @@ public class AbstractStorageCommitPrimitivesTest {
     }
   }
 
+  /** A restored reference-less engine remains published even though its owner cannot be bound. */
+  @Test
+  public void restoredReferenceLessEngineIsPublishedWithoutOwnerBinding() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+    var engines = indexEngines(storage);
+    var engine = Mockito.mock(BaseIndexEngine.class);
+    var engineName = "restored-reference-less";
+    var owner = new RecordId(95, 21);
+    var slot = engines.size();
+    Mockito.when(engine.getId()).thenReturn(slot);
+    Mockito.when(engine.getName()).thenReturn(engineName);
+    Mockito.when(engine.getEngineReference()).thenReturn(null);
+
+    storage.bindOwnerAndPublishRestoredIndexEngine(slot, engine, owner);
+
+    assertThat(engines.get(slot)).isSameAs(engine);
+    assertThat(storage.loadIndexEngine(engineName)).isGreaterThanOrEqualTo(0);
+  }
+
   /** The lock-held owner resolver rejects a caller without a state lock or commit window. */
   @Test
   public void ownerResolverWithStateLockRejectsUnlockedCaller() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageCommitPrimitivesTest.java
@@ -20,6 +20,8 @@ import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineReference;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValidator;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeSingleValueIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.index.lifecycle.IndexBuildStateStore;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
@@ -28,11 +30,14 @@ import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.After;
 import org.junit.Before;
@@ -446,6 +451,296 @@ public class AbstractStorageCommitPrimitivesTest {
       storage.stateLock.writeLock().unlock();
       db.rollback();
     }
+  }
+
+  /** The collection lookup resolves through every protection branch without dropping ownership. */
+  @Test(timeout = 30_000)
+  public void collectionIdentifierLookupSelfRoutesForEveryProtectionState() {
+    var storage = (AbstractStorage) db.getStorage();
+    var collectionName = MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME;
+    var expected = storage.getCollectionIdByName(collectionName);
+
+    assertThat(storage.getCollectionIdByNameWithStateLock(collectionName)).isEqualTo(expected);
+
+    storage.stateLock.readLock().lock();
+    try {
+      assertThat(storage.getCollectionIdByNameWithStateLock(collectionName)).isEqualTo(expected);
+      assertThat(storage.stateLock.isReadLockedByCurrentThread()).isTrue();
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    storage.stateLock.writeLock().lock();
+    try {
+      assertThat(storage.getCollectionIdByNameWithStateLock(collectionName)).isEqualTo(expected);
+      assertThat(storage.stateLock.isWriteLockedByCurrentThread()).isTrue();
+    } finally {
+      storage.stateLock.writeLock().unlock();
+    }
+
+    storage.enterCommitWindow();
+    try {
+      assertThat(storage.getCollectionIdByNameWithStateLock(collectionName)).isEqualTo(expected);
+    } finally {
+      storage.exitCommitWindow();
+    }
+  }
+
+  /** The public lifecycle creation boundary rejects a caller without state protection. */
+  @Test
+  public void initialLifecycleCreationRejectsUnprotectedCaller() {
+    var storage = (AbstractStorage) db.getStorage();
+
+    assertThatThrownBy(
+        () -> storage.createInitialIndexLifecycle(new RecordId(0, 41), null, null))
+        .isExactlyInstanceOf(StorageStateContextException.class)
+        .hasMessageContaining("state lock")
+        .hasMessageContaining("commit window");
+  }
+
+  /** Initial lifecycle creation accepts read mode, write mode, and an open commit window. */
+  @Test
+  public void initialLifecycleCreationAcceptsEveryProtectionState() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+
+    storage.stateLock.readLock().lock();
+    try {
+      createInitialLifecycleInsideAtomicOperation(storage, new RecordId(0, 42));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    storage.stateLock.writeLock().lock();
+    try {
+      createInitialLifecycleInsideAtomicOperation(storage, new RecordId(0, 43));
+    } finally {
+      storage.stateLock.writeLock().unlock();
+    }
+
+    storage.enterCommitWindow();
+    try {
+      createInitialLifecycleInsideAtomicOperation(storage, new RecordId(0, 44));
+    } finally {
+      storage.exitCommitWindow();
+    }
+  }
+
+  /** The commit-time record primitive rejects a caller without storage state protection. */
+  @Test
+  public void commitRecordCreateRejectsUnprotectedCaller() {
+    var storage = (AbstractStorage) db.getStorage();
+    var collectionId =
+        storage.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var rid = new ChangeableRecordId(collectionId, RecordIdInternal.COLLECTION_POS_INVALID);
+
+    db.begin();
+    try {
+      var operation = db.getActiveTransaction().getAtomicOperation();
+      assertThatThrownBy(
+          () -> storage.createRecordInsideCommitAtomicOperation(
+              operation, rid, new byte[] {1}, RecordBytes.RECORD_TYPE))
+          .isExactlyInstanceOf(StorageStateContextException.class)
+          .hasMessageContaining("state lock")
+          .hasMessageContaining("commit window");
+    } finally {
+      db.rollback();
+    }
+  }
+
+  /** An applying ownership rejection leaves storage usable for a later valid write. */
+  @Test
+  public void applyingRecordOwnershipRejectionDoesNotSetStorageErrorMarker() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+    var collectionId =
+        storage.getCollectionIdByName(MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var rid = new ChangeableRecordId(collectionId, RecordIdInternal.COLLECTION_POS_INVALID);
+
+    assertThatThrownBy(
+        () -> storage
+            .getAtomicOperationsManager()
+            .executeInsideAtomicOperation(
+                operation -> storage.createRecordInsideCommitAtomicOperation(
+                    operation, rid, new byte[] {1}, RecordBytes.RECORD_TYPE)))
+        .hasRootCauseInstanceOf(StorageStateContextException.class);
+
+    var created = new IndexBuildStateStorageBackend(storage).create(Map.of("value", 1));
+
+    assertThat(created.identity().isPersistent()).isTrue();
+    assertThat(storage.getStatus().name()).isEqualTo("OPEN");
+  }
+
+  /** Checked record writes accept read mode, write mode, and an open commit window. */
+  @Test
+  public void checkedRecordCreateAcceptsEveryProtectionState() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+
+    storage.stateLock.readLock().lock();
+    try {
+      createPrimitiveRecordInsideAtomicOperation(storage);
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+
+    storage.stateLock.writeLock().lock();
+    try {
+      createPrimitiveRecordInsideAtomicOperation(storage);
+    } finally {
+      storage.stateLock.writeLock().unlock();
+    }
+
+    storage.enterCommitWindow();
+    try {
+      createPrimitiveRecordInsideAtomicOperation(storage);
+    } finally {
+      storage.exitCommitWindow();
+    }
+  }
+
+  /** Protected standalone lifecycle writes fail promptly with operation-specific messages. */
+  @Test(timeout = 30_000)
+  public void standaloneLifecycleWritesRejectProtectedReentryWithClearMessages() {
+    var storage = (AbstractStorage) db.getStorage();
+    var backend = new IndexBuildStateStorageBackend(storage);
+    var foreignIdentity = new RecordId(0, 99);
+
+    storage.stateLock.writeLock().lock();
+    try {
+      assertThatThrownBy(() -> backend.create(Map.of("value", 1)))
+          .isExactlyInstanceOf(StorageStateContextException.class)
+          .hasMessageContaining("creation")
+          .hasMessageContaining("createInsideAtomicOperation");
+      assertThatThrownBy(() -> backend.update(foreignIdentity, 0, Map.of("value", 2)))
+          .isExactlyInstanceOf(StorageStateContextException.class)
+          .hasMessageContaining("update")
+          .hasMessageNotContaining("createInsideAtomicOperation");
+      assertThatThrownBy(() -> backend.delete(foreignIdentity, 0))
+          .isExactlyInstanceOf(StorageStateContextException.class)
+          .hasMessageContaining("deletion")
+          .hasMessageNotContaining("createInsideAtomicOperation");
+    } finally {
+      storage.stateLock.writeLock().unlock();
+    }
+  }
+
+  /** A protected caller rejects before waiting for the standalone backend monitor. */
+  @Test(timeout = 30_000)
+  public void protectedStandaloneCallerCannotDeadlockOnBackendMonitor() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+    var backend = new IndexBuildStateStorageBackend(storage);
+    var monitorHeld = new CountDownLatch(1);
+    var writeModeHeld = new CountDownLatch(1);
+    var rejectionObserved = new CountDownLatch(1);
+    var failure = new AtomicReference<Throwable>();
+
+    var monitorHolder =
+        new Thread(
+            () -> {
+              synchronized (backend) {
+                monitorHeld.countDown();
+                try {
+                  writeModeHeld.await();
+                  backend.create(Map.of("value", 1));
+                } catch (Throwable throwable) {
+                  failure.compareAndSet(null, throwable);
+                }
+              }
+            });
+    var protectedCaller =
+        new Thread(
+            () -> {
+              try {
+                monitorHeld.await();
+                storage.stateLock.writeLock().lock();
+                writeModeHeld.countDown();
+                try {
+                  assertProtectedCallRejected(
+                      () -> backend.create(Map.of("value", 2)));
+                  assertProtectedCallRejected(
+                      () -> backend.update(new RecordId(0, 102), 0, Map.of("value", 3)));
+                  assertProtectedCallRejected(
+                      () -> backend.delete(new RecordId(0, 103), 0));
+                  rejectionObserved.countDown();
+                } catch (Throwable throwable) {
+                  failure.compareAndSet(null, throwable);
+                } finally {
+                  storage.stateLock.writeLock().unlock();
+                }
+              } catch (Throwable throwable) {
+                failure.compareAndSet(null, throwable);
+              }
+            });
+    monitorHolder.setDaemon(true);
+    protectedCaller.setDaemon(true);
+    monitorHolder.start();
+    protectedCaller.start();
+
+    assertThat(rejectionObserved.await(10, TimeUnit.SECONDS))
+        .as("the protected caller must reject before monitor acquisition")
+        .isTrue();
+    monitorHolder.join(10_000);
+    protectedCaller.join(10_000);
+    assertThat(monitorHolder.isAlive()).isFalse();
+    assertThat(protectedCaller.isAlive()).isFalse();
+    if (failure.get() != null) {
+      throw new AssertionError("both lifecycle callers must finish", failure.get());
+    }
+  }
+
+  /** Update and delete reject protected reentry before validating a foreign identity. */
+  @Test
+  public void standaloneReentryRejectionPrecedesIdentityValidation() {
+    var storage = (AbstractStorage) db.getStorage();
+    var backend = new IndexBuildStateStorageBackend(storage);
+    var foreignIdentity = new RecordId(0, 100);
+
+    storage.stateLock.readLock().lock();
+    try {
+      assertThatThrownBy(() -> backend.update(foreignIdentity, 0, Map.of()))
+          .isExactlyInstanceOf(StorageStateContextException.class);
+      assertThatThrownBy(() -> backend.delete(foreignIdentity, 0))
+          .isExactlyInstanceOf(StorageStateContextException.class);
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+  }
+
+  /** Standalone create, update, and delete hold state read mode before atomic admission. */
+  @Test(timeout = 30_000)
+  public void standaloneLifecycleWritesAcquireStateLockBeforeAtomicWindow() throws Exception {
+    var storage = (AbstractStorage) db.getStorage();
+    var backend = new IndexBuildStateStorageBackend(storage);
+    var created = backend.create(Map.of("value", 1));
+    var updated = new AtomicReference<IndexBuildStateStore.VersionedRecord>();
+
+    assertStateLockHeldBeforeAtomicAdmission(
+        storage, backend, () -> backend.create(Map.of("value", 2)));
+    assertStateLockHeldBeforeAtomicAdmission(
+        storage,
+        backend,
+        () -> updated.set(
+            backend.update(
+                created.identity(), created.record().version(), Map.of("value", 3))));
+    assertStateLockHeldBeforeAtomicAdmission(
+        storage,
+        backend,
+        () -> backend.delete(created.identity(), updated.get().version()));
+  }
+
+  /** A lifecycle context rejection leaves the storage open for a later valid write. */
+  @Test
+  public void lifecycleContextRejectionDoesNotSetStorageErrorMarker() {
+    var storage = (AbstractStorage) db.getStorage();
+    var backend = new IndexBuildStateStorageBackend(storage);
+    var rejection =
+        org.junit.Assert.assertThrows(
+            StorageStateContextException.class,
+            () -> storage.createInitialIndexLifecycle(new RecordId(0, 101), null, null));
+
+    storage.moveToErrorStateIfNeeded(rejection);
+    var created = backend.create(Map.of("value", 1));
+
+    assertThat(created.identity().isPersistent()).isTrue();
+    assertThat(storage.getStatus().name()).isEqualTo("OPEN");
   }
 
   /** Caller-owned create and update operations persist versions without nested transactions. */
@@ -1345,6 +1640,77 @@ public class AbstractStorageCommitPrimitivesTest {
       engines.set(slot, registered);
       db.rollback();
     }
+  }
+
+  private static void assertProtectedCallRejected(Runnable call) {
+    try {
+      call.run();
+      throw new AssertionError("the protected caller must be rejected");
+    } catch (StorageStateContextException expected) {
+      // Expected before monitor acquisition.
+    }
+  }
+
+  private void assertStateLockHeldBeforeAtomicAdmission(
+      AbstractStorage storage, IndexBuildStateStorageBackend backend, Runnable write)
+      throws Exception {
+    var failure = new AtomicReference<Throwable>();
+    var reachedAtomicAdmission = new CountDownLatch(1);
+    backend.setBeforeAtomicOperationTestHook(reachedAtomicAdmission::countDown);
+    storage.freeze(db, false);
+    var writer =
+        new Thread(
+            () -> {
+              try {
+                write.run();
+              } catch (Throwable throwable) {
+                failure.set(throwable);
+              }
+            });
+    writer.setDaemon(true);
+    writer.start();
+    try {
+      assertThat(reachedAtomicAdmission.await(10, TimeUnit.SECONDS))
+          .as("the standalone writer must reach atomic admission")
+          .isTrue();
+      var competingWriterEntered = storage.stateLock.writeLock().tryLock();
+      if (competingWriterEntered) {
+        storage.stateLock.writeLock().unlock();
+      }
+      assertThat(competingWriterEntered)
+          .as("the standalone writer must hold state read mode while atomic admission waits")
+          .isFalse();
+    } finally {
+      backend.setBeforeAtomicOperationTestHook(null);
+      storage.release(db);
+      writer.join(10_000);
+    }
+    assertThat(writer.isAlive()).isFalse();
+    if (failure.get() != null) {
+      throw new AssertionError("the standalone lifecycle write must finish", failure.get());
+    }
+  }
+
+  private static void createInitialLifecycleInsideAtomicOperation(
+      AbstractStorage storage, RecordId descriptorIdentity) throws IOException {
+    storage
+        .getAtomicOperationsManager()
+        .executeInsideAtomicOperation(
+            operation -> storage.createInitialIndexLifecycle(
+                descriptorIdentity, null, operation));
+  }
+
+  private static void createPrimitiveRecordInsideAtomicOperation(AbstractStorage storage)
+      throws IOException {
+    var collectionId =
+        storage.getCollectionIdByNameWithStateLock(
+            MetadataDefault.INDEX_BUILD_STATE_COLLECTION_NAME);
+    var rid = new ChangeableRecordId(collectionId, RecordIdInternal.COLLECTION_POS_INVALID);
+    storage
+        .getAtomicOperationsManager()
+        .executeInsideAtomicOperation(
+            operation -> storage.createRecordInsideCommitAtomicOperation(
+                operation, rid, new byte[] {1}, RecordBytes.RECORD_TYPE));
   }
 
   private static void assertForwardedFailure(ThrowingCallable call, Throwable failure) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageRecordPrimitiveDirtyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageRecordPrimitiveDirtyTest.java
@@ -1,0 +1,81 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.id.ChangeableRecordId;
+import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
+import com.jetbrains.youtrackdb.internal.core.record.impl.RecordBytes;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Verifies crash-recovery dirty marking for caller-owned record writes on disk storage. */
+public class AbstractStorageRecordPrimitiveDirtyTest {
+
+  private final String dbName = "record-primitive-dirty-" + UUID.randomUUID();
+  private YouTrackDBImpl youTrackDB;
+  private DatabaseSessionEmbedded db;
+
+  @Before
+  public void before() {
+    youTrackDB = DbTestBase.createYTDBManagerAndDb(dbName, DatabaseType.DISK, getClass());
+    db = youTrackDB.open(dbName, "admin", DbTestBase.ADMIN_PASSWORD);
+  }
+
+  @After
+  public void after() {
+    db.close();
+    youTrackDB.close();
+  }
+
+  /** Both creation and update mark clean storage dirty before their page mutations. */
+  @Test
+  public void callerOwnedCreateAndUpdateMarkStorageDirty() throws Exception {
+    var cls = db.createVertexClass("DirtyPrimitiveRecord");
+    var storage = (AbstractStorage) db.getStorage();
+    var rid =
+        new ChangeableRecordId(
+            cls.getCollectionIds()[0], RecordIdInternal.COLLECTION_POS_INVALID);
+
+    storage.clearStorageDirty();
+    assertThat(storage.isDirty()).isFalse();
+
+    long initialVersion;
+    storage.stateLock.readLock().lock();
+    try {
+      initialVersion =
+          storage
+              .getAtomicOperationsManager()
+              .calculateInsideAtomicOperation(
+                  operation -> storage.createRecordInsideAtomicOperation(
+                      operation, rid, new byte[] {1}, RecordBytes.RECORD_TYPE));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+    assertThat(storage.isDirty()).isTrue();
+
+    storage.clearStorageDirty();
+    assertThat(storage.isDirty()).isFalse();
+
+    storage.stateLock.readLock().lock();
+    try {
+      storage
+          .getAtomicOperationsManager()
+          .calculateInsideAtomicOperation(
+              operation -> storage.updateRecordInsideAtomicOperation(
+                  operation,
+                  rid,
+                  new byte[] {2},
+                  initialVersion,
+                  RecordBytes.RECORD_TYPE));
+    } finally {
+      storage.stateLock.readLock().unlock();
+    }
+    assertThat(storage.isDirty()).isTrue();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageSnapshotIndexQueryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageSnapshotIndexQueryTest.java
@@ -8,7 +8,6 @@ import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.InvalidIndexEngineIdException;
 import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import java.util.UUID;
@@ -320,8 +319,8 @@ public class AbstractStorageSnapshotIndexQueryTest {
    */
   private long resolveInternalEngineId(String indexName)
       throws InvalidIndexEngineIdException {
-    var index = (IndexAbstract) db.getSharedContext().getIndexManager().getIndex(indexName);
-    return db.getStorage().getIndexEngine(index.getIndexId()).getId();
+    return com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+        .internalIdentifier(db, indexName);
   }
 
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AtomicOperationIdGenTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AtomicOperationIdGenTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -10,158 +11,112 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link AtomicOperationIdGen}. Pins the three observable behaviours of the
- * monotonic id generator: {@link AtomicOperationIdGen#nextId()} returns strictly increasing
- * values, {@link AtomicOperationIdGen#setStartId(long)} resets the underlying counter so the
- * next {@code nextId()} returns {@code id + 1}, and {@link AtomicOperationIdGen#getLastId()}
- * exposes the last generated id without advancing it. Also exercises monotonic uniqueness
- * under concurrent load, since the class is the source of WAL operation ids and a missed
- * increment would corrupt the WAL ordering.
- */
+/** Tests monotonic generation, recovery-floor installation, concurrency, and exhaustion. */
 public class AtomicOperationIdGenTest {
 
-  /**
-   * A fresh generator starts at 0; the first {@code nextId()} returns 1 and advances the
-   * internal counter. This pins the post-incrementAndGet contract.
-   */
+  /** A fresh generator issues one first and exposes the issued value without advancing it. */
   @Test
-  public void testNextIdStartsAtOne() {
-    var gen = new AtomicOperationIdGen();
+  public void testNextIdStartsAtOneAndLastIdIsPureRead() {
+    final var gen = new AtomicOperationIdGen();
     assertThat(gen.getLastId()).isZero();
-    assertThat(gen.nextId()).isEqualTo(1L);
-    assertThat(gen.getLastId()).isEqualTo(1L);
+    assertThat(gen.nextId()).isEqualTo(1);
+    assertThat(gen.getLastId()).isEqualTo(1);
+    assertThat(gen.getLastId()).isEqualTo(1);
   }
 
-  /**
-   * Repeated {@code nextId()} calls return strictly increasing values (1, 2, 3, ...).
-   */
+  /** Installing a highest-issued floor makes the next identifier strictly greater. */
   @Test
-  public void testNextIdIsStrictlyIncreasing() {
-    var gen = new AtomicOperationIdGen();
-    for (long expected = 1; expected <= 100; expected++) {
-      assertThat(gen.nextId()).isEqualTo(expected);
-    }
-    assertThat(gen.getLastId()).isEqualTo(100L);
+  public void testAdvanceInstallsHighestIssuedFloor() {
+    final var gen = new AtomicOperationIdGen();
+    gen.advanceToAtLeast(42);
+
+    assertThat(gen.getLastId()).isEqualTo(42);
+    assertThat(gen.nextId()).isEqualTo(43);
   }
 
-  /**
-   * After {@code setStartId(N)}, the very next {@code nextId()} returns {@code N + 1} (because
-   * {@code nextId()} is incrementAndGet). Verifies the counter is reset, not adjusted.
-   */
+  /** Reinstalling the current floor is idempotent. */
   @Test
-  public void testSetStartIdResetsCounter() {
-    var gen = new AtomicOperationIdGen();
-    gen.nextId();
-    gen.nextId();
-    gen.nextId();
-    assertThat(gen.getLastId()).isEqualTo(3L);
+  public void testAdvanceToCurrentFloorIsIdempotent() {
+    final var gen = new AtomicOperationIdGen();
+    gen.advanceToAtLeast(7);
+    gen.advanceToAtLeast(7);
 
-    gen.setStartId(42L);
-    assertThat(gen.getLastId()).isEqualTo(42L);
-    assertThat(gen.nextId()).isEqualTo(43L);
-    assertThat(gen.getLastId()).isEqualTo(43L);
+    assertThat(gen.getLastId()).isEqualTo(7);
   }
 
-  /**
-   * {@code setStartId} accepts the same value as the current last id (idempotent reset).
-   */
+  /** A lower or negative recovery floor is rejected and cannot alter the current value. */
   @Test
-  public void testSetStartIdToCurrent() {
-    var gen = new AtomicOperationIdGen();
-    gen.nextId();
-    gen.nextId();
-    long current = gen.getLastId();
+  public void testAdvanceRejectsRewindAndNegativeFloor() {
+    final var gen = new AtomicOperationIdGen();
+    gen.advanceToAtLeast(10);
 
-    gen.setStartId(current);
-    assertThat(gen.getLastId()).isEqualTo(current);
-    assertThat(gen.nextId()).isEqualTo(current + 1);
+    assertThatThrownBy(() -> gen.advanceToAtLeast(9))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("rewind");
+    assertThatThrownBy(() -> gen.advanceToAtLeast(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThat(gen.getLastId()).isEqualTo(10);
   }
 
-  /**
-   * {@code setStartId} accepts arbitrary values, including a value lower than the current id
-   * (e.g., during WAL restore the id is re-seeded to the last persisted operation id).
-   */
+  /** Exhausting the signed range fails closed instead of wrapping into negative identifiers. */
   @Test
-  public void testSetStartIdCanRewindForWalRestore() {
-    var gen = new AtomicOperationIdGen();
-    for (int i = 0; i < 1000; i++) {
-      gen.nextId();
-    }
-    assertThat(gen.getLastId()).isEqualTo(1000L);
+  public void testNextIdRejectsOverflow() {
+    final var gen = new AtomicOperationIdGen();
+    gen.advanceToAtLeast(Long.MAX_VALUE);
 
-    // Simulate WAL restore: seed the gen to a smaller value.
-    gen.setStartId(7L);
-    assertThat(gen.getLastId()).isEqualTo(7L);
-    assertThat(gen.nextId()).isEqualTo(8L);
+    assertThatThrownBy(gen::nextId)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("exhausted");
+    assertThat(gen.getLastId()).isEqualTo(Long.MAX_VALUE);
   }
 
-  /**
-   * {@code getLastId} must be a pure read — it must not advance the counter.
-   */
-  @Test
-  public void testGetLastIdDoesNotAdvance() {
-    var gen = new AtomicOperationIdGen();
-    gen.nextId();
-    long before = gen.getLastId();
-    long secondRead = gen.getLastId();
-    assertThat(secondRead).isEqualTo(before);
-    assertThat(gen.nextId()).isEqualTo(before + 1);
-  }
-
-  /**
-   * Concurrent {@code nextId()} calls from multiple threads must produce strictly unique ids
-   * because the WAL ordering depends on it. Total expected ids: {@code threads * iterations}.
-   */
+  /** Concurrent callers receive one unique, gap-free range of logical identifiers. */
   @Test
   public void testNextIdIsUniqueUnderConcurrency() throws Exception {
-    int threads = 8;
-    int iterations = 5_000;
-    var gen = new AtomicOperationIdGen();
-    var barrier = new CyclicBarrier(threads);
-    var done = new CountDownLatch(threads);
-    var error = new AtomicReference<Throwable>();
-    var allIds = new ArrayList<long[]>(threads);
+    final int threads = 8;
+    final int iterations = 5_000;
+    final var gen = new AtomicOperationIdGen();
+    final var barrier = new CyclicBarrier(threads);
+    final var done = new CountDownLatch(threads);
+    final var error = new AtomicReference<Throwable>();
+    final var allIds = new ArrayList<long[]>(threads);
     for (int i = 0; i < threads; i++) {
       allIds.add(new long[iterations]);
     }
 
-    var workers = new ArrayList<Thread>(threads);
-    for (int t = 0; t < threads; t++) {
-      int idx = t;
-      var thread = new Thread(() -> {
-        try {
-          var local = allIds.get(idx);
-          barrier.await();
-          for (int i = 0; i < iterations; i++) {
-            local[i] = gen.nextId();
-          }
-        } catch (Throwable th) {
-          error.compareAndSet(null, th);
-        } finally {
-          done.countDown();
-        }
-      });
+    for (int threadIndex = 0; threadIndex < threads; threadIndex++) {
+      final int index = threadIndex;
+      final var thread =
+          new Thread(
+              () -> {
+                try {
+                  final var local = allIds.get(index);
+                  barrier.await();
+                  for (int i = 0; i < iterations; i++) {
+                    local[i] = gen.nextId();
+                  }
+                } catch (Throwable failure) {
+                  error.compareAndSet(null, failure);
+                } finally {
+                  done.countDown();
+                }
+              });
       thread.setDaemon(true);
-      workers.add(thread);
+      thread.start();
     }
-    workers.forEach(Thread::start);
-    assertThat(done.await(30, TimeUnit.SECONDS))
-        .as("all generator threads finish within 30s")
-        .isTrue();
+
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
     if (error.get() != null) {
       throw new AssertionError(error.get());
     }
 
-    // Collect into a set; total unique ids must equal threads * iterations.
-    var seen = new HashSet<Long>(threads * iterations);
-    for (var arr : allIds) {
-      for (long id : arr) {
-        seen.add(id);
+    final var seen = new HashSet<Long>(threads * iterations);
+    for (var identifiers : allIds) {
+      for (long identifier : identifiers) {
+        seen.add(identifier);
       }
     }
     assertThat(seen).hasSize(threads * iterations);
-    // Final getLastId must match the highest id observed.
     assertThat(gen.getLastId()).isEqualTo(threads * iterations);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/ClearIndexApiRollbackTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/ClearIndexApiRollbackTest.java
@@ -10,7 +10,6 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexHistogramManager;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -221,10 +220,8 @@ public class ClearIndexApiRollbackTest {
    */
   private static int getExternalIndexId(
       DatabaseSessionEmbedded session, String indexName) throws Exception {
-    var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-    var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-    indexIdField.setAccessible(true);
-    return indexIdField.getInt(idx);
+    return com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+        .externalIdentifier(session, indexName);
   }
 
   /**
@@ -236,9 +233,8 @@ public class ClearIndexApiRollbackTest {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class.getMethod("getIndexEngine", int.class);
       return (BTreeIndexEngine) getEngineMethod.invoke(storage, indexId);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
@@ -677,7 +677,7 @@ public class IndexEngineFileBaseIdTest {
           .getIndex("FbiDRFIdx");
       assertEquals("the restored engine must be bound to its descriptor owner",
           restoredIndex.getIndexId(),
-          storage.resolveIndexEngineByOwner(restoredIndex.getIdentity()));
+          storage.resolveIndexEngineByOwner(restoredIndex.getIdentity()).engineIdentifier());
 
       // The invariant bar: the index is still fully usable after the failed commit.
       session.executeInTx(tx -> tx.newEntity("FbiDropRecreateFail").setProperty("val", "alive"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
@@ -15,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
+import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -672,6 +673,11 @@ public class IndexEngineFileBaseIdTest {
           oldFileBaseId, restored.getFileBaseId());
       assertTrue("the in-memory registry must still resolve the old engine",
           storage.loadIndexEngine("FbiDRFIdx") >= 0);
+      var restoredIndex = (IndexAbstract) session.getSharedContext().getIndexManager()
+          .getIndex("FbiDRFIdx");
+      assertEquals("the restored engine must be bound to its descriptor owner",
+          restoredIndex.getIndexId(),
+          storage.resolveIndexEngineByOwner(restoredIndex.getIdentity()));
 
       // The invariant bar: the index is still fully usable after the failed commit.
       session.executeInTx(tx -> tx.newEntity("FbiDropRecreateFail").setProperty("val", "alive"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/IndexEngineFileBaseIdTest.java
@@ -15,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
 import com.jetbrains.youtrackdb.internal.core.exception.ConfigurationException;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
 import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -461,9 +462,12 @@ public class IndexEngineFileBaseIdTest {
   }
 
   /**
-   * The storage-format gate rejects a pre-24 database at open — before any engine or collection
-   * component touches its files — with the export/import redirect message, mirroring the schema
-   * record's reject-and-redirect policy.
+   * Scenario: a database whose storage configuration carries storage layout version 23 opens,
+   * while the bootstrap authority record carries the supported version 24.
+   *
+   * <p>Expected outcome: the later layout check reports the named inconsistent-metadata result
+   * with the storage layout version value. The check runs before any engine or collection
+   * component touches its files. The report keeps the export and reimport guidance.
    */
   @Test
   public void preCurrentFormatIsRejectedAtOpenWithExportRedirect() throws Exception {
@@ -472,17 +476,40 @@ public class IndexEngineFileBaseIdTest {
 
     try {
       ytdb.open(dbName, ADMIN, PWD);
-      fail("opening a version-23 database must be rejected by the storage-format gate");
+      fail("opening a version-23 database must report the inconsistent-metadata result");
     } catch (final Exception e) {
-      assertMessageChainContains(e, "predates the current format");
-      assertMessageChainContains(e, "please export your old database");
+      assertLayoutVersionInconsistency(e);
+      assertMessageChainContains(e, "The storage configuration reports storage layout version 23");
+      assertMessageChainContains(e, "with the earlier version of YouTrackDB");
     }
   }
 
   /**
-   * The gate also enforces a forward ceiling: a database written by a newer format is rejected
-   * with a distinct message directing the user to a matching YouTrackDB version, instead of
-   * misparsing entries whose layout these binaries cannot know.
+   * Finds the named inconsistent-metadata result inside one failure chain and asserts the storage
+   * layout version value of that result.
+   */
+  private static void assertLayoutVersionInconsistency(final Throwable failure) {
+    InconsistentStorageMetadataException result = null;
+    for (var current = failure; current != null; current = current.getCause()) {
+      if (current instanceof InconsistentStorageMetadataException inconsistency) {
+        result = inconsistency;
+        break;
+      }
+    }
+    assertNotNull("the failure must carry the inconsistent-metadata result, saw: " + failure,
+        result);
+    assertEquals("the result must name the storage layout version source",
+        InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+        result.inconsistency());
+  }
+
+  /**
+   * Scenario: a database whose storage configuration carries storage layout version 25 opens,
+   * while the bootstrap authority record carries the supported version 24.
+   *
+   * <p>Expected outcome: the later layout check reports the named inconsistent-metadata result
+   * with the storage layout version value. The message directs the operator to the matching
+   * YouTrackDB version instead of misparsing an unknown layout.
    */
   @Test
   public void newerFormatIsRejectedAtOpenWithCeilingMessage() throws Exception {
@@ -491,10 +518,11 @@ public class IndexEngineFileBaseIdTest {
 
     try {
       ytdb.open(dbName, ADMIN, PWD);
-      fail("opening a version-25 database must be rejected by the storage-format gate");
+      fail("opening a version-25 database must report the inconsistent-metadata result");
     } catch (final Exception e) {
-      assertMessageChainContains(e, "is newer than the format this version of YouTrackDB"
-          + " supports");
+      assertLayoutVersionInconsistency(e);
+      assertMessageChainContains(e, "The storage configuration reports storage layout version 25");
+      assertMessageChainContains(e, "newer than the layout of this build");
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/MainCommitCounterSyncTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/MainCommitCounterSyncTest.java
@@ -7,7 +7,6 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
-import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -276,9 +275,8 @@ public class MainCommitCounterSyncTest {
       DatabaseSessionEmbedded session, String indexName) {
     try {
       var idx = session.getSharedContext().getIndexManager().getIndex(indexName);
-      var indexIdField = IndexAbstract.class.getDeclaredField("indexId");
-      indexIdField.setAccessible(true);
-      int indexId = indexIdField.getInt(idx);
+      int indexId = com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+          .externalIdentifier(idx);
       var storage = (AbstractStorage) session.getStorage();
       var getEngineMethod = AbstractStorage.class.getMethod("getIndexEngine", int.class);
       return (BTreeIndexEngine) getEngineMethod.invoke(storage, indexId);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/MetadataConsistencyCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/MetadataConsistencyCheckTest.java
@@ -1,0 +1,235 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBInternalEmbedded;
+import com.jetbrains.youtrackdb.internal.core.exception.InconsistentStorageMetadataException;
+import com.jetbrains.youtrackdb.internal.core.storage.config.CollectionBasedStorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the two later consistency checks of Track 24.
+ *
+ * <p>A storage is one physical database image on disk. Storage admission is the decision that
+ * accepts an existing storage image for use. Admission runs before recovery. Recovery is the
+ * replay of write-ahead log content into the storage files.
+ *
+ * <p>A consistency check is a later check that compares two durable sources without deciding
+ * admission. The first later check compares the storage layout version of the storage
+ * configuration against the storage layout version of the bootstrap authority record. The second
+ * later check compares the accepted lifecycle state against the genesis marker. Genesis is the
+ * creation of the initial database metadata. The genesis marker is the durable value that records
+ * a finished genesis.
+ *
+ * <p>Each test of this class states one scenario and one expected outcome in its own comment.
+ */
+public class MetadataConsistencyCheckTest {
+
+  private static final String ADMIN = "admin";
+  private static final String PASSWORD = "adminpwd";
+  private static final FeatureFormatIdentity FEATURE_FORMAT = new FeatureFormatIdentity(1);
+
+  private Path root;
+  private Path databasesPath;
+  private YouTrackDBImpl youTrackDB;
+
+  @Before
+  public void createDirectories() throws Exception {
+    root = Files.createTempDirectory("metadata-consistency-");
+    databasesPath = Files.createDirectories(root.resolve("databases"));
+    youTrackDB = openContext();
+  }
+
+  @After
+  public void deleteDirectories() {
+    if (youTrackDB != null && youTrackDB.isOpen()) {
+      youTrackDB.close();
+    }
+    FileUtils.deleteRecursively(root.toFile());
+  }
+
+  /**
+   * Scenario: the storage configuration of an accepted image reports a storage layout version of
+   * an earlier build, while the bootstrap authority record reports the supported version.
+   *
+   * <p>Expected outcome has three parts. The open reports the named inconsistent-metadata result
+   * with the storage layout version value. The open leaves no registered storage, so the storage
+   * stays closed for the caller. The bootstrap authority record still holds the active lifecycle
+   * state, so the check never reverses the admission decision.
+   */
+  @Test
+  public void layoutVersionInconsistencyKeepsTheStorageClosedAndKeepsAdmissionAccepting()
+      throws Exception {
+    var databaseName = "layoutInconsistent";
+    createDatabaseWithTamperedLayoutVersion(databaseName, 23);
+
+    var failure = openAndExpectFailure(databaseName);
+    assertEquals("the check must name the storage layout version source",
+        InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+        inconsistencyOf(failure).inconsistency());
+    assertNull("the refused image must leave no registered storage",
+        internal().getStorage(databaseName));
+    assertNull("the admission decision must stay an acceptance",
+        admissionReasonOf(databaseName));
+
+    // A second open repeats the same result, which proves that the first report changed nothing.
+    var secondFailure = openAndExpectFailure(databaseName);
+    assertEquals("the repeated open must report the same result",
+        InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+        inconsistencyOf(secondFailure).inconsistency());
+  }
+
+  /**
+   * Scenario: an accepted image carries no genesis marker, while the bootstrap authority record
+   * holds the active lifecycle state.
+   *
+   * <p>Expected outcome has three parts. The open reports the named inconsistent-metadata result
+   * with the genesis marker value. The open leaves no registered storage. The bootstrap authority
+   * record still holds the active lifecycle state.
+   */
+  @Test
+  public void genesisMarkerInconsistencyKeepsTheStorageClosedAndKeepsAdmissionAccepting() {
+    var databaseName = "genesisInconsistent";
+    createDatabaseWithoutGenesisMarker(databaseName);
+
+    var failure = openAndExpectFailure(databaseName);
+    assertEquals("the check must name the genesis marker source",
+        InconsistentStorageMetadataException.Inconsistency.GENESIS_MARKER,
+        inconsistencyOf(failure).inconsistency());
+    assertTrue("the message must name both disagreeing sources",
+        messageChainOf(failure).contains("reports the active lifecycle state")
+            && messageChainOf(failure).contains("genesis-completion marker"));
+    assertNull("the refused image must leave no registered storage",
+        internal().getStorage(databaseName));
+    assertNull("the admission decision must stay an acceptance",
+        admissionReasonOf(databaseName));
+  }
+
+  /**
+   * Scenario: an operator drops an image whose genesis marker is absent, and an operator drops an
+   * image whose storage layout version disagrees with the bootstrap authority record.
+   *
+   * <p>Expected outcome: the drop of the genesis marker case reports success, because the drop
+   * tolerates that result. The drop of the storage layout version case stays loud and still
+   * deletes the image, because an operator must see a layout version mismatch.
+   */
+  @Test
+  public void dropToleratesTheGenesisMarkerResultAndStaysLoudForTheLayoutVersionResult()
+      throws Exception {
+    var markerLess = "genesisDiscard";
+    createDatabaseWithoutGenesisMarker(markerLess);
+    youTrackDB.drop(markerLess);
+    assertFalse("the drop must discard the marker-less image", youTrackDB.exists(markerLess));
+
+    var oldLayout = "layoutDiscard";
+    createDatabaseWithTamperedLayoutVersion(oldLayout, 23);
+    try {
+      youTrackDB.drop(oldLayout);
+      fail("the drop must stay loud for the storage layout version result");
+    } catch (RuntimeException expected) {
+      assertEquals("the loud drop must carry the storage layout version value",
+          InconsistentStorageMetadataException.Inconsistency.STORAGE_LAYOUT_VERSION,
+          inconsistencyOf(expected).inconsistency());
+    }
+    assertFalse("the loud drop must still delete the image", youTrackDB.exists(oldLayout));
+  }
+
+  /** Creates a disk database and rewrites the storage layout version of its configuration. */
+  private void createDatabaseWithTamperedLayoutVersion(String databaseName, int layoutVersion)
+      throws Exception {
+    youTrackDB.create(databaseName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+    try (var session = (DatabaseSessionEmbedded) youTrackDB.open(databaseName, ADMIN, PASSWORD)) {
+      var storage = (AbstractStorage) session.getStorage();
+      var configuration = (CollectionBasedStorageConfiguration) storage.configuration;
+      storage.getAtomicOperationsManager().executeInsideAtomicOperation(
+          operation -> configuration.updateVersionForTesting(operation, layoutVersion));
+    }
+    reopenContext();
+  }
+
+  /** Creates a disk database and removes the genesis marker of that database. */
+  private void createDatabaseWithoutGenesisMarker(String databaseName) {
+    youTrackDB.create(databaseName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+    internal().getStorage(databaseName)
+        .setProperty(SharedContext.GENESIS_COMPLETED_PROPERTY, "false");
+    reopenContext();
+  }
+
+  /** Opens one database and returns the failure of that open. */
+  private RuntimeException openAndExpectFailure(String databaseName) {
+    try {
+      youTrackDB.open(databaseName, ADMIN, PASSWORD).close();
+      throw new AssertionError("the open of database " + databaseName + " must fail");
+    } catch (RuntimeException failure) {
+      return failure;
+    }
+  }
+
+  /** Returns the named inconsistent-metadata result inside one failure chain. */
+  private static InconsistentStorageMetadataException inconsistencyOf(Throwable failure) {
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof InconsistentStorageMetadataException result) {
+        return result;
+      }
+    }
+    throw new AssertionError("the failure must carry the inconsistent-metadata result", failure);
+  }
+
+  /** Joins every message of one failure chain. */
+  private static String messageChainOf(Throwable failure) {
+    var builder = new StringBuilder();
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      builder.append(cause.getMessage()).append('\n');
+    }
+    return builder.toString();
+  }
+
+  /** Returns the admission reason of one database directory, or null for an accepted image. */
+  private StorageAdmissionException.Reason admissionReasonOf(String databaseName) {
+    try {
+      new StorageBootstrapMetadata(databasesPath.resolve(databaseName), FEATURE_FORMAT)
+          .readActiveRequired();
+      return null;
+    } catch (StorageAdmissionException rejection) {
+      return rejection.reason();
+    } catch (IOException failure) {
+      throw new UncheckedIOException(failure);
+    }
+  }
+
+  private YouTrackDBInternalEmbedded internal() {
+    return (YouTrackDBInternalEmbedded) youTrackDB.internal;
+  }
+
+  private YouTrackDBImpl openContext() {
+    var context = (YouTrackDBImpl) YourTracks.instance(databasesPath.toString());
+    assertNotNull("the test needs one open context", context);
+    return context;
+  }
+
+  /** Closes the context and opens a fresh context, so the next open reads every value again. */
+  private void reopenContext() {
+    youTrackDB.close();
+    youTrackDB = openContext();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/RestoreLifecycleTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/RestoreLifecycleTest.java
@@ -1,0 +1,1261 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YouTrackDB;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseLifecycleListener;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBInternalEmbedded;
+import com.jetbrains.youtrackdb.internal.core.storage.config.CollectionBasedStorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.FeatureFormatIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageBootstrapMetadata;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Covers the restore order and the destructive restart entry of Track 24.
+ *
+ * <p>Restore creates the restore target without genesis and without activation. Genesis is the
+ * creation of the initial database metadata. Genesis creates the schema, the index manager, the
+ * index statistics, and the default users. A destructive restart is the full deletion of an
+ * interrupted restore target and a fresh restore of the same backup.
+ *
+ * <p>Storage admission is the decision that accepts an existing storage image for use. Admission
+ * reports one named reason for every rejected image. The lifecycle state of a restore target is
+ * therefore observable through the admission reason of that target.
+ *
+ * <p>Each test of this class states one scenario and one expected outcome in its own comment.
+ */
+public class RestoreLifecycleTest {
+
+  private static final String ADMIN = "admin";
+  private static final String PASSWORD = "adminpwd";
+  private static final String RECORD_CLASS = "RestoredClass";
+  private static final String SOURCE = "restoreSource";
+  private static final String TARGET = "restoreTarget";
+  private static final FeatureFormatIdentity FEATURE_FORMAT = new FeatureFormatIdentity(1);
+
+  private Path root;
+  private Path databasesPath;
+  private Path backupPath;
+  private Path emptyBackupPath;
+
+  @Before
+  public void createDirectories() throws Exception {
+    root = Files.createTempDirectory("restore-lifecycle-");
+    databasesPath = Files.createDirectories(root.resolve("databases"));
+    backupPath = Files.createDirectories(root.resolve("backup"));
+    emptyBackupPath = Files.createDirectories(root.resolve("empty-backup"));
+  }
+
+  @After
+  public void deleteDirectories() {
+    FileUtils.deleteRecursively(root.toFile());
+  }
+
+  /**
+   * The restore target carries the restore-in-progress state before any content write.
+   *
+   * <p>The scenario probes the admission reason of the target from inside the read of every backup
+   * file. The expected outcome has three parts. Every probe before the content copy reports the
+   * interrupted-restore reason, which proves the restore-in-progress lifecycle state. The finished
+   * restore leaves an accepted image, which proves the active lifecycle state. The restored
+   * database opens and carries the content of the backup.
+   */
+  @Test
+  public void restoreTargetCarriesRestoreStateBeforeContentAndActiveStateAfterward()
+      throws Exception {
+    createSourceDatabaseAndBackup();
+    var observedReasons = new ArrayList<StorageAdmissionException.Reason>();
+
+    try (var youTrackDB = openManager()) {
+      internalOf(youTrackDB).restore(
+          TARGET,
+          this::backupFileNames,
+          fileName -> {
+            observedReasons.add(admissionReasonOf(TARGET));
+            return openBackupFile(fileName);
+          },
+          null,
+          null);
+
+      assertFalse("the restore must read at least one backup file", observedReasons.isEmpty());
+      for (var reason : observedReasons) {
+        assertEquals(
+            "the target must carry the restore-in-progress state before the content copy",
+            StorageAdmissionException.Reason.INTERRUPTED_RESTORE,
+            reason);
+      }
+      assertNull(
+          "the finished restore must publish the active lifecycle state",
+          admissionReasonOf(TARGET));
+    }
+
+    try (var youTrackDB = openManager();
+        var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+      assertTrue(
+          "the restored database must carry the content of the backup",
+          session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+    }
+  }
+
+  /**
+   * A restore without any backup content leaves a target in the restore-in-progress state.
+   *
+   * <p>The scenario restores from an empty backup directory, which interrupts the restore before
+   * the first content write. The expected outcome has three parts. The restore reports a failure.
+   * The target stays visible and reports the interrupted-restore reason. An open of the target
+   * repeats that same rejection.
+   */
+  @Test
+  public void restoreWithoutBackupContentLeavesRestoreInProgressTarget() throws Exception {
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+
+      assertTrue("the interrupted restore target must stay visible", youTrackDB.exists(TARGET));
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE, admissionReasonOf(TARGET));
+      var openFailure =
+          assertThrows(RuntimeException.class, () -> youTrackDB.open(TARGET, ADMIN, PASSWORD));
+      assertEquals(
+          "an open must reject the interrupted restore target",
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE,
+          admissionReason(openFailure));
+    }
+  }
+
+  /**
+   * A restore interrupted inside the content read leaves a target in the restore-in-progress
+   * state.
+   *
+   * <p>The scenario truncates the stream of every backup file, which interrupts the restore during
+   * the content stage. The expected outcome has two parts. The restore reports a failure. The
+   * target reports the interrupted-restore reason.
+   */
+  @Test
+  public void restoreInterruptedInsideContentLeavesRestoreInProgressTarget() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(
+              TARGET,
+              this::backupFileNames,
+              this::openTruncatedBackupFile,
+              null,
+              null));
+
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE, admissionReasonOf(TARGET));
+    }
+  }
+
+  /**
+   * A backup without a set genesis marker never reaches the active lifecycle state.
+   *
+   * <p>The genesis marker is the durable property that records a finished genesis. The scenario
+   * clears that marker in the source database, takes a backup, and restores that backup. The
+   * content copy therefore succeeds and only the validation fails. The expected outcome has three
+   * parts. The restore names the missing genesis marker. The target reports the interrupted-restore
+   * reason, so no target reaches the active state before the validation passes. A drop discards
+   * the target and reports success.
+   */
+  @Test
+  public void restoreOfContentWithoutGenesisMarkerNeverReachesActiveState() throws Exception {
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      storageOf(youTrackDB, SOURCE).setProperty(SharedContext.GENESIS_COMPLETED_PROPERTY, "false");
+      storageOf(youTrackDB, SOURCE).fullBackup(backupPath);
+    }
+
+    try (var youTrackDB = openManager()) {
+      var failure =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB).restore(TARGET, backupPath.toString(), null, null));
+
+      assertTrue(
+          "the failure must name the missing genesis completion marker, saw: "
+              + rootMessage(failure),
+          rootMessage(failure).contains("no genesis completion marker"));
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE, admissionReasonOf(TARGET));
+
+      youTrackDB.drop(TARGET);
+      assertFalse("the drop must discard the interrupted restore target",
+          youTrackDB.exists(TARGET));
+    }
+  }
+
+  /**
+   * A backup of an unsupported storage layout version stays discardable.
+   *
+   * <p>The storage layout version is the version of the on-disk storage layout. The scenario
+   * rewrites that version in the source database, takes a backup, and restores that backup. The
+   * expected outcome has four parts. The restore reports a failure. The destructive restart
+   * repeats that same failure and names the disagreeing storage layout versions, so the restart
+   * alone cannot clear the target. The refused restart leaves the restore-in-progress state. A
+   * drop discards the target and reports success.
+   *
+   * <p>The reachable refusal comes from the layout consistency check of the configuration load.
+   * That load runs inside the restore, before the restore validation of the restored content.
+   */
+  @Test
+  public void restoreOfUnsupportedStorageLayoutVersionStaysDiscardable() throws Exception {
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      var storage = storageOf(youTrackDB, SOURCE);
+      var configuration = (CollectionBasedStorageConfiguration) storage.configuration;
+      storage.getAtomicOperationsManager().executeInsideAtomicOperation(
+          atomicOperation -> configuration.updateVersionForTesting(atomicOperation, 23));
+      storage.fullBackup(backupPath);
+    }
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, backupPath.toString(), null, null));
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE, admissionReasonOf(TARGET));
+
+      var restartFailure =
+          assertThrows(
+              "the destructive restart must repeat the failure of the unusable backup",
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(TARGET, backupPath.toString(), null, null));
+      assertTrue(
+          "the restart must name the unsupported layout version of the backup, saw: "
+              + rootMessage(restartFailure),
+          rootMessage(restartFailure)
+              .contains("The storage configuration reports storage layout version 23"));
+      assertEquals(
+          "the repeated restart must leave the restore-in-progress state",
+          StorageAdmissionException.Reason.INTERRUPTED_RESTORE,
+          admissionReasonOf(TARGET));
+
+      youTrackDB.drop(TARGET);
+      assertFalse("the drop must discard the unusable restore target", youTrackDB.exists(TARGET));
+    }
+  }
+
+  /**
+   * The destructive restart deletes an interrupted restore target and restores the backup.
+   *
+   * <p>The scenario interrupts one restore and then restarts that restore with a complete backup.
+   * The expected outcome has two parts. The restart leaves an accepted image, which proves the
+   * active lifecycle state. The restarted database opens and carries the content of the backup.
+   */
+  @Test
+  public void restartDeletesInterruptedTargetAndRestoresTheBackup() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+
+      internalOf(youTrackDB).restartInterruptedRestore(TARGET, backupPath.toString(), null, null);
+
+      assertNull("the restart must publish the active lifecycle state", admissionReasonOf(TARGET));
+      try (var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the restarted database must carry the content of the backup",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart refuses a healthy database and deletes nothing.
+   *
+   * <p>The scenario restarts the restore of a healthy database. The expected outcome has two
+   * parts. The restart names the reason for a target that is no interrupted restore. The healthy
+   * database still opens and still carries its own content.
+   */
+  @Test
+  public void restartRefusesHealthyDatabaseAndKeepsEveryFile() throws Exception {
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      storageOf(youTrackDB, SOURCE).fullBackup(backupPath);
+
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(SOURCE, backupPath.toString(), null, null));
+
+      assertEquals(
+          "the restart must refuse an active target by name",
+          StorageAdmissionException.Reason.RESTART_TARGET_NOT_RESTORE_IN_PROGRESS,
+          admissionReason(refusal));
+      try (var session = youTrackDB.open(SOURCE, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the refused database must keep its own content",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart refuses an interrupted storage birth and deletes nothing.
+   *
+   * <p>The scenario publishes one birth record without any further creation step, which is the
+   * residue of an interrupted creation. The expected outcome has two parts. The restart names the
+   * interrupted-birth reason, which a drop tolerates. The bootstrap authority artifact survives
+   * the refusal.
+   */
+  @Test
+  public void restartRefusesInterruptedBirthTarget() throws Exception {
+    createSourceDatabaseAndBackup();
+    var birthDirectory = Files.createDirectories(databasesPath.resolve("birthResidue"));
+    new StorageBootstrapMetadata(birthDirectory, FEATURE_FORMAT)
+        .createBirth(StorageIdentity.random(), StorageLineageIdentity.random());
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(
+                      "birthResidue", backupPath.toString(), null, null));
+
+      assertEquals(
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH, admissionReason(refusal));
+      assertFalse(
+          "the refused image must keep its bootstrap authority artifact",
+          bootstrapArtifactNames(birthDirectory).isEmpty());
+    }
+  }
+
+  /**
+   * The destructive restart accepts the residue of a crash inside an earlier restart deletion.
+   *
+   * <p>The deletion of a restart removes every content file first and every authority copy last,
+   * and the deletion keeps the authority lock file. A crash in the tail of that deletion
+   * therefore leaves one directory whose only entry is the authority lock file. The scenario
+   * builds exactly that shape. The expected outcome has two parts. The restart accepts that
+   * residue. The restarted database opens and carries the content of the backup.
+   */
+  @Test
+  public void restartAcceptsResidueOfInterruptedDeletion() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+    }
+    deleteEveryEntryExceptTheAuthorityLockFile(databasesPath.resolve(TARGET));
+
+    try (var youTrackDB = openManager()) {
+      internalOf(youTrackDB).restartInterruptedRestore(TARGET, backupPath.toString(), null, null);
+
+      assertNull("the restart must publish the active lifecycle state", admissionReasonOf(TARGET));
+      try (var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the restarted database must carry the content of the backup",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart refuses a directory without any bootstrap authority artifact.
+   *
+   * <p>A bootstrap authority record names one storage identity, one storage lineage, and one
+   * lifecycle state. A database of an earlier format holds real content and no such record. The
+   * scenario names such a directory in a restart. The expected outcome has three parts. The
+   * restart refuses the target with the missing-record reason. Every content file survives the
+   * refusal. The refusal creates no bootstrap authority artifact.
+   */
+  @Test
+  public void restartRefusesDirectoryWithoutAuthorityRecordAndKeepsEveryFile() throws Exception {
+    createSourceDatabaseAndBackup();
+    var earlierFormatDirectory = Files.createDirectories(databasesPath.resolve("earlierFormat"));
+    Files.writeString(earlierFormatDirectory.resolve("database.ocf"), "payload");
+    Files.writeString(earlierFormatDirectory.resolve("config.bd"), "payload");
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(
+                      "earlierFormat", backupPath.toString(), null, null));
+
+      assertEquals(
+          "the restart must refuse a target without any readable authority record",
+          StorageAdmissionException.Reason.AUTHORITY_MISSING,
+          admissionReason(refusal));
+    }
+
+    assertEquals(
+        "the refused directory must keep every file",
+        List.of("config.bd", "database.ocf"),
+        entryNames(earlierFormatDirectory));
+  }
+
+  /**
+   * The destructive restart refuses a directory that holds content and one authority lock file.
+   *
+   * <p>The authority lock file is the durable file that gives mutual exclusion over the authority
+   * copies. A directory that holds that lock file and content files carries no readable authority
+   * record, so the directory can hold a database of an earlier format. The scenario names such a
+   * directory in a restart. The expected outcome has two parts. The restart refuses the target
+   * with the interrupted-birth reason. Every content file survives the refusal.
+   */
+  @Test
+  public void restartRefusesContentWithLockFileAndKeepsEveryFile() throws Exception {
+    createSourceDatabaseAndBackup();
+    var residueDirectory = Files.createDirectories(databasesPath.resolve("lockedResidue"));
+    Files.writeString(residueDirectory.resolve("database.ocf"), "payload");
+    Files.createFile(residueDirectory.resolve("storage-bootstrap.bsml"));
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore("lockedResidue", backupPath.toString(), null, null));
+
+      assertEquals(
+          "the restart must refuse content without any readable authority record",
+          StorageAdmissionException.Reason.INTERRUPTED_BIRTH,
+          admissionReason(refusal));
+    }
+
+    assertEquals(
+        "the refused directory must keep every file",
+        List.of("database.ocf", "storage-bootstrap.bsml"),
+        entryNames(residueDirectory));
+  }
+
+  /**
+   * The destructive restart refuses a database name that escapes the databases directory.
+   *
+   * <p>The name of a single dot resolves to the databases directory itself. A deletion of that
+   * target would destroy every database of the manager. The scenario names a single dot and a
+   * double dot in two restarts. The expected outcome has two parts. Both restarts refuse the
+   * name. The database directory of the source database survives both refusals.
+   */
+  @Test
+  public void restartRefusesPathEscapingNameAndKeepsEveryDatabase() throws Exception {
+    createSourceDatabaseAndBackup();
+    var sourceEntriesBeforeRestart = entryNames(databasesPath.resolve(SOURCE));
+    assertFalse("the source database must hold files", sourceEntriesBeforeRestart.isEmpty());
+
+    try (var youTrackDB = openManager()) {
+      for (var escapingName : List.of(".", "..")) {
+        var refusal =
+            assertThrows(
+                "the restart must refuse the escaping name " + escapingName,
+                RuntimeException.class,
+                () -> internalOf(youTrackDB)
+                    .restartInterruptedRestore(escapingName, backupPath.toString(), null, null));
+        assertTrue(
+            "the refusal must name the invalid database name, saw: " + rootMessage(refusal),
+            rootMessage(refusal).contains("Invalid database name"));
+      }
+    }
+
+    assertTrue("the databases directory must survive", Files.isDirectory(databasesPath));
+    assertEquals(
+        "the source database must keep every file",
+        sourceEntriesBeforeRestart,
+        entryNames(databasesPath.resolve(SOURCE)));
+  }
+
+  /**
+   * The destructive restart refuses a reserved name prefix before any deletion.
+   *
+   * <p>The two reserved prefixes are the prefix for graph traversal names and the prefix for
+   * server names. Both name checks of the restart use one lower-case rule, so an upper-case
+   * spelling reaches the same refusal. The scenario names a directory with an upper-case reserved
+   * prefix. The expected outcome has two parts. The restart refuses the name. The content file of
+   * that directory survives the refusal.
+   */
+  @Test
+  public void restartRefusesReservedNamePrefixBeforeAnyDeletion() throws Exception {
+    createSourceDatabaseAndBackup();
+    var reservedDirectory = Files.createDirectories(databasesPath.resolve("SERVERtarget"));
+    Files.writeString(reservedDirectory.resolve("database.ocf"), "payload");
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore("SERVERtarget", backupPath.toString(), null, null));
+
+      assertTrue(
+          "the refusal must name the reserved prefix, saw: " + rootMessage(refusal),
+          rootMessage(refusal).contains("server"));
+    }
+
+    assertEquals(
+        "the refused directory must keep every file",
+        List.of("database.ocf"),
+        entryNames(reservedDirectory));
+  }
+
+  /**
+   * A refused destructive restart keeps every live session of the named database.
+   *
+   * <p>The acceptance check of the restart runs before the restart touches any in-memory state.
+   * The scenario holds one open session of a healthy database and restarts that database. The
+   * expected outcome has three parts. The restart refuses the healthy target. The held session
+   * still reads its own content. The registered storage of that database survives the refusal.
+   */
+  @Test
+  public void restartRefusalKeepsFilesAndLiveSession() throws Exception {
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      storageOf(youTrackDB, SOURCE).fullBackup(backupPath);
+
+      try (var liveSession = youTrackDB.open(SOURCE, ADMIN, PASSWORD)) {
+        var registeredStorage = storageOf(youTrackDB, SOURCE);
+
+        var refusal =
+            assertThrows(
+                RuntimeException.class,
+                () -> internalOf(youTrackDB)
+                    .restartInterruptedRestore(SOURCE, backupPath.toString(), null, null));
+
+        assertEquals(
+            "the restart must refuse an active target by name",
+            StorageAdmissionException.Reason.RESTART_TARGET_NOT_RESTORE_IN_PROGRESS,
+            admissionReason(refusal));
+        assertTrue(
+            "the live session must still read its own content",
+            liveSession.getMetadata().getSchema().existsClass(RECORD_CLASS));
+        assertEquals(
+            "the refusal must keep the registered storage of the healthy database",
+            registeredStorage,
+            internalOf(youTrackDB).getStorage(SOURCE));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart excludes a concurrent creation of the same database name.
+   *
+   * <p>The restart holds one exclusion over the deletion and over the new restore. A creation
+   * that runs between the deletion and the new restore would leave an empty active database under
+   * the name of the restore target. The scenario runs one restart while a second thread creates
+   * the same name in a loop. The expected outcome has two parts. The restart finishes. The
+   * database of that name carries the content of the backup, so no empty database survived.
+   */
+  @Test(timeout = 300_000)
+  public void restartExcludesAConcurrentCreationOfTheSameName() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+
+      var competitorRuns = new java.util.concurrent.atomic.AtomicBoolean(true);
+      var competitor =
+          new Thread(
+              () -> {
+                while (competitorRuns.get()) {
+                  try {
+                    youTrackDB.createIfNotExists(TARGET, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+                  } catch (RuntimeException expectedFailure) {
+                    // Every refusal of the competing creation is expected. Only the final state
+                    // of the database decides this test.
+                  }
+                }
+              });
+      competitor.start();
+      try {
+        internalOf(youTrackDB).restartInterruptedRestore(TARGET, backupPath.toString(), null, null);
+      } finally {
+        competitorRuns.set(false);
+        competitor.join();
+      }
+
+      try (var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+        assertTrue(
+            "no empty database may survive the restart",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart refuses a symbolic link that carries a database name.
+   *
+   * <p>A symbolic link would redirect the deletion of the restart outside of the databases
+   * directory. The scenario links one database name to a directory outside of the databases
+   * directory. The expected outcome has two parts. The restart refuses the link. The content of
+   * the linked directory survives the refusal.
+   */
+  @Test
+  public void restartRefusesSymbolicLinkTargetAndKeepsTheLinkedContent() throws Exception {
+    createSourceDatabaseAndBackup();
+    var outsideDirectory = Files.createDirectories(root.resolve("outside"));
+    var outsideFile = Files.writeString(outsideDirectory.resolve("precious.txt"), "payload");
+    try {
+      Files.createSymbolicLink(databasesPath.resolve("linkedTarget"), outsideDirectory);
+    } catch (UnsupportedOperationException | IOException linksUnsupported) {
+      org.junit.Assume.assumeNoException("symbolic links are unsupported", linksUnsupported);
+    }
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore("linkedTarget", backupPath.toString(), null, null));
+
+      assertTrue(
+          "the refusal must name the missing real directory, saw: " + rootMessage(refusal),
+          rootMessage(refusal).contains("no real directory"));
+    }
+
+    assertTrue("the linked content must survive the refusal", Files.exists(outsideFile));
+  }
+
+  /**
+   * Two opens of one unchanged image report the same admission reason.
+   *
+   * <p>An admission that creates the authority lock file would turn a directory without any
+   * bootstrap authority artifact into birth residue. The second open would then report the
+   * interrupted-birth reason and would advise a drop. The scenario opens one directory of an
+   * earlier format twice. The expected outcome has two parts. Both opens report the
+   * missing-record reason. The two opens create no bootstrap authority artifact.
+   */
+  @Test
+  public void twoOpensOfOneUnchangedImageReportTheSameAdmissionReason() throws Exception {
+    var earlierFormatDirectory = Files.createDirectories(databasesPath.resolve("earlierFormat"));
+    Files.writeString(earlierFormatDirectory.resolve("database.ocf"), "payload");
+
+    try (var youTrackDB = openManager()) {
+      var firstFailure =
+          assertThrows(
+              RuntimeException.class,
+              () -> youTrackDB.open("earlierFormat", ADMIN, PASSWORD));
+      var secondFailure =
+          assertThrows(
+              RuntimeException.class,
+              () -> youTrackDB.open("earlierFormat", ADMIN, PASSWORD));
+
+      assertEquals(
+          "the first open must report the missing-record reason",
+          StorageAdmissionException.Reason.AUTHORITY_MISSING,
+          admissionReason(firstFailure));
+      assertEquals(
+          "the second open must report the same reason as the first open",
+          StorageAdmissionException.Reason.AUTHORITY_MISSING,
+          admissionReason(secondFailure));
+    }
+
+    assertEquals(
+        "an admission must create no bootstrap authority artifact",
+        List.of(),
+        bootstrapArtifactNames(earlierFormatDirectory));
+  }
+
+  /**
+   * The public restart entry deletes an interrupted target and restores the backup.
+   *
+   * <p>Every earlier restart test of this class calls the internal manager directly. The public
+   * entry converts the configuration of the caller and then delegates. The scenario interrupts one
+   * restore and then calls the public entry of the manager with one Apache configuration. The
+   * expected outcome has three parts. The public entry finishes. The target reaches the active
+   * lifecycle state. The restarted database opens and carries the content of the backup.
+   */
+  @Test
+  public void publicRestartEntryDeletesInterruptedTargetAndRestoresTheBackup() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+
+      // The public entry accepts an Apache configuration, which the embedded entry never sees.
+      youTrackDB.restartInterruptedRestore(
+          TARGET, backupPath.toString(), null, new BaseConfiguration());
+
+      assertNull(
+          "the public restart must publish the active lifecycle state",
+          admissionReasonOf(TARGET));
+      try (var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the restarted database must carry the content of the backup",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The public restart entry accepts an absent configuration and uses the default configuration.
+   *
+   * <p>The scenario interrupts one restore and then calls the public entry with a null
+   * configuration. The expected outcome has two parts. The public entry finishes. The restarted
+   * database opens and carries the content of the backup.
+   */
+  @Test
+  public void publicRestartEntryAcceptsAnAbsentConfiguration() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      assertThrows(
+          RuntimeException.class,
+          () -> internalOf(youTrackDB).restore(TARGET, emptyBackupPath.toString(), null, null));
+
+      youTrackDB.restartInterruptedRestore(TARGET, backupPath.toString(), null, null);
+
+      assertNull(
+          "the public restart must publish the active lifecycle state",
+          admissionReasonOf(TARGET));
+      try (var session = youTrackDB.open(TARGET, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the restarted database must carry the content of the backup",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * Every connection other than an embedded connection refuses the restart entry.
+   *
+   * <p>The restart deletes a whole database directory of the host that stores the database, so a
+   * remote connection must never run the restart. The interface therefore carries a refusing
+   * default method, and only the embedded implementation overrides that method. The scenario calls
+   * the default method through a proxy that implements the interface and nothing else. The
+   * expected outcome has two parts. The call reports an unsupported operation. The message names
+   * the database and prescribes the embedded connection.
+   */
+  @Test
+  public void nonEmbeddedRestartEntryRefusesAndNamesTheDatabase() {
+    var connectionWithoutOverride =
+        (YouTrackDB) Proxy.newProxyInstance(
+            YouTrackDB.class.getClassLoader(),
+            new Class<?>[] {YouTrackDB.class},
+            (proxy, method, arguments) -> InvocationHandler.invokeDefault(proxy, method,
+                arguments));
+
+    var refusal =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> connectionWithoutOverride.restartInterruptedRestore(
+                TARGET, backupPath.toString(), null, null));
+
+    assertTrue(
+        "the refusal must name the database, saw: " + refusal.getMessage(),
+        refusal.getMessage().contains(TARGET));
+    assertTrue(
+        "the refusal must prescribe an embedded connection, saw: " + refusal.getMessage(),
+        refusal.getMessage().contains("embedded connection"));
+  }
+
+  /**
+   * The restored target carries a fresh storage identity and a fresh storage lineage.
+   *
+   * <p>A storage identity is the unique identifier of one storage image. A storage lineage is the
+   * identifier of the ancestry of one storage image. A restored image never shares either value
+   * with the backup source, because the restore target adopts both values at its birth
+   * publication. The scenario restores one backup into a new database name. The expected outcome
+   * has two parts. The restored target carries another storage identity than the source database.
+   * The restored target carries another storage lineage than the source database.
+   */
+  @Test
+  public void restoredTargetCarriesFreshIdentityAndFreshLineage() throws Exception {
+    StorageIdentity sourceIdentity;
+    StorageLineageIdentity sourceLineage;
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      var sourceStorage = storageOf(youTrackDB, SOURCE);
+      sourceIdentity = sourceStorage.getStorageIdentity();
+      sourceLineage = sourceStorage.getStorageLineageIdentity();
+      sourceStorage.fullBackup(backupPath);
+    }
+
+    try (var youTrackDB = openManager()) {
+      internalOf(youTrackDB).restore(TARGET, backupPath.toString(), null, null);
+      var restoredStorage = storageOf(youTrackDB, TARGET);
+
+      assertNotEquals(
+          "the restored target must carry a fresh storage identity",
+          sourceIdentity,
+          restoredStorage.getStorageIdentity());
+      assertNotEquals(
+          "the restored target must carry a fresh storage lineage",
+          sourceLineage,
+          restoredStorage.getStorageLineageIdentity());
+    }
+  }
+
+  /**
+   * A restore refuses a database name that already exists, and keeps every file of that database.
+   *
+   * <p>The scenario opens the source database and then restores one backup into the name of that
+   * healthy database. The expected outcome has three parts. The restore refuses the name and names
+   * the existing database. The refusal keeps the registered storage of the healthy database, so no
+   * fresh storage of the refused restore replaces that registration. The source database still
+   * opens and still carries its own content.
+   */
+  @Test
+  public void restoreRefusesAnExistingDatabaseName() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      try (var ignored = youTrackDB.open(SOURCE, ADMIN, PASSWORD)) {
+        var registeredStorage = storageOf(youTrackDB, SOURCE);
+
+        var refusal =
+            assertThrows(
+                RuntimeException.class,
+                () -> internalOf(youTrackDB).restore(SOURCE, backupPath.toString(), null, null));
+
+        assertTrue(
+            "the refusal must name the existing database, saw: " + rootMessage(refusal),
+            rootMessage(refusal).contains("already exists"));
+        assertSame(
+            "the refusal must keep the registered storage of the existing database",
+            registeredStorage,
+            internalOf(youTrackDB).getStorage(SOURCE));
+      }
+      try (var session = youTrackDB.open(SOURCE, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the refused database must keep its own content",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * A restore refuses a reserved database name prefix and creates no directory.
+   *
+   * <p>The two reserved prefixes are the prefix for graph traversal names and the prefix for
+   * server names. The scenario restores one backup into a name with an upper-case reserved prefix.
+   * The expected outcome has two parts. The restore refuses the name. The restore creates no
+   * directory under that name.
+   */
+  @Test
+  public void restoreRefusesAReservedNamePrefix() throws Exception {
+    createSourceDatabaseAndBackup();
+
+    try (var youTrackDB = openManager()) {
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restore("SERVERrestore", backupPath.toString(), null, null));
+
+      assertTrue(
+          "the refusal must name the reserved prefix, saw: " + rootMessage(refusal),
+          rootMessage(refusal).contains("server"));
+    }
+
+    assertFalse(
+        "the refused restore must create no directory",
+        Files.exists(databasesPath.resolve("SERVERrestore")));
+  }
+
+  /**
+   * A restore runs no database creation listener, and a plain creation still runs that listener.
+   *
+   * <p>A database creation listener runs after a creation published a usable database. A restore
+   * target is no such database, because the backup content replaces every genesis artifact. The
+   * scenario registers one counting listener and then runs one restore and one plain creation. The
+   * expected outcome has two parts. The restore runs the listener zero times. The plain creation
+   * runs the listener at least one time.
+   *
+   * <p>The listener registry belongs to the whole virtual machine, and a sibling test class can
+   * create a database at the same time. The counting listener therefore counts one call per
+   * database name, and both assertions read the counter of one name of this test only. The name of
+   * the plain creation also carries the name of this test, so no sibling class can raise that
+   * counter.
+   *
+   * <p>The creation assertion names no exact count on purpose. The create path of the manager
+   * calls the listener set twice for one plain creation, which predates Track 24. This test
+   * therefore proves the presence of the call and never freezes the count of that call.
+   */
+  @Test
+  public void restoreRunsNoCreationListenerAndCreationStillRunsThatListener() throws Exception {
+    createSourceDatabaseAndBackup();
+    var plainCreationName = "restoreLifecycleListenerPlainCreation";
+    var creationCountsByName = new ConcurrentHashMap<String, AtomicInteger>();
+    DatabaseLifecycleListener countingListener =
+        new DatabaseLifecycleListener() {
+          @Override
+          public void onCreate(@Nonnull DatabaseSessionEmbedded session) {
+            creationCountsByName
+                .computeIfAbsent(session.getDatabaseName(), name -> new AtomicInteger())
+                .incrementAndGet();
+          }
+        };
+
+    YouTrackDBEnginesManager.instance().addDbLifecycleListener(countingListener);
+    try (var youTrackDB = openManager()) {
+      internalOf(youTrackDB).restore(TARGET, backupPath.toString(), null, null);
+
+      assertEquals(
+          "a restore must run no database creation listener for the restore target",
+          0,
+          creationCountOf(creationCountsByName, TARGET));
+
+      youTrackDB.create(plainCreationName, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+      assertTrue(
+          "a plain creation must still run the database creation listener, saw "
+              + creationCountOf(creationCountsByName, plainCreationName)
+              + " calls",
+          creationCountOf(creationCountsByName, plainCreationName) >= 1);
+    } finally {
+      YouTrackDBEnginesManager.instance().removeDbLifecycleListener(countingListener);
+    }
+  }
+
+  /** Returns the counted creation listener calls of one database name. */
+  private static int creationCountOf(
+      ConcurrentHashMap<String, AtomicInteger> creationCountsByName, String databaseName) {
+    var counter = creationCountsByName.get(databaseName);
+    return counter == null ? 0 : counter.get();
+  }
+
+  /**
+   * The destructive restart refuses a live memory database and keeps that database working.
+   *
+   * <p>The registration map of the manager holds one storage per database name, and a memory
+   * database keeps no directory at all. A restart that trusts the registration map alone would
+   * shut down that memory database without any evidence on disk. The scenario creates one memory
+   * database and then names that memory database in a restart. The expected outcome has three
+   * parts. The restart refuses the name with the missing-record reason. The registered storage of
+   * the memory database survives the refusal. The memory database still opens and still carries
+   * its own content.
+   */
+  @Test
+  public void restartRefusesALiveMemoryDatabaseAndKeepsThatDatabaseWorking() throws Exception {
+    createSourceDatabaseAndBackup();
+    var memoryName = "memoryRestartTarget";
+
+    try (var youTrackDB = openManager()) {
+      youTrackDB.create(memoryName, DatabaseType.MEMORY, ADMIN, PASSWORD, ADMIN);
+      try (var session = youTrackDB.open(memoryName, ADMIN, PASSWORD)) {
+        session.getMetadata().getSchema().createClass(RECORD_CLASS);
+      }
+      var registeredStorage = storageOf(youTrackDB, memoryName);
+
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(memoryName, backupPath.toString(), null, null));
+
+      assertEquals(
+          "the restart must refuse a name without any evidence on disk",
+          StorageAdmissionException.Reason.AUTHORITY_MISSING,
+          admissionReason(refusal));
+      assertSame(
+          "the refusal must keep the registered storage of the memory database",
+          registeredStorage,
+          internalOf(youTrackDB).getStorage(memoryName));
+      try (var session = youTrackDB.open(memoryName, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the memory database must still carry its own content",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The plain restore refuses a database name that escapes the databases directory.
+   *
+   * <p>The name of a single dot resolves to the databases directory itself, and the name of a
+   * double dot resolves to the parent of that directory. A restore into such a target would write
+   * storage files over the databases directory. The scenario names a single dot and a double dot
+   * in two plain restores. The expected outcome has two parts. Both restores refuse the name. The
+   * database directory of the source database survives both refusals.
+   */
+  @Test
+  public void plainRestoreRefusesPathEscapingNameAndKeepsEveryDatabase() throws Exception {
+    createSourceDatabaseAndBackup();
+    var sourceEntriesBeforeRestore = entryNames(databasesPath.resolve(SOURCE));
+    assertFalse("the source database must hold files", sourceEntriesBeforeRestore.isEmpty());
+
+    try (var youTrackDB = openManager()) {
+      for (var escapingName : List.of(".", "..")) {
+        var refusal =
+            assertThrows(
+                "the plain restore must refuse the escaping name " + escapingName,
+                RuntimeException.class,
+                () -> internalOf(youTrackDB)
+                    .restore(escapingName, backupPath.toString(), null, null));
+        assertTrue(
+            "the refusal must name the invalid database name, saw: " + rootMessage(refusal),
+            rootMessage(refusal).contains("Invalid database name"));
+      }
+    }
+
+    assertTrue("the databases directory must survive", Files.isDirectory(databasesPath));
+    assertEquals(
+        "the source database must keep every file",
+        sourceEntriesBeforeRestore,
+        entryNames(databasesPath.resolve(SOURCE)));
+  }
+
+  /**
+   * The destructive restart accepts a directory that holds the authority lock file alone.
+   *
+   * <p>Two events produce that directory shape. The deletion of an earlier restart produces the
+   * shape, because the deletion keeps the authority lock file. An interrupted storage birth also
+   * produces the shape, because the birth creates the authority lock file before the birth writes
+   * the first record. The shape holds no content file under either event, so the restart accepts
+   * the shape and destroys no data.
+   *
+   * <p>The scenario builds the shape of an interrupted storage birth, which holds the authority
+   * lock file alone. The expected outcome has two parts. The restart accepts that directory. The
+   * restarted database opens and carries the content of the backup.
+   */
+  @Test
+  public void restartAcceptsTheLockFileOnlyShapeOfAnInterruptedBirth() throws Exception {
+    createSourceDatabaseAndBackup();
+    var birthResidueName = "lockFileOnlyBirthResidue";
+    var birthResidueDirectory = Files.createDirectories(databasesPath.resolve(birthResidueName));
+    // The name of the authority lock file. A storage birth creates that file first.
+    Files.createFile(birthResidueDirectory.resolve("storage-bootstrap.bsml"));
+
+    try (var youTrackDB = openManager()) {
+      internalOf(youTrackDB)
+          .restartInterruptedRestore(birthResidueName, backupPath.toString(), null, null);
+
+      assertNull(
+          "the restart must publish the active lifecycle state",
+          admissionReasonOf(birthResidueName));
+      try (var session = youTrackDB.open(birthResidueName, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the restarted database must carry the content of the backup",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+    }
+  }
+
+  /**
+   * The destructive restart refuses a registered storage that another directory backs.
+   *
+   * <p>The registration map of the manager holds one storage per database name. A restart that
+   * trusts that map alone would shut down a storage of another directory. The scenario registers
+   * one memory database under the target name and then builds the accepted restart shape on disk
+   * under the same name. The accepted restart shape is a directory whose only entry is the
+   * authority lock file. The disk evidence therefore passes the acceptance check, and the restart
+   * reaches the registration check afterwards.
+   *
+   * <p>The expected outcome has four parts. The restart refuses the name and names the resolved
+   * target directory. The registered storage of the memory database survives the refusal. The
+   * memory database still opens and still carries its own content. The target directory keeps its
+   * single entry, so the refusal deletes no file.
+   *
+   * <p>This test reaches the registration check directly. The sibling test of a live memory
+   * database without any directory never reaches the registration check, because the absent
+   * directory refuses first.
+   */
+  @Test
+  public void restartRefusesARegisteredStorageOfAnotherDirectory() throws Exception {
+    createSourceDatabaseAndBackup();
+    var mismatchName = "registrationMismatchTarget";
+
+    try (var youTrackDB = openManager()) {
+      // The memory database occupies the name first. A memory database creates no directory, so
+      // the creation sees no existing database of that name.
+      youTrackDB.create(mismatchName, DatabaseType.MEMORY, ADMIN, PASSWORD, ADMIN);
+      try (var session = youTrackDB.open(mismatchName, ADMIN, PASSWORD)) {
+        session.getMetadata().getSchema().createClass(RECORD_CLASS);
+      }
+      var registeredStorage = storageOf(youTrackDB, mismatchName);
+
+      // The disk evidence of an interrupted storage birth follows the registration. The restart
+      // accepts this directory shape, so the acceptance check passes and the guard decides.
+      var targetDirectory = Files.createDirectories(databasesPath.resolve(mismatchName));
+      Files.createFile(targetDirectory.resolve("storage-bootstrap.bsml"));
+
+      var refusal =
+          assertThrows(
+              RuntimeException.class,
+              () -> internalOf(youTrackDB)
+                  .restartInterruptedRestore(mismatchName, backupPath.toString(), null, null));
+
+      assertTrue(
+          "the refusal must name the resolved target directory, saw: " + rootMessage(refusal),
+          rootMessage(refusal).contains(targetDirectory.toAbsolutePath().normalize().toString()));
+      assertSame(
+          "the refusal must keep the registered storage of the memory database",
+          registeredStorage,
+          internalOf(youTrackDB).getStorage(mismatchName));
+      try (var session = youTrackDB.open(mismatchName, ADMIN, PASSWORD)) {
+        assertTrue(
+            "the memory database must still carry its own content",
+            session.getMetadata().getSchema().existsClass(RECORD_CLASS));
+      }
+      assertEquals(
+          "the refusal must delete no file of the target directory",
+          List.of("storage-bootstrap.bsml"),
+          entryNames(targetDirectory));
+    }
+  }
+
+  /** Creates the source database with one class and one record, and then takes one full backup. */
+  private void createSourceDatabaseAndBackup() {
+    try (var youTrackDB = openManager()) {
+      createSourceDatabase(youTrackDB);
+      assertNotNull(storageOf(youTrackDB, SOURCE).fullBackup(backupPath));
+    }
+  }
+
+  /** Creates the source database with one class and one record. */
+  private void createSourceDatabase(YouTrackDBImpl youTrackDB) {
+    youTrackDB.create(SOURCE, DatabaseType.DISK, ADMIN, PASSWORD, ADMIN);
+    try (var session = youTrackDB.open(SOURCE, ADMIN, PASSWORD)) {
+      session.getMetadata().getSchema().createClass(RECORD_CLASS);
+      session.begin();
+      var entity = session.newEntity(RECORD_CLASS);
+      entity.setProperty("value", "restored");
+      session.commit();
+    }
+  }
+
+  private YouTrackDBImpl openManager() {
+    return (YouTrackDBImpl) YourTracks.instance(databasesPath.toString());
+  }
+
+  private static YouTrackDBInternalEmbedded internalOf(YouTrackDBImpl youTrackDB) {
+    return (YouTrackDBInternalEmbedded) youTrackDB.internal;
+  }
+
+  private static AbstractStorage storageOf(YouTrackDBImpl youTrackDB, String databaseName) {
+    var storage = internalOf(youTrackDB).getStorage(databaseName);
+    assertNotNull("the database must hold one registered storage", storage);
+    return storage;
+  }
+
+  /** Returns the admission reason of one database directory, or null for an accepted image. */
+  private StorageAdmissionException.Reason admissionReasonOf(String databaseName) {
+    try {
+      new StorageBootstrapMetadata(databasesPath.resolve(databaseName), FEATURE_FORMAT)
+          .readActiveRequired();
+      return null;
+    } catch (StorageAdmissionException rejection) {
+      return rejection.reason();
+    } catch (IOException failure) {
+      throw new UncheckedIOException(failure);
+    }
+  }
+
+  /** Returns the admission reason inside the cause chain of one failure. */
+  private static StorageAdmissionException.Reason admissionReason(Throwable failure) {
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof StorageAdmissionException admission) {
+        return admission.reason();
+      }
+    }
+    return null;
+  }
+
+  /** Joins every message of the cause chain of one failure. */
+  private static String rootMessage(Throwable failure) {
+    var message = new StringBuilder();
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      message.append(cause.getMessage()).append(' ');
+    }
+    return message.toString();
+  }
+
+  private Iterator<String> backupFileNames() {
+    try (var paths = Files.list(backupPath)) {
+      List<String> names =
+          paths.map(path -> path.getFileName().toString()).filter(name -> name.endsWith(".ibu"))
+              .sorted()
+              .toList();
+      return names.iterator();
+    } catch (IOException failure) {
+      throw new UncheckedIOException(failure);
+    }
+  }
+
+  private InputStream openBackupFile(String fileName) {
+    try {
+      return Files.newInputStream(backupPath.resolve(fileName));
+    } catch (IOException failure) {
+      throw new UncheckedIOException(failure);
+    }
+  }
+
+  /** Returns a truncated stream of one backup file, which interrupts the content stage. */
+  private InputStream openTruncatedBackupFile(String fileName) {
+    try {
+      var content = Files.readAllBytes(backupPath.resolve(fileName));
+      return new ByteArrayInputStream(Arrays.copyOf(content, Math.min(64, content.length)));
+    } catch (IOException failure) {
+      throw new UncheckedIOException(failure);
+    }
+  }
+
+  /** Removes every entry of one target and keeps the authority lock file. */
+  private static void deleteEveryEntryExceptTheAuthorityLockFile(Path storageDirectory)
+      throws IOException {
+    try (var paths = Files.list(storageDirectory)) {
+      for (var path : paths.toList()) {
+        if (!path.getFileName().toString().endsWith(".bsml")) {
+          FileUtils.deleteRecursively(path.toFile());
+        }
+      }
+    }
+  }
+
+  /** Returns the sorted names of every entry of one directory. */
+  private static List<String> entryNames(Path directory) throws IOException {
+    try (var paths = Files.list(directory)) {
+      return paths.map(path -> path.getFileName().toString()).sorted().toList();
+    }
+  }
+
+  private static List<String> bootstrapArtifactNames(Path storageDirectory) throws IOException {
+    try (var paths = Files.list(storageDirectory)) {
+      return paths
+          .map(path -> path.getFileName().toString())
+          .filter(StorageBootstrapMetadata::isBootstrapArtifactName)
+          .sorted()
+          .toList();
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageBirthTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageBirthTestSupport.java
@@ -1,0 +1,49 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Opens the two birth completion boundaries of one storage to a test.
+ *
+ * <p>Storage birth is the creation of a new storage image. Genesis is the creation of the initial
+ * database metadata. A durability barrier forces earlier writes to durable media before later
+ * work. The creation path runs genesis, then the durability barrier, and then the activation.
+ *
+ * <p>A test needs both boundaries to build the on-disk image of a crash at each boundary. The two
+ * boundaries live inside one final method of the storage, so no subclass can reach them. This
+ * class therefore exposes the package-private observer seam of the storage to a test of another
+ * package.
+ */
+public final class StorageBirthTestSupport {
+
+  private StorageBirthTestSupport() {
+  }
+
+  /**
+   * Installs two observers of one storage birth on the current thread.
+   *
+   * @param afterGenesis  runs after genesis finished and before the durability barrier starts
+   * @param afterBarrier  runs after the durability barrier finished and before the activation
+   * @return the scope that removes both observers again
+   */
+  public static AutoCloseable observeBirthCompletion(
+      final Consumer<AbstractStorage> afterGenesis,
+      final Consumer<AbstractStorage> afterBarrier) {
+    Objects.requireNonNull(afterGenesis, "afterGenesis");
+    Objects.requireNonNull(afterBarrier, "afterBarrier");
+    return AbstractStorage.useBirthCompletionObserverForCurrentThread(
+        new AbstractStorage.BirthCompletionObserver() {
+
+          @Override
+          public void afterGenesisBeforeBarrier(final AbstractStorage storage) {
+            afterGenesis.accept(storage);
+          }
+
+          @Override
+          public void afterBarrierBeforeActivation(final AbstractStorage storage) {
+            afterBarrier.accept(storage);
+          }
+        });
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageIdentityHolderTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/StorageIdentityHolderTest.java
@@ -1,0 +1,37 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageIdentity;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageLineageIdentity;
+import org.junit.Test;
+
+/** Covers identity publication for volatile and durable storage profiles. */
+public class StorageIdentityHolderTest {
+
+  /** An empty holder rejects both identity reads before durable identity publication. */
+  @Test
+  public void identityReadsFailBeforeDurablePublication() {
+    var holder = new StorageIdentityHolder();
+
+    var storageFailure = assertThrows(IllegalStateException.class, holder::storageIdentity);
+    var lineageFailure = assertThrows(IllegalStateException.class, holder::lineageIdentity);
+
+    assertEquals("Storage identity is not initialized", storageFailure.getMessage());
+    assertEquals("Storage identity is not initialized", lineageFailure.getMessage());
+  }
+
+  /** One update publishes both durable identities to later readers. */
+  @Test
+  public void updatePublishesCompleteDurableIdentityPair() {
+    var holder = new StorageIdentityHolder();
+    var storageIdentity = StorageIdentity.random();
+    var lineageIdentity = StorageLineageIdentity.random();
+
+    holder.update(storageIdentity, lineageIdentity);
+
+    assertEquals(storageIdentity, holder.storageIdentity());
+    assertEquals(lineageIdentity, holder.lineageIdentity());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/BootstrapMetadataTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/BootstrapMetadataTestSupport.java
@@ -1,0 +1,33 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Provides an observable bootstrap publication failure to a real storage creation. */
+public final class BootstrapMetadataTestSupport {
+
+  private BootstrapMetadataTestSupport() {
+  }
+
+  /** Fails the next current-thread move after observing its completed publication candidate. */
+  public static FailedPublication failNextPublication() {
+    var candidateObserved = new AtomicBoolean();
+    var scope = StorageBootstrapMetadata.useMoveStrategyForCurrentThread(
+        (source, target, requester) -> {
+          candidateObserved.set(Files.isRegularFile(source));
+          throw new IOException("injected birth publication failure");
+        });
+    return new FailedPublication(candidateObserved, scope);
+  }
+
+  /** Holds the candidate observation and removes the current-thread failure strategy. */
+  public record FailedPublication(AtomicBoolean candidateObserved, AutoCloseable scope)
+      implements AutoCloseable {
+
+    @Override
+    public void close() throws Exception {
+      scope.close();
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/ForeignFileLockHolder.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/ForeignFileLockHolder.java
@@ -1,0 +1,31 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+/** Holds one existing file lock for a bounded cross-process restart-deletion test. */
+public final class ForeignFileLockHolder {
+
+  private ForeignFileLockHolder() {
+  }
+
+  public static void main(final String[] arguments) throws Exception {
+    if (arguments.length != 1) {
+      throw new IllegalArgumentException("Expected the path of one existing lock file");
+    }
+    final var lockPath = Path.of(arguments[0]);
+    try (var channel =
+        FileChannel.open(lockPath, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        var ignored = channel.lock();
+        var input = new BufferedReader(new InputStreamReader(System.in))) {
+      System.out.println("READY");
+      System.out.flush();
+      if (!"release".equals(input.readLine())) {
+        throw new IllegalStateException("Parent did not request lock release");
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
@@ -1,0 +1,879 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import net.jpountz.xxhash.XXHashFactory;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests redundant bootstrap selection, publication, recovery, and birth ownership. */
+public class StorageBootstrapMetadataTest {
+
+  private static final FeatureFormatIdentity FORMAT = new FeatureFormatIdentity(25);
+  private static final StorageIdentity STORAGE =
+      new StorageIdentity(UUID.fromString("10000000-0000-0000-0000-000000000001"));
+  private static final StorageLineageIdentity LINEAGE_ONE =
+      new StorageLineageIdentity(UUID.fromString("20000000-0000-0000-0000-000000000001"));
+  private static final StorageLineageIdentity LINEAGE_TWO =
+      new StorageLineageIdentity(UUID.fromString("20000000-0000-0000-0000-000000000002"));
+  private static final StorageLineageIdentity LINEAGE_THREE =
+      new StorageLineageIdentity(UUID.fromString("20000000-0000-0000-0000-000000000003"));
+  private static final StorageIdentity SOURCE_STORAGE =
+      new StorageIdentity(UUID.fromString("30000000-0000-0000-0000-000000000001"));
+  private static final StorageLineageIdentity SOURCE_LINEAGE =
+      new StorageLineageIdentity(UUID.fromString("40000000-0000-0000-0000-000000000001"));
+
+  private Path directory;
+
+  @Before
+  public void setUp() throws IOException {
+    directory = Files.createTempDirectory("storage-bootstrap-metadata-");
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (directory != null && Files.exists(directory)) {
+      try (Stream<Path> paths = Files.walk(directory)) {
+        paths.sorted(Comparator.reverseOrder()).forEach(this::deleteQuietly);
+      }
+    }
+    assertThat(StorageBootstrapMetadata.processLockCountForTests()).isZero();
+  }
+
+  /** Initial establishment writes only durable BIRTH_IN_PROGRESS authority in the first slot. */
+  @Test
+  public void birthEstablishesOnlyPendingAuthority() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+
+    assertThat(birth.state()).isEqualTo(StorageBootstrapMetadata.State.BIRTH_IN_PROGRESS);
+    assertThat(birth.generation()).isEqualTo(1);
+    assertThat(birth.sequenceFloor().highestIssued()).isZero();
+    assertThat(authorityFiles()).containsExactly(authorityPath(0));
+    assertThat(Files.size(authorityPath(0))).isEqualTo(80);
+  }
+
+  /** The live creator can activate its token while another instance rejects the interrupted birth. */
+  @Test
+  public void onlyCreatingCallCanContinueDurableBirth() throws IOException {
+    final var creator = metadata();
+    final var birth = creator.createBirth(STORAGE, LINEAGE_ONE);
+    final var laterOperation = metadata();
+    final var discovered = laterOperation.readRequired();
+
+    assertThatThrownBy(laterOperation::readActiveRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Interrupted storage birth");
+    assertThatThrownBy(() -> laterOperation.activate(discovered))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("cannot continue");
+
+    assertThat(creator.activate(birth).state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+  }
+
+  /** A later creation attempt cannot overwrite durable incomplete-birth authority. */
+  @Test
+  public void repeatedBirthIsRejectedUntilExplicitRemoval() throws IOException {
+    metadata().createBirth(STORAGE, LINEAGE_ONE);
+
+    assertThatThrownBy(() -> metadata().createBirth(STORAGE, LINEAGE_TWO))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("already exists");
+  }
+
+  /** Each update uses another slot and recovery selects the newest legal generation. */
+  @Test
+  public void redundantPublicationSelectsNewestLegalRecord() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var active = metadata.activate(birth);
+    final var advanced =
+        metadata.advanceFloor(active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 9));
+
+    assertThat(authorityFiles()).hasSize(3);
+    assertThat(metadata().readRequired()).isEqualTo(advanced);
+  }
+
+  /** Once all slots are used, publication safely reuses the oldest non-selected location. */
+  @Test
+  public void publicationSafelyReusesOldestLocation() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var active = metadata.activate(birth);
+    final var floorThree =
+        metadata.advanceFloor(active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 3));
+    final var floorFour =
+        metadata.advanceFloor(floorThree, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 4));
+
+    assertThat(floorFour.generation()).isEqualTo(4);
+    assertThat(metadata.readRequired()).isEqualTo(floorFour);
+    assertThat(readGeneration(authorityPath(0))).isEqualTo(4);
+  }
+
+  /** Confirmation reuses one damaged slot while preserving two verified authority records. */
+  @Test
+  public void confirmationReusesDamagedOccupiedSlot() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    Files.write(authorityPath(2), new byte[] {1, 2, 3});
+
+    final var confirmed = metadata().readRequired();
+
+    assertThat(confirmed).isEqualTo(active);
+    assertThat(Files.size(authorityPath(2))).isEqualTo(80);
+    assertThat(metadata().readRequired()).isEqualTo(active);
+    assertThat(metadata().readActiveRequired()).isEqualTo(active);
+  }
+
+  /** Damaged slots remain reusable even when only the selected authority is verified. */
+  @Test
+  public void publicationReusesDamageWithoutOverwritingSelectedAuthority() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final byte[] selectedBytes = Files.readAllBytes(authorityPath(0));
+    Files.write(authorityPath(1), new byte[] {1});
+    Files.write(authorityPath(2), new byte[] {2});
+
+    final var active = metadata.activate(birth);
+
+    assertThat(active.state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+    assertThat(Files.readAllBytes(authorityPath(0))).isEqualTo(selectedBytes);
+  }
+
+  /** A failed publication removes its candidate and leaves selected authority readable. */
+  @Test
+  public void failedPublicationPreservesSelectedAuthority() throws IOException {
+    final var creator = metadata();
+    final var birth = creator.createBirth(STORAGE, LINEAGE_ONE);
+    final var active = creator.activate(birth);
+    final byte[] selectedBytes = Files.readAllBytes(authorityPath(1));
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw new IOException("injected publication failure");
+            });
+
+    assertThatThrownBy(
+        () -> failing.advanceFloor(
+            active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("injected");
+    assertThat(Files.readAllBytes(authorityPath(1))).isEqualTo(selectedBytes);
+    assertThat(temporaryFiles()).isEmpty();
+    assertThat(metadata().readActiveRequired()).isEqualTo(active);
+  }
+
+  /** An unchecked publication failure removes its owned candidate and remains primary. */
+  @Test
+  public void uncheckedPublicationFailureRemovesOwnedCandidate() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var publicationFailure = new IllegalStateException("unchecked publication failure");
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw publicationFailure;
+            });
+
+    final Throwable thrown =
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)));
+
+    assertThat(thrown).isSameAs(publicationFailure);
+    assertThat(temporaryFiles()).isEmpty();
+    assertThat(metadata().readActiveRequired()).isEqualTo(active);
+  }
+
+  /** A failed warning remains diagnostic and cannot prevent candidate removal. */
+  @Test
+  public void warningFailureDoesNotPreventCandidateRemoval() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var publicationFailure = new IOException("primary publication failure");
+    final var removalAttempted = new AtomicBoolean();
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw publicationFailure;
+            },
+            (requester, storageDirectory, candidate, failure) -> {
+              throw new IllegalStateException("warning failure");
+            },
+            candidate -> {
+              removalAttempted.set(true);
+              Files.deleteIfExists(candidate);
+            });
+
+    final Throwable thrown =
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)));
+
+    assertThat(thrown).isSameAs(publicationFailure);
+    assertThat(removalAttempted).isTrue();
+    assertThat(temporaryFiles()).isEmpty();
+  }
+
+  /** Warning and removal failures remain diagnostic under the original publication failure. */
+  @Test
+  public void warningAndRemovalFailuresDoNotReplacePublicationFailure() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var publicationFailure = new IOException("primary publication failure");
+    final var removalFailure = new IllegalStateException("removal failure");
+    final var removalAttempted = new AtomicBoolean();
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw publicationFailure;
+            },
+            (requester, storageDirectory, candidate, failure) -> {
+              throw new IllegalStateException("warning failure");
+            },
+            candidate -> {
+              removalAttempted.set(true);
+              throw removalFailure;
+            });
+
+    final Throwable thrown =
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)));
+
+    assertThat(thrown).isSameAs(publicationFailure);
+    assertThat(removalAttempted).isTrue();
+    assertThat(thrown.getSuppressed()).containsExactly(removalFailure);
+  }
+
+  /** The same failure from publication and cleanup remains primary without self-suppression. */
+  @Test
+  public void sharedPublicationAndCleanupFailureRemainsPrimary() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var sharedFailure = new IllegalStateException("shared publication and cleanup failure");
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw sharedFailure;
+            },
+            (requester, storageDirectory, candidate, failure) -> {
+            },
+            candidate -> {
+              throw sharedFailure;
+            });
+
+    final Throwable thrown =
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)));
+
+    assertThat(thrown).isSameAs(sharedFailure);
+    assertThat(thrown.getSuppressed()).isEmpty();
+  }
+
+  /** A cleanup throwable outside standard exception categories remains diagnostic only. */
+  @Test
+  public void arbitraryCleanupThrowableDoesNotReplacePublicationFailure() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var publicationFailure = new IOException("primary publication failure");
+    final var cleanupFailure = new Throwable("arbitrary cleanup failure");
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw publicationFailure;
+            },
+            (requester, storageDirectory, candidate, failure) -> {
+            },
+            candidate -> throwUnchecked(cleanupFailure));
+
+    final Throwable thrown =
+        org.assertj.core.api.Assertions.catchThrowable(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)));
+
+    assertThat(thrown).isSameAs(publicationFailure);
+    assertThat(thrown.getSuppressed()).containsExactly(cleanupFailure);
+  }
+
+  /** Residue present before a call is not removed and keeps recovery fail closed. */
+  @Test
+  public void preexistingCandidateResidueIsNeverRemoved() throws IOException {
+    final var metadata = metadata();
+    final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    Files.write(temporaryPath(2), new byte[] {1});
+
+    assertThatThrownBy(
+        () -> metadata.advanceFloor(
+            active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("temporary");
+    assertThat(Files.readAllBytes(temporaryPath(2))).containsExactly(1);
+    assertThatThrownBy(metadata::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("temporary");
+  }
+
+  /** Candidate cleanup failure is suppressed under the original publication failure. */
+  @Test
+  public void cleanupFailureDoesNotReplacePublicationFailure() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var failing =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw new IOException("primary publication failure");
+            },
+            (requester, storageDirectory, candidate, failure) -> {
+            },
+            candidate -> {
+              throw new IOException("secondary cleanup failure");
+            });
+
+    final IOException failure =
+        org.assertj.core.api.Assertions.catchThrowableOfType(
+            () -> failing.advanceFloor(
+                active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)),
+            IOException.class);
+
+    assertThat(failure).hasMessageContaining("primary publication failure");
+    assertThat(failure.getSuppressed()).hasSize(1);
+    assertThat(failure.getSuppressed()[0].getMessage()).contains("secondary cleanup failure");
+  }
+
+  /** A complete active candidate from a failed barrier is selected only after fresh confirmation. */
+  @Test
+  public void recoverySelectsUnconfirmedActiveCandidateAfterFreshBarrier() throws IOException {
+    final var moves = new AtomicInteger();
+    final var uncertainCreator =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              FileUtils.durableAtomicMove(source, target, requester);
+              if (moves.incrementAndGet() == 2) {
+                throw new IOException("directory barrier failed after move");
+              }
+            });
+    final var birth = uncertainCreator.createBirth(STORAGE, LINEAGE_ONE);
+
+    assertThatThrownBy(() -> uncertainCreator.activate(birth))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("barrier failed");
+
+    final var recovered = metadata().readActiveRequired();
+    assertThat(recovered.state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+    assertThat(authorityFiles()).hasSize(3);
+  }
+
+  /** Different records at the newest generation are ambiguous and keep storage unavailable. */
+  @Test
+  public void conflictingNewestGenerationIsRejectedAsAmbiguous() throws IOException {
+    final var metadata = metadata();
+    final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] conflict = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(conflict).putLong(64, 11);
+    updateChecksum(conflict);
+    Files.write(authorityPath(0), conflict);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("ambiguous");
+    assertThat(active.generation()).isEqualTo(2);
+  }
+
+  /** Foreign storage identity among valid records makes authority ambiguous. */
+  @Test
+  public void foreignStorageIdentityIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] foreign = Files.readAllBytes(authorityPath(0));
+    ByteBuffer.wrap(foreign).putLong(32, 0x7777777777777777L);
+    updateChecksum(foreign);
+    Files.write(authorityPath(0), foreign);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("ambiguous");
+  }
+
+  /** Consecutive valid generations with an illegal lifecycle transition fail closed. */
+  @Test
+  public void illegalStateTransitionIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] illegal = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(illegal).putInt(24, 3);
+    updateChecksum(illegal);
+    Files.write(authorityPath(1), illegal);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("illegal state transition");
+  }
+
+  /** One torn authority is ignored when another complete authority remains selectable. */
+  @Test
+  public void tornCandidateDoesNotDestroyPriorAuthority() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    Files.write(authorityPath(1), new byte[] {1, 2, 3});
+
+    assertThat(metadata.readRequired()).isEqualTo(birth);
+  }
+
+  /** A symbolic authority cannot import a valid record from outside its fixed location. */
+  @Test
+  public void symbolicAuthorityIsRejected() throws Exception {
+    final var metadata = metadata();
+    metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var foreign = directory.resolve("foreign.bsm");
+    Files.move(authorityPath(0), foreign);
+    try {
+      Files.createSymbolicLink(authorityPath(0), foreign.getFileName());
+    } catch (UnsupportedOperationException | IOException e) {
+      Assume.assumeNoException("Symbolic links are not supported", e);
+    }
+
+    assertThatThrownBy(metadata::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("not a regular file");
+  }
+
+  /** A checksum-valid wrong magic value fails closed instead of using older authority. */
+  @Test
+  public void invalidAuthorityMagicIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] invalid = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(invalid).putLong(0, 7);
+    updateChecksum(invalid);
+    Files.write(authorityPath(1), invalid);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Invalid bootstrap authority magic: 7");
+  }
+
+  /** A checksum-valid unsupported encoding version fails closed and names that version. */
+  @Test
+  public void unsupportedEncodingVersionIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] unsupported = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(unsupported).putInt(8, 99);
+    updateChecksum(unsupported);
+    Files.write(authorityPath(1), unsupported);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unsupported bootstrap encoding version: 99");
+  }
+
+  /** A checksum-valid foreign feature format fails closed instead of using an older record. */
+  @Test
+  public void unsupportedFeatureFormatIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] unsupported = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(unsupported).putInt(12, 99);
+    updateChecksum(unsupported);
+    Files.write(authorityPath(1), unsupported);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unsupported feature format version: 99");
+  }
+
+  /** A checksum-valid unknown state fails closed instead of using an older record. */
+  @Test
+  public void unsupportedAuthorityStateIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] invalid = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(invalid).putInt(24, 99);
+    updateChecksum(invalid);
+    Files.write(authorityPath(1), invalid);
+
+    assertThatThrownBy(metadata::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unsupported bootstrap state: 99");
+  }
+
+  /** A checksum-valid nonzero reserved field fails closed and names that value. */
+  @Test
+  public void nonzeroReservedFieldIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] invalid = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(invalid).putInt(28, 99);
+    updateChecksum(invalid);
+    Files.write(authorityPath(1), invalid);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Invalid bootstrap authority reserved field: 99");
+  }
+
+  /** A checksum-valid nonpositive generation fails closed and names that value. */
+  @Test
+  public void invalidAuthorityGenerationIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] invalid = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(invalid).putLong(16, 0);
+    updateChecksum(invalid);
+    Files.write(authorityPath(1), invalid);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Invalid bootstrap authority generation: 0");
+  }
+
+  /** A checksum-valid negative sequence value fails closed and names that value. */
+  @Test
+  public void invalidHighestIssuedValueIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] invalid = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(invalid).putLong(64, -1);
+    updateChecksum(invalid);
+    Files.write(authorityPath(1), invalid);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Invalid bootstrap authority highest issued value: -1");
+  }
+
+  /** Temporary publication residue is never treated as confirmed authority. */
+  @Test
+  public void temporaryResidueFailsClosed() throws IOException {
+    final var metadata = metadata();
+    metadata.createBirth(STORAGE, LINEAGE_ONE);
+    Files.write(temporaryPath(1), new byte[] {1});
+
+    assertThatThrownBy(metadata::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("temporary");
+  }
+
+  /** Equal floor advance preserves the live token so its creating object can activate birth. */
+  @Test
+  public void equalBirthFloorAdvancePreservesLiveToken() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+
+    final var repeated =
+        metadata.advanceFloor(birth, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 0));
+
+    assertThat(repeated).isSameAs(birth);
+    assertThat(metadata.activate(repeated).state())
+        .isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+  }
+
+  /** Floor rules reject rewinds and foreign identities while accepting an equal no-op. */
+  @Test
+  public void floorAdvancementIsIdentityQualifiedAndMonotonic() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var floor = new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 8);
+    final var advanced = metadata.advanceFloor(birth, floor);
+
+    assertThat(metadata.advanceFloor(advanced, floor)).isEqualTo(advanced);
+    assertThatThrownBy(
+        () -> metadata.advanceFloor(
+            advanced, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("rewind");
+    assertThatThrownBy(
+        () -> metadata.advanceFloor(
+            advanced, new LogicalSequenceFloor(SOURCE_STORAGE, LINEAGE_ONE, 9)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("identity");
+  }
+
+  /** Production replacement generates a lineage distinct from both inputs and retains the floor. */
+  @Test
+  public void lineageReplacementRetainsTargetHighWater() throws IOException {
+    final var metadata = metadata();
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var highTarget =
+        metadata.advanceFloor(birth, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 50));
+    final var active = metadata.activate(highTarget);
+
+    final var replacement = metadata.beginLineageReplacement(active, adoption(20));
+    final var newLineage = replacement.lineageIdentity();
+    assertThat(newLineage).isNotEqualTo(LINEAGE_ONE).isNotEqualTo(SOURCE_LINEAGE);
+    assertThat(replacement.sequenceFloor())
+        .isEqualTo(new LogicalSequenceFloor(STORAGE, newLineage, 50));
+  }
+
+  /** A current-lineage collision is retried, and the next fresh candidate is returned. */
+  @Test
+  public void freshLineageRetriesCurrentLineageCollision() {
+    final var candidates = List.of(LINEAGE_ONE, LINEAGE_THREE).iterator();
+
+    assertThat(
+        StorageBootstrapMetadata.generateFreshLineage(
+            candidates::next, LINEAGE_ONE, SOURCE_LINEAGE))
+        .isEqualTo(LINEAGE_THREE);
+  }
+
+  /** A source-lineage collision is retried, and the next fresh candidate is returned. */
+  @Test
+  public void freshLineageRetriesSourceLineageCollision() {
+    final var candidates = List.of(SOURCE_LINEAGE, LINEAGE_THREE).iterator();
+
+    assertThat(
+        StorageBootstrapMetadata.generateFreshLineage(
+            candidates::next, LINEAGE_ONE, SOURCE_LINEAGE))
+        .isEqualTo(LINEAGE_THREE);
+  }
+
+  /** Three colliding candidates exhaust the fixed retry bound and report the collision cause. */
+  @Test
+  public void freshLineageRejectsCollisionExhaustion() {
+    final var attempts = new AtomicInteger();
+
+    assertThatThrownBy(
+        () -> StorageBootstrapMetadata.generateFreshLineage(
+            () -> attempts.getAndIncrement() % 2 == 0 ? LINEAGE_ONE : SOURCE_LINEAGE,
+            LINEAGE_ONE,
+            SOURCE_LINEAGE))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("all 3 candidates collided")
+        .hasMessageContaining("current or source lineage identity");
+    assertThat(attempts).hasValue(3);
+  }
+
+  /** Every null generation input is rejected with the protected parameter's name. */
+  @Test
+  public void freshLineageRejectsNullInputs() {
+    assertThatThrownBy(
+        () -> StorageBootstrapMetadata.generateFreshLineage(null, LINEAGE_ONE, SOURCE_LINEAGE))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("candidateSource");
+    assertThatThrownBy(
+        () -> StorageBootstrapMetadata.generateFreshLineage(() -> LINEAGE_THREE, null,
+            SOURCE_LINEAGE))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("currentLineage");
+    assertThatThrownBy(
+        () -> StorageBootstrapMetadata.generateFreshLineage(() -> LINEAGE_THREE, LINEAGE_ONE, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("sourceLineage");
+    assertThatThrownBy(
+        () -> StorageBootstrapMetadata.generateFreshLineage(() -> null, LINEAGE_ONE,
+            SOURCE_LINEAGE))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("candidateSource returned null");
+  }
+
+  /** Recovery accepts the active-to-restore successor that starts a fresh lineage. */
+  @Test
+  public void recoveryAcceptsLineageReplacementSuccessor() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var replacement = creator.beginLineageReplacement(active, adoption(20));
+
+    assertThat(metadata().readRequired()).isEqualTo(replacement);
+  }
+
+  /** A FIFO at the lock path is rejected before FileChannel.open can block. */
+  @Test(timeout = 10_000)
+  public void specialLockResourceFailsPromptly() throws Exception {
+    Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+    final var lockPath = directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME);
+    final var process = new ProcessBuilder("mkfifo", lockPath.toString()).start();
+    Assume.assumeTrue("mkfifo is unavailable", process.waitFor() == 0);
+
+    assertThatThrownBy(metadata()::readRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("lock is not a regular file");
+  }
+
+  /** Process lock entries exist only while an operation uses them. */
+  @Test
+  public void processLockRetentionIsBoundedByActiveOperations() throws IOException {
+    for (var i = 0; i < 100; i++) {
+      final var child = Files.createDirectory(directory.resolve("storage-" + i));
+      assertThatThrownBy(() -> new StorageBootstrapMetadata(child, FORMAT).readRequired())
+          .isInstanceOf(IOException.class);
+      assertThat(StorageBootstrapMetadata.processLockCountForTests()).isZero();
+    }
+  }
+
+  /** A symbolic directory alias shares the same process publication exclusion domain. */
+  @Test
+  public void pathAliasesSerializePublication() throws Exception {
+    final var alias = directory.resolveSibling(directory.getFileName() + "-alias");
+    try {
+      Files.createSymbolicLink(alias, directory);
+    } catch (UnsupportedOperationException | IOException e) {
+      Assume.assumeNoException("Symbolic links are not supported", e);
+    }
+    try {
+      final var started = new CountDownLatch(1);
+      final var proceed = new CountDownLatch(1);
+      final var moves = new AtomicInteger();
+      final var blocking =
+          new StorageBootstrapMetadata(
+              directory,
+              FORMAT,
+              (source, target, requester) -> {
+                if (moves.incrementAndGet() == 2) {
+                  started.countDown();
+                  await(proceed);
+                }
+                FileUtils.durableAtomicMove(source, target, requester);
+              });
+      final var birth = blocking.createBirth(STORAGE, LINEAGE_ONE);
+      final var throughAlias = new StorageBootstrapMetadata(alias, FORMAT);
+
+      try (var executor = Executors.newFixedThreadPool(2)) {
+        final var activation = executor.submit(() -> blocking.activate(birth));
+        assertThat(started.await(10, TimeUnit.SECONDS)).isTrue();
+        final var read = executor.submit(throughAlias::readRequired);
+        assertThat(read.isDone()).isFalse();
+        proceed.countDown();
+        assertThat(activation.get(10, TimeUnit.SECONDS).state())
+            .isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+        assertThat(read.get(10, TimeUnit.SECONDS).state())
+            .isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+      }
+    } finally {
+      Files.deleteIfExists(alias);
+    }
+  }
+
+  /** Generation exhaustion fails before a wrapped record can be published. */
+  @Test
+  public void generationExhaustionIsRejected() throws Exception {
+    final var metadata = metadata();
+    final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] record = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(record).putLong(16, Long.MAX_VALUE);
+    updateChecksum(record);
+    Files.write(authorityPath(1), record);
+    final var exhausted = metadata().readRequired();
+
+    assertThatThrownBy(
+        () -> metadata().advanceFloor(
+            exhausted, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 1)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("generation is exhausted");
+    assertThat(active.state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+  }
+
+  /** Value objects reject null identities and invalid numeric values before persistence. */
+  @Test
+  public void identityValueObjectsRejectInvalidValues() {
+    assertThatThrownBy(() -> new FeatureFormatIdentity(0))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StorageIdentity(null)).isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new StorageLineageIdentity(null))
+        .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, -1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private StorageBootstrapMetadata metadata() throws IOException {
+    return new StorageBootstrapMetadata(directory, FORMAT);
+  }
+
+  private List<Path> authorityFiles() {
+    return Stream.iterate(0, i -> i + 1)
+        .limit(StorageBootstrapMetadata.AUTHORITY_FILE_NAMES.size())
+        .map(this::authorityPath)
+        .filter(Files::exists)
+        .toList();
+  }
+
+  private List<Path> temporaryFiles() {
+    return Stream.iterate(0, i -> i + 1)
+        .limit(StorageBootstrapMetadata.AUTHORITY_FILE_NAMES.size())
+        .map(this::temporaryPath)
+        .filter(Files::exists)
+        .toList();
+  }
+
+  private Path authorityPath(final int index) {
+    return directory.resolve(StorageBootstrapMetadata.AUTHORITY_FILE_NAMES.get(index));
+  }
+
+  private Path temporaryPath(final int index) {
+    final var authority = authorityPath(index);
+    return authority.resolveSibling(authority.getFileName() + ".tmp");
+  }
+
+  private LineageFloorAdoption adoption(final long highestIssued) {
+    return new LineageFloorAdoption(
+        FORMAT, new LogicalSequenceFloor(SOURCE_STORAGE, SOURCE_LINEAGE, highestIssued));
+  }
+
+  private static long readGeneration(final Path path) throws IOException {
+    return ByteBuffer.wrap(Files.readAllBytes(path)).getLong(16);
+  }
+
+  private static void updateChecksum(final byte[] record) {
+    final var checksum =
+        XXHashFactory.fastestInstance().hash64().hash(record, 0, 72, 0x648B7A2195D3L);
+    ByteBuffer.wrap(record).putLong(72, checksum);
+  }
+
+  private static void await(final CountDownLatch latch) throws IOException {
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IOException("Timed out while holding publication");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while holding publication", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Throwable> void throwUnchecked(final Throwable failure) throws T {
+    throw (T) failure;
+  }
+
+  private void deleteQuietly(final Path path) {
+    try {
+      Files.deleteIfExists(path);
+    } catch (IOException ignored) {
+      // Best-effort cleanup after each deterministic test.
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -16,14 +17,17 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import net.jpountz.xxhash.XXHashFactory;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /** Tests redundant bootstrap selection, publication, recovery, and birth ownership. */
+@Category(SequentialTest.class)
 public class StorageBootstrapMetadataTest {
 
   private static final FeatureFormatIdentity FORMAT = new FeatureFormatIdentity(25);
@@ -157,18 +161,21 @@ public class StorageBootstrapMetadataTest {
     assertThat(Files.readAllBytes(authorityPath(0))).isEqualTo(selectedBytes);
   }
 
-  /** A failed publication removes its candidate and leaves selected authority readable. */
+  /** Failed publication removes the observed candidate without deleting the storage directory. */
   @Test
-  public void failedPublicationPreservesSelectedAuthority() throws IOException {
+  public void failedPublicationRemovesCandidateWithoutDirectoryDeletion() throws IOException {
     final var creator = metadata();
     final var birth = creator.createBirth(STORAGE, LINEAGE_ONE);
     final var active = creator.activate(birth);
     final byte[] selectedBytes = Files.readAllBytes(authorityPath(1));
+    final var observedCandidate = new AtomicReference<Path>();
     final var failing =
         new StorageBootstrapMetadata(
             directory,
             FORMAT,
             (source, target, requester) -> {
+              assertThat(source).exists();
+              observedCandidate.set(source);
               throw new IOException("injected publication failure");
             });
 
@@ -177,8 +184,10 @@ public class StorageBootstrapMetadataTest {
             active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)))
         .isInstanceOf(IOException.class)
         .hasMessageContaining("injected");
+    assertThat(observedCandidate).doesNotHaveValue(null);
+    assertThat(observedCandidate.get()).doesNotExist();
+    assertThat(directory).isDirectory();
     assertThat(Files.readAllBytes(authorityPath(1))).isEqualTo(selectedBytes);
-    assertThat(temporaryFiles()).isEmpty();
     assertThat(metadata().readActiveRequired()).isEqualTo(active);
   }
 
@@ -326,22 +335,15 @@ public class StorageBootstrapMetadataTest {
     assertThat(thrown.getSuppressed()).containsExactly(cleanupFailure);
   }
 
-  /** Residue present before a call is not removed and keeps recovery fail closed. */
+  /** Confirmation removes an abandoned candidate when durable authority still exists. */
   @Test
-  public void preexistingCandidateResidueIsNeverRemoved() throws IOException {
+  public void preexistingCandidateResidueIsRemovedDuringRead() throws IOException {
     final var metadata = metadata();
     final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
     Files.write(temporaryPath(2), new byte[] {1});
 
-    assertThatThrownBy(
-        () -> metadata.advanceFloor(
-            active, new LogicalSequenceFloor(STORAGE, LINEAGE_ONE, 7)))
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("temporary");
-    assertThat(Files.readAllBytes(temporaryPath(2))).containsExactly(1);
-    assertThatThrownBy(metadata::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("temporary");
+    assertThat(metadata.readActiveRequired()).isEqualTo(active);
+    assertThat(temporaryFiles()).isEmpty();
   }
 
   /** Candidate cleanup failure is suppressed under the original publication failure. */
@@ -577,16 +579,25 @@ public class StorageBootstrapMetadataTest {
         .hasMessageContaining("Invalid bootstrap authority highest issued value: -1");
   }
 
-  /** Temporary publication residue is never treated as confirmed authority. */
+  /** Temporary publication residue is removed without treating its bytes as authority. */
   @Test
-  public void temporaryResidueFailsClosed() throws IOException {
+  public void temporaryResidueIsDiscardedWhenAuthorityExists() throws IOException {
     final var metadata = metadata();
-    metadata.createBirth(STORAGE, LINEAGE_ONE);
+    final var birth = metadata.createBirth(STORAGE, LINEAGE_ONE);
     Files.write(temporaryPath(1), new byte[] {1});
 
-    assertThatThrownBy(metadata::readRequired)
+    assertThat(metadata.readRequired()).isEqualTo(birth);
+    assertThat(temporaryFiles()).isEmpty();
+  }
+
+  /** Temporary publication residue without durable authority still blocks a new birth. */
+  @Test
+  public void temporaryResidueWithoutAuthorityBlocksCreation() throws IOException {
+    Files.write(temporaryPath(0), new byte[] {1});
+
+    assertThatThrownBy(() -> metadata().createBirth(STORAGE, LINEAGE_ONE))
         .isInstanceOf(IOException.class)
-        .hasMessageContaining("temporary");
+        .hasMessageContaining("already exists");
   }
 
   /** Equal floor advance preserves the live token so its creating object can activate birth. */
@@ -622,6 +633,16 @@ public class StorageBootstrapMetadataTest {
             advanced, new LogicalSequenceFloor(SOURCE_STORAGE, LINEAGE_ONE, 9)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("identity");
+  }
+
+  /** Lineage replacement rejects a birth that has not become active. */
+  @Test
+  public void lineageReplacementRequiresActiveStorage() throws IOException {
+    final var birth = metadata().createBirth(STORAGE, LINEAGE_ONE);
+
+    assertThatThrownBy(() -> metadata().beginLineageReplacement(birth, adoption(20)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Lineage replacement requires active storage");
   }
 
   /** Production replacement generates a lineage distinct from both inputs and retains the floor. */
@@ -709,6 +730,33 @@ public class StorageBootstrapMetadataTest {
     final var replacement = creator.beginLineageReplacement(active, adoption(20));
 
     assertThat(metadata().readRequired()).isEqualTo(replacement);
+  }
+
+  /** Open rejects an interrupted restore instead of accepting partially replaced content. */
+  @Test
+  public void openRejectsInterruptedRestore() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    creator.beginLineageReplacement(active, adoption(20));
+
+    assertThatThrownBy(metadata()::readActiveRequired)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Interrupted storage restore");
+  }
+
+  /** A failed replacement token permits another restore attempt under the pending lineage. */
+  @Test
+  public void failedLineageReplacementCanBeRetried() throws IOException {
+    final var metadata = metadata();
+    final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final var failedReplacement = metadata.beginLineageReplacement(active, adoption(20));
+
+    final var retry = metadata.beginLineageReplacement(failedReplacement, adoption(30));
+    final var completed = metadata.activate(retry);
+
+    assertThat(retry).isEqualTo(failedReplacement);
+    assertThat(completed.state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
+    assertThat(completed.lineageIdentity()).isEqualTo(failedReplacement.lineageIdentity());
   }
 
   /** A FIFO at the lock path is rejected before FileChannel.open can block. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageBootstrapMetadataTest.java
@@ -2,15 +2,23 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.StorageAdmissionException.Reason;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -72,6 +80,210 @@ public class StorageBootstrapMetadataTest {
     assertThat(birth.sequenceFloor().highestIssued()).isZero();
     assertThat(authorityFiles()).containsExactly(authorityPath(0));
     assertThat(Files.size(authorityPath(0))).isEqualTo(80);
+    // Storage birth writes the storage layout version into the former spare field at offset 28.
+    assertThat(readStorageLayoutVersion(authorityPath(0)))
+        .isEqualTo(StorageBootstrapMetadata.SUPPORTED_STORAGE_LAYOUT_VERSION);
+  }
+
+  /**
+   * A record whose storage layout version field holds an unsupported value is rejected by name.
+   *
+   * <p>The scenario mutates one checksum-valid copy to storage layout version 99. The expected
+   * outcome is one rejection with the unsupported-storage-layout-version reason.
+   */
+  @Test
+  public void unsupportedStorageLayoutVersionIsRejected() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] unsupported = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(unsupported).putInt(28, 99);
+    updateChecksum(unsupported);
+    Files.write(authorityPath(1), unsupported);
+
+    final var rejection = admissionRejection(metadata()::readRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.UNSUPPORTED_STORAGE_LAYOUT_VERSION);
+    assertThat(rejection).hasMessageContaining("Unsupported storage layout version: 99");
+  }
+
+  /**
+   * An image of an earlier commit of this branch holds the empty storage layout version zero.
+   *
+   * <p>The scenario mutates one checksum-valid copy to the empty value zero. The expected outcome
+   * is the unsupported-storage-layout-version reason. The outcome is neither a damaged record nor
+   * a missing record.
+   */
+  @Test
+  public void emptyStorageLayoutVersionOfEarlierCommitIsUnsupported() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] earlierCommit = Files.readAllBytes(authorityPath(1));
+    ByteBuffer.wrap(earlierCommit).putInt(28, 0);
+    updateChecksum(earlierCommit);
+    Files.write(authorityPath(1), earlierCommit);
+
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.UNSUPPORTED_STORAGE_LAYOUT_VERSION);
+    assertThat(rejection.reason()).isNotEqualTo(Reason.AUTHORITY_DAMAGED);
+    assertThat(rejection.reason()).isNotEqualTo(Reason.AUTHORITY_MISSING);
+    assertThat(rejection).hasMessageContaining("Unsupported storage layout version: 0");
+  }
+
+  /**
+   * The integrity check runs before the storage layout version check.
+   *
+   * <p>The scenario breaks the storage layout version of the older copy and leaves the checksum
+   * stale. The expected outcome is a tolerated damaged copy and a successful read of the active
+   * copy. A layout check before the integrity check would instead reject the whole image.
+   */
+  @Test
+  public void integrityCheckPrecedesStorageLayoutVersionCheck() throws IOException {
+    final var metadata = metadata();
+    final var active = metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] damaged = Files.readAllBytes(authorityPath(0));
+    ByteBuffer.wrap(damaged).putInt(28, 99);
+    Files.write(authorityPath(0), damaged);
+
+    assertThat(metadata().readActiveRequired()).isEqualTo(active);
+  }
+
+  /**
+   * A directory whose every copy fails the integrity check reports an interrupted birth.
+   *
+   * <p>The scenario overwrites both existing copies with checksum-invalid content. The expected
+   * outcome is the interrupted-birth reason with one suppressed damaged-copy failure per copy.
+   */
+  @Test
+  public void everyCopyDamagedReportsInterruptedBirthWithDamageDetail() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    for (var index = 0; index < 2; index++) {
+      final byte[] damaged = Files.readAllBytes(authorityPath(index));
+      ByteBuffer.wrap(damaged).putLong(72, 0);
+      Files.write(authorityPath(index), damaged);
+    }
+
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    assertThat(rejection.getSuppressed()).hasSize(2);
+    for (var suppressed : rejection.getSuppressed()) {
+      assertThat(((StorageAdmissionException) suppressed).reason())
+          .isEqualTo(Reason.AUTHORITY_DAMAGED);
+    }
+  }
+
+  /**
+   * A directory without any bootstrap authority artifact reports a missing record.
+   *
+   * <p>The scenario reads an empty storage directory. The expected outcome is the authority-missing
+   * reason and a message that names the reason and the storage path.
+   */
+  @Test
+  public void directoryWithoutArtifactReportsMissingRecord() throws IOException {
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_MISSING);
+    assertThat(rejection).hasMessageContaining("admission reason: AUTHORITY_MISSING");
+    assertThat(rejection).hasMessageContaining(directory.toRealPath().toString());
+  }
+
+  /**
+   * A directory that holds only the authority lock file reports an interrupted birth.
+   *
+   * <p>The scenario creates the authority lock file alone. The expected outcome is the
+   * interrupted-birth reason, because the lock file is a bootstrap authority artifact.
+   */
+  @Test
+  public void lockFileResidueReportsInterruptedBirth() throws IOException {
+    Files.createFile(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME));
+
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+  }
+
+  /**
+   * A directory that holds only an unfinished record candidate reports an interrupted birth.
+   *
+   * <p>The scenario creates one candidate file without any authority copy. The expected outcome is
+   * the interrupted-birth reason, and the candidate file survives the rejected decision.
+   */
+  @Test
+  public void candidateResidueWithoutRecordReportsInterruptedBirth() throws IOException {
+    Files.write(temporaryPath(0), new byte[] {1});
+
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    assertThat(temporaryPath(0)).exists();
+  }
+
+  /**
+   * Admission repair removes candidate residue and confirms the accepted snapshot.
+   *
+   * <p>The scenario leaves one candidate file next to one active record. The expected outcome is an
+   * accepted snapshot, no candidate residue, and one further confirmed copy.
+   */
+  @Test
+  public void admissionRepairRemovesCandidateAndConfirmsSnapshot() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    Files.delete(authorityPath(0));
+    Files.write(temporaryPath(2), new byte[] {1});
+
+    assertThat(metadata().readActiveRequired()).isEqualTo(active);
+    assertThat(temporaryFiles()).isEmpty();
+    assertThat(authorityFiles()).hasSize(2);
+  }
+
+  /**
+   * A failed repair after acceptance never fails the admission decision.
+   *
+   * <p>The scenario injects a publication failure into the repair of an accepted image. The
+   * expected outcome is the accepted snapshot and an unchanged authority copy count.
+   */
+  @Test
+  public void failedRepairAfterAcceptanceKeepsAdmissionSuccessful() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var failingRepair =
+        new StorageBootstrapMetadata(
+            directory,
+            FORMAT,
+            (source, target, requester) -> {
+              throw new IOException("injected repair failure");
+            });
+
+    assertThat(failingRepair.readActiveRequired()).isEqualTo(active);
+    assertThat(authorityFiles()).hasSize(2);
+    assertThat(temporaryFiles()).isEmpty();
+  }
+
+  /**
+   * A low-level input and output failure of the decision carries one named reason.
+   *
+   * <p>The scenario removes every read permission from the only authority copy. The expected
+   * outcome is the authority-input-output-failure reason.
+   */
+  @Test
+  public void lowLevelReadFailureReportsInputOutputReason() throws IOException {
+    Assume.assumeTrue(
+        "Posix file permissions are unavailable",
+        Files.getFileStore(directory).supportsFileAttributeView("posix"));
+    Assume.assumeFalse("The root user ignores file permissions", "root".equals(
+        System.getProperty("user.name")));
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    Files.setPosixFilePermissions(authorityPath(0), PosixFilePermissions.fromString("---------"));
+    try {
+      final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+      assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_IO_FAILURE);
+    } finally {
+      Files.setPosixFilePermissions(authorityPath(0), PosixFilePermissions.fromString("rw-------"));
+    }
   }
 
   /** The live creator can activate its token while another instance rejects the interrupted birth. */
@@ -82,9 +294,9 @@ public class StorageBootstrapMetadataTest {
     final var laterOperation = metadata();
     final var discovered = laterOperation.readRequired();
 
-    assertThatThrownBy(laterOperation::readActiveRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Interrupted storage birth");
+    final var rejection = admissionRejection(laterOperation::readActiveRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    assertThat(rejection).hasMessageContaining("Interrupted storage birth");
     assertThatThrownBy(() -> laterOperation.activate(discovered))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("cannot continue");
@@ -410,9 +622,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(conflict);
     Files.write(authorityPath(0), conflict);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("ambiguous");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_AMBIGUOUS);
+    assertThat(rejection).hasMessageContaining("ambiguous");
     assertThat(active.generation()).isEqualTo(2);
   }
 
@@ -426,24 +638,36 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(foreign);
     Files.write(authorityPath(0), foreign);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("ambiguous");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.FOREIGN_AUTHORITY_COPY);
+    assertThat(rejection).hasMessageContaining("different storage identities");
   }
 
-  /** Consecutive valid generations with an illegal lifecycle transition fail closed. */
+  /**
+   * Consecutive valid generations with an illegal lifecycle transition fail closed.
+   *
+   * <p>The scenario mutates the older copy into the active lifecycle state and mutates the newer
+   * copy into the birth-in-progress lifecycle state. An active image never returns to a birth, so
+   * that pair stays illegal. The expected outcome is one rejection with the illegal-transition
+   * reason. The pair of a birth and a restore is no longer illegal, because Track 24 allows the
+   * transition from birth in progress to restore in progress.
+   */
   @Test
   public void illegalStateTransitionIsRejected() throws IOException {
     final var metadata = metadata();
     metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    final byte[] olderCopy = Files.readAllBytes(authorityPath(0));
+    ByteBuffer.wrap(olderCopy).putInt(24, 2);
+    updateChecksum(olderCopy);
+    Files.write(authorityPath(0), olderCopy);
     final byte[] illegal = Files.readAllBytes(authorityPath(1));
-    ByteBuffer.wrap(illegal).putInt(24, 3);
+    ByteBuffer.wrap(illegal).putInt(24, 1);
     updateChecksum(illegal);
     Files.write(authorityPath(1), illegal);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("illegal state transition");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_ILLEGAL_TRANSITION);
+    assertThat(rejection).hasMessageContaining("illegal state transition");
   }
 
   /** One torn authority is ignored when another complete authority remains selectable. */
@@ -469,9 +693,9 @@ public class StorageBootstrapMetadataTest {
       Assume.assumeNoException("Symbolic links are not supported", e);
     }
 
-    assertThatThrownBy(metadata::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("not a regular file");
+    final var rejection = admissionRejection(metadata::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.NON_REGULAR_AUTHORITY_FILE);
+    assertThat(rejection).hasMessageContaining("not a regular file");
   }
 
   /** A checksum-valid wrong magic value fails closed instead of using older authority. */
@@ -484,9 +708,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(invalid);
     Files.write(authorityPath(1), invalid);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Invalid bootstrap authority magic: 7");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_INVALID_CONTENT);
+    assertThat(rejection).hasMessageContaining("Invalid bootstrap authority magic: 7");
   }
 
   /** A checksum-valid unsupported encoding version fails closed and names that version. */
@@ -499,9 +723,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(unsupported);
     Files.write(authorityPath(1), unsupported);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Unsupported bootstrap encoding version: 99");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.UNSUPPORTED_ENCODING_VERSION);
+    assertThat(rejection).hasMessageContaining("Unsupported bootstrap encoding version: 99");
   }
 
   /** A checksum-valid foreign feature format fails closed instead of using an older record. */
@@ -514,9 +738,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(unsupported);
     Files.write(authorityPath(1), unsupported);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Unsupported feature format version: 99");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.UNSUPPORTED_FEATURE_FORMAT_VERSION);
+    assertThat(rejection).hasMessageContaining("Unsupported feature format version: 99");
   }
 
   /** A checksum-valid unknown state fails closed instead of using an older record. */
@@ -529,24 +753,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(invalid);
     Files.write(authorityPath(1), invalid);
 
-    assertThatThrownBy(metadata::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Unsupported bootstrap state: 99");
-  }
-
-  /** A checksum-valid nonzero reserved field fails closed and names that value. */
-  @Test
-  public void nonzeroReservedFieldIsRejected() throws IOException {
-    final var metadata = metadata();
-    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
-    final byte[] invalid = Files.readAllBytes(authorityPath(1));
-    ByteBuffer.wrap(invalid).putInt(28, 99);
-    updateChecksum(invalid);
-    Files.write(authorityPath(1), invalid);
-
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Invalid bootstrap authority reserved field: 99");
+    final var rejection = admissionRejection(metadata::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.UNSUPPORTED_LIFECYCLE_STATE);
+    assertThat(rejection).hasMessageContaining("Unsupported bootstrap state: 99");
   }
 
   /** A checksum-valid nonpositive generation fails closed and names that value. */
@@ -559,9 +768,9 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(invalid);
     Files.write(authorityPath(1), invalid);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Invalid bootstrap authority generation: 0");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_INVALID_CONTENT);
+    assertThat(rejection).hasMessageContaining("Invalid bootstrap authority generation: 0");
   }
 
   /** A checksum-valid negative sequence value fails closed and names that value. */
@@ -574,9 +783,10 @@ public class StorageBootstrapMetadataTest {
     updateChecksum(invalid);
     Files.write(authorityPath(1), invalid);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Invalid bootstrap authority highest issued value: -1");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.INVALID_SEQUENCE_FLOOR);
+    assertThat(rejection).hasMessageContaining(
+        "Invalid bootstrap authority highest issued value: -1");
   }
 
   /** Temporary publication residue is removed without treating its bytes as authority. */
@@ -739,9 +949,9 @@ public class StorageBootstrapMetadataTest {
     final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
     creator.beginLineageReplacement(active, adoption(20));
 
-    assertThatThrownBy(metadata()::readActiveRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("Interrupted storage restore");
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_RESTORE);
+    assertThat(rejection).hasMessageContaining("Interrupted storage restore");
   }
 
   /** A failed replacement token permits another restore attempt under the pending lineage. */
@@ -767,9 +977,9 @@ public class StorageBootstrapMetadataTest {
     final var process = new ProcessBuilder("mkfifo", lockPath.toString()).start();
     Assume.assumeTrue("mkfifo is unavailable", process.waitFor() == 0);
 
-    assertThatThrownBy(metadata()::readRequired)
-        .isInstanceOf(IOException.class)
-        .hasMessageContaining("lock is not a regular file");
+    final var rejection = admissionRejection(metadata()::readRequired);
+    assertThat(rejection.reason()).isEqualTo(Reason.NON_REGULAR_AUTHORITY_FILE);
+    assertThat(rejection).hasMessageContaining("lock is not a regular file");
   }
 
   /** Process lock entries exist only while an operation uses them. */
@@ -845,6 +1055,545 @@ public class StorageBootstrapMetadataTest {
     assertThat(active.state()).isEqualTo(StorageBootstrapMetadata.State.ACTIVE);
   }
 
+  /**
+   * A restore target publishes the restore-in-progress state directly from the birth state.
+   *
+   * <p>The scenario creates one birth record and publishes the restore-in-progress lifecycle state
+   * without any activation. The expected outcome has three parts. The published record carries the
+   * restore-in-progress lifecycle state. The published record keeps the storage identity, the
+   * storage lineage, and the logical sequence floor of the birth record. A later read accepts the
+   * successor, which proves that the lifecycle transition table allows the new transition.
+   */
+  @Test
+  public void restoreTargetPublishesRestoreStateFromBirthState() throws IOException {
+    final var creator = metadata();
+    final var birth = creator.createBirth(STORAGE, LINEAGE_ONE);
+
+    final var restoreTarget = creator.beginRestoreFromBirth(birth);
+
+    assertThat(restoreTarget.state())
+        .isEqualTo(StorageBootstrapMetadata.State.RESTORE_IN_PROGRESS);
+    assertThat(restoreTarget.generation()).isEqualTo(birth.generation() + 1);
+    assertThat(restoreTarget.sequenceFloor()).isEqualTo(birth.sequenceFloor());
+    assertThat(metadata().readRequired()).isEqualTo(restoreTarget);
+  }
+
+  /**
+   * The restore transition of one target is repeat safe.
+   *
+   * <p>A restore of one target can start a second time after a failed first attempt. The scenario
+   * publishes the restore-in-progress lifecycle state twice for the same target. The expected
+   * outcome has three parts. The second call returns the snapshot of the first call. The second
+   * call publishes no new generation. The durable record still holds the first published record.
+   */
+  @Test
+  public void restoreTransitionIsRepeatSafeForTheSameTarget() throws IOException {
+    final var creator = metadata();
+    final var first = creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+
+    final var second = creator.beginRestoreFromBirth(first);
+
+    assertThat(second).isEqualTo(first);
+    assertThat(second.generation()).isEqualTo(first.generation());
+    assertThat(metadata().readRequired()).isEqualTo(first);
+  }
+
+  /**
+   * The new transition refuses a record that no longer carries the birth-in-progress state.
+   *
+   * <p>The scenario activates one birth record and then asks for the restore transition. The
+   * expected outcome is one refusal that names the required source state.
+   */
+  @Test
+  public void restoreTransitionRequiresTheBirthState() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+
+    assertThatThrownBy(() -> creator.beginRestoreFromBirth(active))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("birth-in-progress state only");
+  }
+
+  /**
+   * The restart deletion removes every content file before the authority copies.
+   *
+   * <p>A destructive restart is the full deletion of an interrupted restore target and a fresh
+   * restore. The scenario deletes one restore target and inspects the directory from inside the
+   * content deletion. The expected outcome has four parts. Every authority copy still exists
+   * while the content deletion runs. The content file is gone after the deletion. No authority
+   * copy and no unfinished record candidate survives the deletion. The authority lock file stays
+   * in place, because an unlink of that file would split the exclusive unit across two file
+   * objects.
+   */
+  @Test
+  public void restartDeletionRemovesAuthorityCopiesAfterContent() throws IOException {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var contentFile = Files.createFile(directory.resolve("content.pcl"));
+    final var authorityCountBeforeDeletion = authorityFiles().size();
+    final var authorityCountDuringContentDeletion = new AtomicInteger(-1);
+
+    creator.deleteInterruptedRestoreTarget(
+        storageDirectory -> {
+          authorityCountDuringContentDeletion.set(authorityFiles().size());
+          Files.delete(contentFile);
+        });
+
+    assertThat(authorityCountBeforeDeletion).isPositive();
+    assertThat(authorityCountDuringContentDeletion.get()).isEqualTo(authorityCountBeforeDeletion);
+    assertThat(Files.exists(contentFile)).isFalse();
+    assertThat(authorityFiles()).isEmpty();
+    assertThat(temporaryFiles()).isEmpty();
+    assertThat(Files.exists(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME))).isTrue();
+  }
+
+  /**
+   * The restart deletion unlinks the copy of the newest record last.
+   *
+   * <p>A generation is a counter inside the bootstrap authority record, and a higher value means a
+   * newer record. A crash inside the copy loop must keep the newest record on disk, because that
+   * newest record carries the restore-in-progress lifecycle state. A deletion in file-name order
+   * would break that property for one reachable slot layout.
+   *
+   * <p>The scenario builds the slot layout of an in-place restore. That layout writes the restore
+   * record into the first slot and keeps the older active record in the second slot and in the
+   * third slot. The scenario then stops the deletion after two unlinked copies. The expected
+   * outcome has three parts. The single remaining copy is the copy of the first slot. That
+   * remaining copy carries the restore record. A later restart still accepts the target.
+   */
+  @Test
+  public void restartDeletionUnlinksTheNewestAuthorityCopyLast() throws IOException {
+    final var creator = metadata();
+    final var active = creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    // A second instance confirms the active record into the third slot.
+    metadata().readRequired();
+    final var restore = creator.beginLineageReplacement(active, adoption(20));
+    assertThat(readGeneration(authorityPath(0))).isEqualTo(restore.generation());
+    assertThat(readGeneration(authorityPath(1))).isEqualTo(active.generation());
+    assertThat(readGeneration(authorityPath(2))).isEqualTo(active.generation());
+
+    final var unlinkedCopies = new AtomicInteger();
+    final var deletionStop = new IOException("the deletion stops inside the authority copy loop");
+    assertThatThrownBy(
+        () -> creator.deleteInterruptedRestoreTarget(
+            storageDirectory -> {
+            },
+            copy -> {
+              if (unlinkedCopies.getAndIncrement() == 2) {
+                throw deletionStop;
+              }
+              Files.deleteIfExists(copy);
+            }))
+        .isSameAs(deletionStop);
+
+    assertThat(authorityFiles()).containsExactly(authorityPath(0));
+    assertThat(readGeneration(authorityPath(0))).isEqualTo(restore.generation());
+    // The remaining copy still proves an interrupted restore, so a later restart repeats.
+    metadata().requireInterruptedRestoreTarget();
+  }
+
+  /**
+   * The interrupted-birth message names both causes of the state and advises no single deletion.
+   *
+   * <p>A complete database whose every authority copy fails the integrity check reaches the
+   * interrupted-birth reason. The message of that reason therefore must not advise the drop of the
+   * database as the single course of action. The scenario damages every copy of one active image.
+   * The expected outcome has three parts. The rejection reports the interrupted-birth reason. The
+   * message names the interrupted creation and names the damaged records. The message offers the
+   * backup of a complete database next to the drop of an incomplete database.
+   */
+  @Test
+  public void interruptedBirthMessageNamesBothCausesAndOffersARestore() throws IOException {
+    final var metadata = metadata();
+    metadata.activate(metadata.createBirth(STORAGE, LINEAGE_ONE));
+    for (var index = 0; index < 2; index++) {
+      final byte[] damaged = Files.readAllBytes(authorityPath(index));
+      ByteBuffer.wrap(damaged).putLong(72, 0);
+      Files.write(authorityPath(index), damaged);
+    }
+
+    final var rejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    final var description = Reason.INTERRUPTED_BIRTH.description();
+    assertThat(description).contains("An interrupted creation produces this state");
+    assertThat(description).contains("Damaged bootstrap authority records");
+    assertThat(description).contains("A backup restores a complete database");
+    assertThat(description).doesNotContain("Drop the database, and create the database again");
+  }
+
+  /**
+   * The restart refuses an active target and keeps every file of that target.
+   *
+   * <p>The scenario asks for the restart deletion of an active image. The expected outcome has two
+   * parts. The refusal names the reason for a target that is no interrupted restore. The content
+   * file and the authority copies survive the refusal.
+   */
+  @Test
+  public void restartRefusesActiveTarget() throws IOException {
+    final var creator = metadata();
+    creator.activate(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var contentFile = Files.createFile(directory.resolve("content.pcl"));
+
+    final var rejection =
+        admissionRejection(
+            () -> creator.deleteInterruptedRestoreTarget(
+                storageDirectory -> Files.delete(contentFile)));
+
+    assertThat(rejection.reason()).isEqualTo(Reason.RESTART_TARGET_NOT_RESTORE_IN_PROGRESS);
+    assertThat(rejection).hasMessageContaining("restore-in-progress lifecycle state only");
+    assertThat(Files.exists(contentFile)).isTrue();
+    assertThat(authorityFiles()).isNotEmpty();
+  }
+
+  /**
+   * The restart refuses an interrupted storage birth and keeps every file of that image.
+   *
+   * <p>The scenario asks for the restart deletion of a birth record. The expected outcome has two
+   * parts. The refusal names the interrupted-birth reason, which a drop tolerates. The authority
+   * copy survives the refusal.
+   */
+  @Test
+  public void restartRefusesInterruptedBirthTarget() throws IOException {
+    final var creator = metadata();
+    creator.createBirth(STORAGE, LINEAGE_ONE);
+
+    final var rejection =
+        admissionRejection(
+            () -> creator.deleteInterruptedRestoreTarget(storageDirectory -> {
+            }));
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    assertThat(authorityFiles()).isNotEmpty();
+  }
+
+  /**
+   * A same-process holder of the normal database lock prevents every restart mutation.
+   *
+   * <p>The scenario holds the existing dirty-file lock in this virtual machine and asks for a
+   * restart deletion. The expected outcome has four parts. The restart reports a busy target. The
+   * content callback never runs. Every original byte and authority copy survives. After lock
+   * release, the same deletion succeeds.
+   */
+  @Test
+  public void restartRefusesOverlappingNormalDatabaseLockAndSucceedsAfterRelease()
+      throws IOException {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var normalLockFile =
+        Files.writeString(
+            directory.resolve(StorageBootstrapMetadata.NORMAL_DATABASE_LOCK_FILE_NAME),
+            "dirty-metadata");
+    final var contentFile = Files.writeString(directory.resolve("content.pcl"), "payload");
+    final var authorityBeforeRefusal = authorityBytes();
+    final var deletionRan = new AtomicBoolean(false);
+
+    try (var channel =
+        FileChannel.open(
+            normalLockFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        var ignored = channel.lock()) {
+      final var rejection =
+          admissionRejection(
+              () -> creator.deleteInterruptedRestoreTarget(
+                  storageDirectory -> deletionRan.set(true)));
+
+      assertThat(rejection.reason()).isEqualTo(Reason.RESTART_TARGET_BUSY);
+      assertThat(Reason.RESTART_TARGET_BUSY.description())
+          .isEqualTo(
+              "The interrupted restore target is busy, so the destructive restart refuses the"
+                  + " database.");
+      assertThat(rejection).hasMessageContaining("normal database lock is busy");
+      assertThat(deletionRan.get()).isFalse();
+      assertThat(Files.readString(normalLockFile)).isEqualTo("dirty-metadata");
+      assertThat(Files.readString(contentFile)).isEqualTo("payload");
+      assertAuthorityBytesUnchanged(authorityBeforeRefusal);
+    }
+
+    creator.deleteInterruptedRestoreTarget(
+        storageDirectory -> {
+          Files.delete(contentFile);
+          Files.delete(normalLockFile);
+        });
+    assertThat(Files.exists(contentFile)).isFalse();
+    assertThat(Files.exists(normalLockFile)).isFalse();
+  }
+
+  /**
+   * A foreign-process holder of the normal database lock prevents every restart mutation.
+   *
+   * <p>The scenario starts one small Java helper process and waits for its bounded ready
+   * handshake. The expected outcome has four parts. The restart reports a busy target without
+   * waiting. Every original byte and authority copy survives. The helper exits after releasing its
+   * lock. The same deletion then succeeds.
+   */
+  @Test(timeout = 60_000)
+  public void restartRefusesForeignProcessNormalDatabaseLockAndSucceedsAfterRelease()
+      throws Exception {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var normalLockFile =
+        Files.writeString(
+            directory.resolve(StorageBootstrapMetadata.NORMAL_DATABASE_LOCK_FILE_NAME),
+            "dirty-metadata");
+    final var contentFile = Files.writeString(directory.resolve("content.pcl"), "payload");
+    final var authorityBeforeRefusal = authorityBytes();
+    final var lockHolder = startForeignLockHolder(normalLockFile);
+    try {
+      assertThat(awaitProcessLine(lockHolder)).isEqualTo("READY");
+
+      final var rejection =
+          admissionRejection(
+              () -> creator.deleteInterruptedRestoreTarget(
+                  storageDirectory -> {
+                    Files.delete(contentFile);
+                    Files.delete(normalLockFile);
+                  }));
+
+      assertThat(rejection.reason()).isEqualTo(Reason.RESTART_TARGET_BUSY);
+      assertThat(Files.readString(normalLockFile)).isEqualTo("dirty-metadata");
+      assertThat(Files.readString(contentFile)).isEqualTo("payload");
+      assertAuthorityBytesUnchanged(authorityBeforeRefusal);
+      lockHolder.outputWriter().write("release\n");
+      lockHolder.outputWriter().flush();
+      assertThat(lockHolder.waitFor(10, TimeUnit.SECONDS)).isTrue();
+      assertThat(lockHolder.exitValue()).isZero();
+    } finally {
+      stopProcess(lockHolder);
+    }
+
+    creator.deleteInterruptedRestoreTarget(
+        storageDirectory -> {
+          Files.delete(contentFile);
+          Files.delete(normalLockFile);
+        });
+    assertThat(Files.exists(contentFile)).isFalse();
+    assertThat(Files.exists(normalLockFile)).isFalse();
+  }
+
+  /**
+   * An unavailable normal database lock file refuses the restart before mutation.
+   *
+   * <p>The scenario puts a directory at the normal lock path, so the path cannot provide a file
+   * lock. The expected outcome has three parts. An input or output failure reaches the caller. The
+   * content callback never runs. Every authority copy and the unavailable path survive.
+   */
+  @Test
+  public void restartRefusesUnavailableNormalDatabaseLockBeforeMutation() throws IOException {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var unavailableLockPath =
+        Files.createDirectory(
+            directory.resolve(StorageBootstrapMetadata.NORMAL_DATABASE_LOCK_FILE_NAME));
+    final var authorityBeforeRefusal = authorityBytes();
+    final var deletionRan = new AtomicBoolean(false);
+
+    assertThatThrownBy(
+        () -> creator.deleteInterruptedRestoreTarget(
+            storageDirectory -> deletionRan.set(true)))
+        .isInstanceOf(IOException.class);
+
+    assertThat(deletionRan.get()).isFalse();
+    assertThat(unavailableLockPath).isDirectory();
+    assertAuthorityBytesUnchanged(authorityBeforeRefusal);
+  }
+
+  /**
+   * A content-deletion failure releases the acquired normal database lock.
+   *
+   * <p>The scenario proves that the lock remains held inside the content callback and then throws
+   * from that callback. The expected outcome has three parts. The same failure reaches the caller.
+   * A later lock attempt succeeds, proving cleanup. A repeated restart deletion then succeeds.
+   */
+  @Test
+  public void restartDeletionFailureReleasesNormalDatabaseLock() throws IOException {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var normalLockFile =
+        Files.writeString(
+            directory.resolve(StorageBootstrapMetadata.NORMAL_DATABASE_LOCK_FILE_NAME),
+            "dirty-metadata");
+    final var contentFile = Files.writeString(directory.resolve("content.pcl"), "payload");
+    final var deletionFailure = new IOException("content deletion failed");
+
+    assertThatThrownBy(
+        () -> creator.deleteInterruptedRestoreTarget(
+            storageDirectory -> {
+              try (var competingChannel =
+                  FileChannel.open(
+                      normalLockFile,
+                      StandardOpenOption.READ,
+                      StandardOpenOption.WRITE)) {
+                assertThatThrownBy(competingChannel::tryLock)
+                    .isInstanceOf(OverlappingFileLockException.class);
+              }
+              throw deletionFailure;
+            }))
+        .isSameAs(deletionFailure);
+
+    try (var channel =
+        FileChannel.open(
+            normalLockFile, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        var acquiredAfterFailure = channel.tryLock()) {
+      assertThat(acquiredAfterFailure).isNotNull();
+    }
+    creator.deleteInterruptedRestoreTarget(
+        storageDirectory -> {
+          Files.delete(contentFile);
+          Files.delete(normalLockFile);
+        });
+    assertThat(authorityFiles()).isEmpty();
+  }
+
+  /**
+   * A missing normal lock file remains valid repeatable restart-deletion residue.
+   *
+   * <p>The scenario deletes a restore target that never gained a dirty file and repeats the
+   * deletion on the authority-lock-only result. The expected outcome has two parts. Both deletions
+   * run without creating a dirty file. The authority lock file survives both deletions.
+   */
+  @Test
+  public void restartAcceptsMissingNormalLockAcrossRepeatedDeletion() throws IOException {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var deletionCount = new AtomicInteger();
+
+    creator.deleteInterruptedRestoreTarget(
+        storageDirectory -> deletionCount.incrementAndGet());
+    metadata().deleteInterruptedRestoreTarget(
+        storageDirectory -> deletionCount.incrementAndGet());
+
+    assertThat(deletionCount.get()).isEqualTo(2);
+    assertThat(
+        Files.exists(
+            directory.resolve(StorageBootstrapMetadata.NORMAL_DATABASE_LOCK_FILE_NAME)))
+        .isFalse();
+    assertThat(Files.exists(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME))).isTrue();
+  }
+
+  /**
+   * The restart refuses a directory that holds no bootstrap authority artifact at all.
+   *
+   * <p>Such a directory can hold a database of a format that carries no bootstrap authority
+   * record. The scenario asks for the restart deletion of a directory that holds one content file
+   * only. The expected outcome has three parts. The refusal names the missing-record reason. The
+   * content deletion never runs. Every file of the directory survives the refusal.
+   */
+  @Test
+  public void restartRefusesDirectoryWithoutAnyBootstrapArtifact() throws IOException {
+    final var contentFile = Files.createFile(directory.resolve("content.pcl"));
+    final var deletionRan = new AtomicBoolean(false);
+
+    final var rejection =
+        admissionRejection(
+            () -> metadata().deleteInterruptedRestoreTarget(
+                storageDirectory -> deletionRan.set(true)));
+
+    assertThat(rejection.reason()).isEqualTo(Reason.AUTHORITY_MISSING);
+    assertThat(deletionRan.get()).isFalse();
+    assertThat(Files.exists(contentFile)).isTrue();
+    assertThat(Files.exists(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME))).isFalse();
+  }
+
+  /**
+   * The restart refuses a directory that holds content files and no readable authority record.
+   *
+   * <p>The deletion of a restart removes every content file before the authority copies, so a
+   * content file can never survive the loss of every authority copy. The scenario builds that
+   * impossible shape with one content file and the authority lock file. The expected outcome has
+   * three parts. The refusal names the interrupted-birth reason. The content deletion never runs.
+   * The content file survives the refusal.
+   */
+  @Test
+  public void restartRefusesContentWithoutAnyReadableRecord() throws IOException {
+    Files.createFile(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME));
+    final var contentFile = Files.createFile(directory.resolve("content.pcl"));
+    final var deletionRan = new AtomicBoolean(false);
+
+    final var rejection =
+        admissionRejection(
+            () -> metadata().deleteInterruptedRestoreTarget(
+                storageDirectory -> deletionRan.set(true)));
+
+    assertThat(rejection.reason()).isEqualTo(Reason.INTERRUPTED_BIRTH);
+    assertThat(deletionRan.get()).isFalse();
+    assertThat(Files.exists(contentFile)).isTrue();
+  }
+
+  /**
+   * A rejected admission reports the same reason for the same unchanged image twice.
+   *
+   * <p>An admission that creates the authority lock file would turn a directory without any
+   * bootstrap authority artifact into birth residue. The second read of the same directory would
+   * then report the interrupted-birth reason instead of the missing-record reason. The scenario
+   * reads one directory with one content file twice. The expected outcome has two parts. Both
+   * reads report the missing-record reason. The read creates no authority lock file.
+   */
+  @Test
+  public void rejectedAdmissionReportsTheSameReasonAcrossTwoReads() throws IOException {
+    Files.createFile(directory.resolve("content.pcl"));
+
+    final var firstRejection = admissionRejection(metadata()::readActiveRequired);
+    final var secondRejection = admissionRejection(metadata()::readActiveRequired);
+
+    assertThat(firstRejection.reason()).isEqualTo(Reason.AUTHORITY_MISSING);
+    assertThat(secondRejection.reason()).isEqualTo(Reason.AUTHORITY_MISSING);
+    assertThat(Files.exists(directory.resolve(StorageBootstrapMetadata.LOCK_FILE_NAME))).isFalse();
+  }
+
+  /**
+   * The acceptance check and the deletion of one restart exclude a concurrent restart.
+   *
+   * <p>The scenario starts one restart deletion and holds that deletion inside the content
+   * deletion. A second thread then starts another restart deletion of the same target. The
+   * expected outcome has two parts. The second restart makes no progress while the first restart
+   * holds the exclusive unit. The second restart finishes after the first restart released the
+   * exclusive unit.
+   */
+  @Test(timeout = 60_000)
+  public void restartAcceptanceAndDeletionExcludeAConcurrentRestart() throws Exception {
+    final var creator = metadata();
+    creator.beginRestoreFromBirth(creator.createBirth(STORAGE, LINEAGE_ONE));
+    final var firstEnteredDeletion = new CountDownLatch(1);
+    final var releaseFirstDeletion = new CountDownLatch(1);
+    final var secondDeletionEntered = new AtomicBoolean(false);
+    final var executor = Executors.newSingleThreadExecutor();
+    try {
+      final var second = new AtomicReference<Throwable>();
+      final var secondFinished = new CountDownLatch(1);
+      creator.deleteInterruptedRestoreTarget(
+          storageDirectory -> {
+            executor.execute(
+                () -> {
+                  try {
+                    new StorageBootstrapMetadata(directory, FORMAT)
+                        .deleteInterruptedRestoreTarget(
+                            ignored -> secondDeletionEntered.set(true));
+                  } catch (Throwable failure) {
+                    second.set(failure);
+                  } finally {
+                    secondFinished.countDown();
+                  }
+                });
+            firstEnteredDeletion.countDown();
+            // The second restart must not enter its own deletion while this deletion runs.
+            assertNoCompletionWithin(secondFinished);
+            assertThat(secondDeletionEntered.get()).isFalse();
+            releaseFirstDeletion.countDown();
+          });
+
+      await(firstEnteredDeletion);
+      assertThat(secondFinished.await(30, TimeUnit.SECONDS)).isTrue();
+      // The second restart runs after the first restart removed every authority copy, so the
+      // second restart accepts a target without any readable record and deletes nothing more.
+      assertThat(second.get()).isNull();
+      assertThat(authorityFiles()).isEmpty();
+    } finally {
+      releaseFirstDeletion.countDown();
+      executor.shutdownNow();
+      executor.awaitTermination(30, TimeUnit.SECONDS);
+    }
+  }
+
   /** Value objects reject null identities and invalid numeric values before persistence. */
   @Test
   public void identityValueObjectsRejectInvalidValues() {
@@ -867,6 +1616,21 @@ public class StorageBootstrapMetadataTest {
         .map(this::authorityPath)
         .filter(Files::exists)
         .toList();
+  }
+
+  private Map<Path, byte[]> authorityBytes() throws IOException {
+    final var bytes = new LinkedHashMap<Path, byte[]>();
+    for (final var path : authorityFiles()) {
+      bytes.put(path, Files.readAllBytes(path));
+    }
+    return bytes;
+  }
+
+  private void assertAuthorityBytesUnchanged(final Map<Path, byte[]> expected) throws IOException {
+    assertThat(authorityFiles()).containsExactlyInAnyOrderElementsOf(expected.keySet());
+    for (final var entry : expected.entrySet()) {
+      assertThat(Files.readAllBytes(entry.getKey())).containsExactly(entry.getValue());
+    }
   }
 
   private List<Path> temporaryFiles() {
@@ -895,10 +1659,34 @@ public class StorageBootstrapMetadataTest {
     return ByteBuffer.wrap(Files.readAllBytes(path)).getLong(16);
   }
 
+  private static int readStorageLayoutVersion(final Path path) throws IOException {
+    return ByteBuffer.wrap(Files.readAllBytes(path)).getInt(28);
+  }
+
+  /** Runs the given call and returns its single named admission rejection. */
+  private static StorageAdmissionException admissionRejection(
+      final org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {
+    final var rejection = catchThrowableOfType(call, StorageAdmissionException.class);
+    assertThat(rejection).isNotNull();
+    return rejection;
+  }
+
   private static void updateChecksum(final byte[] record) {
     final var checksum =
         XXHashFactory.fastestInstance().hash64().hash(record, 0, 72, 0x648B7A2195D3L);
     ByteBuffer.wrap(record).putLong(72, checksum);
+  }
+
+  /** Fails when the given latch completes, which would break the exclusivity of one restart. */
+  private static void assertNoCompletionWithin(final CountDownLatch latch) throws IOException {
+    try {
+      if (latch.await(2, TimeUnit.SECONDS)) {
+        throw new IOException("A concurrent restart entered the exclusive unit of one restart");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while the exclusivity proof waited", e);
+    }
   }
 
   private static void await(final CountDownLatch latch) throws IOException {
@@ -909,6 +1697,46 @@ public class StorageBootstrapMetadataTest {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while holding publication", e);
+    }
+  }
+
+  private static Process startForeignLockHolder(final Path lockPath) throws IOException {
+    final var javaExecutable =
+        Path.of(System.getProperty("java.home"), "bin", "java").toString();
+    final var testClasspath =
+        System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+    return new ProcessBuilder(
+        javaExecutable,
+        "-cp",
+        testClasspath,
+        ForeignFileLockHolder.class.getName(),
+        lockPath.toString())
+        .redirectErrorStream(true)
+        .start();
+  }
+
+  private static String awaitProcessLine(final Process process) throws Exception {
+    final var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    while (System.nanoTime() < deadline) {
+      if (process.inputReader().ready()) {
+        return process.inputReader().readLine();
+      }
+      if (!process.isAlive()) {
+        throw new IOException("Foreign lock holder exited before its ready handshake");
+      }
+      Thread.sleep(10);
+    }
+    throw new IOException("Timed out waiting for the foreign lock holder ready handshake");
+  }
+
+  private static void stopProcess(final Process process) throws InterruptedException {
+    if (!process.isAlive()) {
+      return;
+    }
+    process.destroy();
+    if (!process.waitFor(10, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(10, TimeUnit.SECONDS);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AllocatePageForWriteTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AllocatePageForWriteTest.java
@@ -998,10 +998,23 @@ public class AllocatePageForWriteTest {
   // Exact distinct-page accounting
   // ---------------------------------------------------------------------------
 
+  /** Page accounting is disabled by default and retains no count for ordinary operations. */
+  @Test
+  public void touchedPagesAreNotRecordedByDefault() throws Exception {
+    long fileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+
+    op.loadPageForRead(fileId, 1);
+    op.loadPageForWrite(fileId, 1, 1, true);
+
+    assertThat(op.touchedPagesCount()).isZero();
+  }
+
   /** Repeated read and write access to one physical page contributes exactly one touch. */
   @Test
   public void touchedPagesDeduplicatesAcrossReadAndWritePaths() throws Exception {
     long fileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    op.enablePageTracking();
+    op.enablePageTracking(); // Idempotent enabling must retain the same distinct-page set.
     when(writeCache.getFilledUpTo(fileId)).thenReturn(2L);
 
     op.loadPageForRead(fileId, 1);
@@ -1018,6 +1031,7 @@ public class AllocatePageForWriteTest {
     long secondFile = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
     long allocationFile = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
     when(writeCache.getFilledUpTo(allocationFile)).thenReturn(0L);
+    op.enablePageTracking();
 
     op.loadPageForRead(firstFile, 7);
     op.loadPageForRead(secondFile, 7);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AllocatePageForWriteTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AllocatePageForWriteTest.java
@@ -995,6 +995,38 @@ public class AllocatePageForWriteTest {
   }
 
   // ---------------------------------------------------------------------------
+  // Exact distinct-page accounting
+  // ---------------------------------------------------------------------------
+
+  /** Repeated read and write access to one physical page contributes exactly one touch. */
+  @Test
+  public void touchedPagesDeduplicatesAcrossReadAndWritePaths() throws Exception {
+    long fileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    when(writeCache.getFilledUpTo(fileId)).thenReturn(2L);
+
+    op.loadPageForRead(fileId, 1);
+    op.loadPageForRead(fileId, 1);
+    op.loadPageForWrite(fileId, 1, 1, true);
+
+    assertThat(op.touchedPagesCount()).isEqualTo(1);
+  }
+
+  /** Equal page indexes in different files and a newly allocated page are distinct touches. */
+  @Test
+  public void touchedPagesDistinguishesFilesAndCountsAllocation() throws Exception {
+    long firstFile = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    long secondFile = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    long allocationFile = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    when(writeCache.getFilledUpTo(allocationFile)).thenReturn(0L);
+
+    op.loadPageForRead(firstFile, 7);
+    op.loadPageForRead(secondFile, 7);
+    op.allocatePageForWrite(allocationFile, 0);
+
+    assertThat(op.touchedPagesCount()).isEqualTo(3);
+  }
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
@@ -1,8 +1,11 @@
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +16,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AtomicOperation
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.StorageComponent;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WriteAheadLog;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +62,7 @@ public class AtomicOperationsManagerComponentLockModeTest {
     when(operation.lockedObjects()).thenReturn(new HashSet<>(java.util.Set.of("component-lock")));
     when(operation.lockedObjectMode("component-lock"))
         .thenReturn(AtomicOperation.ComponentLockMode.SHARED);
+    when(component.isSharedOwner()).thenReturn(true);
 
     manager.ensureThatComponentsUnlocked(operation);
 
@@ -79,6 +84,67 @@ public class AtomicOperationsManagerComponentLockModeTest {
         .hasMessageContaining("EXCLUSIVE");
 
     verify(component, never()).lockExclusive();
+  }
+
+  /** Cleanup clears the mode map, so the same operation takes a released lock again. */
+  @Test
+  public void releasedExclusiveLockCanBeAcquiredAgain() {
+    final var modes = new HashMap<String, AtomicOperation.ComponentLockMode>();
+    final var components = new ArrayList<StorageComponent>();
+    when(operation.lockedObjectMode("component-lock"))
+        .thenAnswer(ignored -> modes.get("component-lock"));
+    doAnswer(
+        invocation -> {
+          modes.put(invocation.getArgument(0), invocation.getArgument(1));
+          return null;
+        })
+        .when(operation)
+        .addLockedObject(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.any(AtomicOperation.ComponentLockMode.class));
+    doAnswer(
+        invocation -> {
+          components.add(invocation.getArgument(0));
+          return null;
+        })
+        .when(operation)
+        .addLockedComponent(component);
+    when(operation.lockedComponents()).thenReturn(components);
+    when(operation.lockedObjects()).thenReturn(modes.keySet());
+    when(component.isExclusiveOwner()).thenReturn(true);
+
+    manager.acquireExclusiveLockTillOperationComplete(operation, component);
+    manager.ensureThatComponentsUnlocked(operation);
+    manager.acquireExclusiveLockTillOperationComplete(operation, component);
+
+    verify(component, times(2)).lockExclusive();
+  }
+
+  /** One failed shared release does not prevent later component locks from being released. */
+  @Test
+  public void failedSharedReleaseStillDrainsRemainingLocks() {
+    final var first = mock(StorageComponent.class);
+    final var second = mock(StorageComponent.class);
+    when(first.getLockName()).thenReturn("first");
+    when(second.getLockName()).thenReturn("second");
+    when(first.isSharedOwner()).thenReturn(true);
+    when(second.isSharedOwner()).thenReturn(true);
+    doThrow(new IllegalMonitorStateException("first release failed"))
+        .when(first)
+        .unlockShared();
+    when(operation.lockedComponents())
+        .thenReturn(new ArrayList<>(java.util.List.of(first, second)));
+    when(operation.lockedObjects()).thenReturn(new HashSet<>(java.util.Set.of("first", "second")));
+    when(operation.lockedObjectMode("first"))
+        .thenReturn(AtomicOperation.ComponentLockMode.SHARED);
+    when(operation.lockedObjectMode("second"))
+        .thenReturn(AtomicOperation.ComponentLockMode.SHARED);
+
+    assertThatThrownBy(() -> manager.ensureThatComponentsUnlocked(operation))
+        .isInstanceOf(IllegalMonitorStateException.class)
+        .hasMessageContaining("first release failed");
+
+    verify(second).unlockShared();
   }
 
   /** An exclusive lock satisfies a later shared request without changing recorded mode. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
@@ -129,9 +129,9 @@ public class AtomicOperationsManagerComponentLockModeTest {
     when(second.getLockName()).thenReturn("second");
     when(first.isSharedOwner()).thenReturn(true);
     when(second.isSharedOwner()).thenReturn(true);
-    doThrow(new IllegalMonitorStateException("first release failed"))
-        .when(first)
-        .unlockShared();
+    final var releaseFailure = new IllegalMonitorStateException("first release failed");
+    doThrow(releaseFailure).when(first).unlockShared();
+    doThrow(releaseFailure).when(second).unlockShared();
     when(operation.lockedComponents())
         .thenReturn(new ArrayList<>(java.util.List.of(first, second)));
     when(operation.lockedObjects()).thenReturn(new HashSet<>(java.util.Set.of("first", "second")));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentLockModeTest.java
@@ -1,0 +1,95 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AtomicOperationIdGen;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.StorageComponent;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WriteAheadLog;
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests mode-aware component locks retained until an atomic operation completes. */
+public class AtomicOperationsManagerComponentLockModeTest {
+
+  private AtomicOperationsManager manager;
+  private AtomicOperation operation;
+  private StorageComponent component;
+
+  @Before
+  public void setUp() {
+    final var storage = mock(AbstractStorage.class);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(mock(AtomicOperationIdGen.class));
+    manager = new AtomicOperationsManager(storage, mock(AtomicOperationsTable.class));
+
+    operation = mock(AtomicOperation.class);
+    component = mock(StorageComponent.class);
+    when(component.getLockName()).thenReturn("component-lock");
+  }
+
+  /** A first shared request acquires and records shared mode for operation-end release. */
+  @Test
+  public void sharedAcquisitionRecordsItsMode() {
+    manager.acquireSharedLockTillOperationComplete(operation, component);
+
+    verify(component).lockShared();
+    verify(operation).addLockedComponent(component);
+    verify(operation)
+        .addLockedObject("component-lock", AtomicOperation.ComponentLockMode.SHARED);
+  }
+
+  /** Operation cleanup releases a shared lock through the shared side of the component lock. */
+  @Test
+  public void cleanupReleasesSharedMode() {
+    final var components = new ArrayList<StorageComponent>();
+    components.add(component);
+    when(operation.lockedComponents()).thenReturn(components);
+    when(operation.lockedObjects()).thenReturn(new HashSet<>(java.util.Set.of("component-lock")));
+    when(operation.lockedObjectMode("component-lock"))
+        .thenReturn(AtomicOperation.ComponentLockMode.SHARED);
+
+    manager.ensureThatComponentsUnlocked(operation);
+
+    verify(component).unlockShared();
+    verify(component, never()).unlockExclusive();
+  }
+
+  /** A shared-to-exclusive upgrade fails before entering the non-upgradable component lock. */
+  @Test
+  public void sharedToExclusiveUpgradeFailsFast() {
+    when(operation.lockedObjectMode("component-lock"))
+        .thenReturn(AtomicOperation.ComponentLockMode.SHARED);
+
+    assertThatThrownBy(
+        () -> manager.acquireExclusiveLockTillOperationComplete(operation, component))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("component-lock")
+        .hasMessageContaining("SHARED")
+        .hasMessageContaining("EXCLUSIVE");
+
+    verify(component, never()).lockExclusive();
+  }
+
+  /** An exclusive lock satisfies a later shared request without changing recorded mode. */
+  @Test
+  public void exclusiveModeSatisfiesSharedRequest() {
+    when(operation.lockedObjectMode("component-lock"))
+        .thenReturn(AtomicOperation.ComponentLockMode.EXCLUSIVE);
+
+    manager.acquireSharedLockTillOperationComplete(operation, component);
+
+    verify(component, never()).lockShared();
+    verify(operation, never()).addLockedComponent(component);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentOpExceptionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentOpExceptionTest.java
@@ -47,7 +47,8 @@ public class AtomicOperationsManagerComponentOpExceptionTest {
     operation = mock(AtomicOperation.class);
     // Pretend the lock is already held so acquireExclusiveLockTillOperationComplete
     // skips the actual locking.
-    when(operation.containsInLockedObjects(anyString())).thenReturn(true);
+    when(operation.lockedObjectMode(anyString()))
+        .thenReturn(AtomicOperation.ComponentLockMode.EXCLUSIVE);
 
     component = mock(StorageComponent.class);
     when(component.getLockName()).thenReturn(COMPONENT_LOCK_NAME);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerFlushHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerFlushHookTest.java
@@ -51,7 +51,8 @@ public class AtomicOperationsManagerFlushHookTest {
 
   private AtomicOperation mockOperation() {
     var operation = mock(AtomicOperation.class);
-    when(operation.containsInLockedObjects(anyString())).thenReturn(true);
+    when(operation.lockedObjectMode(anyString()))
+        .thenReturn(AtomicOperation.ComponentLockMode.EXCLUSIVE);
     return operation;
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerSequenceExhaustionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerSequenceExhaustionTest.java
@@ -1,0 +1,203 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AtomicOperationIdGen;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.operationsfreezer.OperationsFreezer;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WriteAheadLog;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/** Tests freezer accounting when logical commit sequence allocation fails. */
+public class AtomicOperationsManagerSequenceExhaustionTest {
+
+  /** Sequence exhaustion releases the freezer admission without changing rollback semantics. */
+  @Test
+  public void sequenceExhaustionReleasesFreezerAdmission() throws Exception {
+    final var idGen = mock(AtomicOperationIdGen.class);
+    when(idGen.nextId())
+        .thenThrow(new IllegalStateException("Logical operation identifier space is exhausted"));
+    final var storage = mock(AbstractStorage.class, CALLS_REAL_METHODS);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var manager =
+        new AtomicOperationsManager(storage, mock(AtomicOperationsTable.class));
+    final var freezer = mock(OperationsFreezer.class);
+    final Field freezerField =
+        AtomicOperationsManager.class.getDeclaredField("writeOperationsFreezer");
+    freezerField.setAccessible(true);
+    freezerField.set(manager, freezer);
+
+    assertThatThrownBy(() -> manager.startToApplyOperations(mock(AtomicOperation.class)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("exhausted");
+
+    verify(freezer).startOperation(false, null);
+    verify(freezer).endOperation();
+  }
+
+  /**
+   * The calculating wrapper keeps the allocation failure as its cause.
+   * It does not run full cleanup after the failed start releases freezer admission.
+   */
+  @Test
+  public void calculatingWrapperDoesNotReleaseAdmissionTwiceOnExhaustion() throws Exception {
+    assertWrapperBalancesExhaustion(false);
+  }
+
+  /**
+   * The executing wrapper keeps the allocation failure as its cause.
+   * It does not run full cleanup after the failed start releases freezer admission.
+   */
+  @Test
+  public void executingWrapperDoesNotReleaseAdmissionTwiceOnExhaustion() throws Exception {
+    assertWrapperBalancesExhaustion(true);
+  }
+
+  /** A wrapper-style table failure completes the real protected error-state transition. */
+  @Test
+  public void tableInvariantFailureMovesStorageToErrorState() throws Exception {
+    final var failure = new IllegalStateException("Broken atomic operations table");
+    final var idGen = mock(AtomicOperationIdGen.class);
+    final var storage = mock(AbstractStorage.class, CALLS_REAL_METHODS);
+    final var storageError = new AtomicReference<Throwable>();
+    final Field errorField = AbstractStorage.class.getDeclaredField("error");
+    errorField.setAccessible(true);
+    errorField.set(storage, storageError);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var table = mock(AtomicOperationsTable.class);
+    doThrow(failure).when(table).startOperation(0, 0);
+    final var manager = new AtomicOperationsManager(storage, table);
+
+    assertThatThrownBy(() -> manager.startToApplyOperations(mock(AtomicOperation.class)))
+        .isSameAs(failure);
+
+    assertThat(storageError.get()).isSameAs(failure);
+    verify(table, never()).rollbackOperation(0);
+  }
+
+  /** A direct commit start failure keeps the pre-track runtime error-state behavior. */
+  @Test
+  public void directCommitStartFailureDoesNotMoveStorageToErrorState() {
+    final var failure = new IllegalStateException("Broken atomic operations table");
+    final var idGen = mock(AtomicOperationIdGen.class);
+    final var storage = mock(AbstractStorage.class);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var table = mock(AtomicOperationsTable.class);
+    doThrow(failure).when(table).startOperation(0, 0);
+    final var manager = new AtomicOperationsManager(storage, table);
+
+    assertThatThrownBy(
+        () -> manager.startToApplyOperations(mock(AtomicOperation.class), false, null))
+        .isSameAs(failure);
+
+    verify(storage, never()).moveToErrorStateIfNeeded(failure);
+  }
+
+  /** An operation start failure rolls back its completed table registration. */
+  @Test
+  public void operationStartFailureRollsBackTableRegistration() {
+    final var failure = new IllegalStateException("Operation apply start failed");
+    final var idGen = mock(AtomicOperationIdGen.class);
+    final var storage = mock(AbstractStorage.class, CALLS_REAL_METHODS);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var table = mock(AtomicOperationsTable.class);
+    final var operation = mock(AtomicOperation.class);
+    doThrow(failure).when(operation).startToApplyOperations(0);
+    final var manager = new AtomicOperationsManager(storage, table);
+
+    assertThatThrownBy(() -> manager.startToApplyOperations(operation)).isSameAs(failure);
+
+    verify(table).startOperation(0, 0);
+    verify(table).rollbackOperation(0);
+  }
+
+  /** Identical start and rollback failures preserve the start failure and release the freezer. */
+  @Test
+  public void identicalRollbackFailureDoesNotSkipFreezerRelease() throws Exception {
+    final var failure = new IllegalStateException("Shared start and rollback failure");
+    final var idGen = mock(AtomicOperationIdGen.class);
+    final var storage = mock(AbstractStorage.class, CALLS_REAL_METHODS);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var table = mock(AtomicOperationsTable.class);
+    final var operation = mock(AtomicOperation.class);
+    doThrow(failure).when(operation).startToApplyOperations(0);
+    doThrow(failure).when(table).rollbackOperation(0);
+    final var manager = new AtomicOperationsManager(storage, table);
+    final var freezer = mock(OperationsFreezer.class);
+    final Field freezerField =
+        AtomicOperationsManager.class.getDeclaredField("writeOperationsFreezer");
+    freezerField.setAccessible(true);
+    freezerField.set(manager, freezer);
+
+    assertThatThrownBy(() -> manager.startToApplyOperations(operation)).isSameAs(failure);
+
+    verify(table).rollbackOperation(0);
+    verify(freezer).endOperation();
+  }
+
+  private static void assertWrapperBalancesExhaustion(final boolean execute) throws Exception {
+    final var idGen = mock(AtomicOperationIdGen.class);
+    final var exhaustion =
+        new IllegalStateException("Logical operation identifier space is exhausted");
+    when(idGen.nextId()).thenThrow(exhaustion);
+    final var storage = mock(AbstractStorage.class, CALLS_REAL_METHODS);
+    when(storage.getName()).thenReturn("sequence-exhaustion-test");
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(idGen);
+    final var manager =
+        spy(new AtomicOperationsManager(storage, mock(AtomicOperationsTable.class)));
+    doReturn(mock(AtomicOperation.class)).when(manager).startAtomicOperation();
+    final var freezer = mock(OperationsFreezer.class);
+    final Field freezerField =
+        AtomicOperationsManager.class.getDeclaredField("writeOperationsFreezer");
+    freezerField.setAccessible(true);
+    freezerField.set(manager, freezer);
+
+    if (execute) {
+      assertThatThrownBy(() -> manager.executeInsideAtomicOperation(operation -> {
+      }))
+          .isInstanceOf(StorageException.class)
+          .hasRootCause(exhaustion);
+    } else {
+      assertThatThrownBy(() -> manager.calculateInsideAtomicOperation(operation -> null))
+          .isInstanceOf(StorageException.class)
+          .hasRootCause(exhaustion);
+    }
+
+    verify(freezer).startOperation(false, null);
+    verify(freezer).endOperation();
+    verify(manager, never()).endAtomicOperation(any(), any());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerWrapperAssertionErrorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerWrapperAssertionErrorTest.java
@@ -177,7 +177,8 @@ public class AtomicOperationsManagerWrapperAssertionErrorTest {
    */
   private AtomicOperation mockOperationWithLockAlreadyHeld() {
     var operation = mock(AtomicOperation.class);
-    when(operation.containsInLockedObjects(anyString())).thenReturn(true);
+    when(operation.lockedObjectMode(anyString()))
+        .thenReturn(AtomicOperation.ComponentLockMode.EXCLUSIVE);
     return operation;
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsTableTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsTableTest.java
@@ -155,6 +155,19 @@ public class AtomicOperationsTableTest {
     assertFalse(snapshot.isEntryVisible(200));
   }
 
+  /** An exhausted identifier space saturates the empty-table boundary without signed wraparound. */
+  @Test
+  public void testSnapshotAtMaximumIdentifierDoesNotWrapVisibilityBoundary() {
+    var table = new AtomicOperationsTable(100, Long.MAX_VALUE);
+
+    var snapshot = table.snapshotAtomicOperationTableState(Long.MAX_VALUE);
+
+    assertEquals(Long.MAX_VALUE, snapshot.minActiveOperationTs());
+    assertEquals(Long.MAX_VALUE, snapshot.maxActiveOperationTs());
+    assertTrue(snapshot.isEntryVisible(1));
+    assertTrue(snapshot.isEntryVisible(Long.MAX_VALUE));
+  }
+
   @Test
   public void testSnapshotWithSingleInProgressOperation() {
     var table = new AtomicOperationsTable(100, 0);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/ProductionAllocatorConcurrencyMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/ProductionAllocatorConcurrencyMTTest.java
@@ -611,8 +611,9 @@ public class ProductionAllocatorConcurrencyMTTest {
         .as("round %d: index '%s' must be registered after the createIndex call",
             round, indexName)
         .isNotNull();
-    final var engineId = index.getIndexId();
-    final var engine = ((AbstractStorage) session.getStorage()).getIndexEngine(engineId);
+    final var engine =
+        com.jetbrains.youtrackdb.internal.core.index.IndexEngineTestSupport
+            .engine(session, indexName);
     assertThat(engine)
         .as("round %d: index engine for '%s' must be a"
             + " BTreeMultiValueIndexEngine; got %s",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeLifecycleTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeLifecycleTest.java
@@ -15,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.TooBigIndexKeyException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValidator;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.File;
 import java.util.UUID;
@@ -172,19 +173,18 @@ public class BTreeLifecycleTest {
       var lockName = tree.getLockName();
 
       // Pre-condition: the lock name is not yet registered on a fresh atomic operation.
-      assertThat(atomicOperation.containsInLockedObjects(lockName))
+      assertThat(atomicOperation.lockedObjectMode(lockName))
           .as("BTree lock name must not be registered before acquireAtomicExclusiveLock")
-          .isFalse();
+          .isNull();
 
       tree.acquireAtomicExclusiveLock(atomicOperation);
 
       // Post-condition: the BTree is now recorded as an exclusive-lock holder for the
       // duration of the operation. The lock will be released when the atomic operation
       // commits or rolls back.
-      assertThat(atomicOperation.containsInLockedObjects(lockName))
-          .as("acquireAtomicExclusiveLock must register the BTree lock name in the "
-              + "atomic operation's locked-objects set")
-          .isTrue();
+      assertThat(atomicOperation.lockedObjectMode(lockName))
+          .as("acquireAtomicExclusiveLock must register the BTree lock mode")
+          .isEqualTo(AtomicOperation.ComponentLockMode.EXCLUSIVE);
     });
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/memory/DirectMemoryStorageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/memory/DirectMemoryStorageTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.storage.memory;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -14,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.engine.memory.EngineMemory;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 /**
@@ -80,6 +82,42 @@ public class DirectMemoryStorageTest {
         }
       }
     }
+  }
+
+  /** Each memory storage instance receives a distinct volatile identity pair. */
+  @Test
+  public void volatileIdentityIsStableAndUniquePerStorageInstance() throws Exception {
+    var firstStorage = new AtomicReference<Object>();
+    var firstLineage = new AtomicReference<Object>();
+    withMemoryStorage(
+        storage -> {
+          firstStorage.set(storage.getStorageIdentity());
+          firstLineage.set(storage.getStorageLineageIdentity());
+          assertEquals(firstStorage.get(), storage.getStorageIdentity());
+          assertEquals(firstLineage.get(), storage.getStorageLineageIdentity());
+        });
+
+    withMemoryStorage(
+        storage -> {
+          assertNotEquals(firstStorage.get(), storage.getStorageIdentity());
+          assertNotEquals(firstLineage.get(), storage.getStorageLineageIdentity());
+        });
+  }
+
+  /** The default identity-read hook leaves volatile memory identities unchanged. */
+  @Test
+  public void defaultIdentityReadHookPreservesMemoryIdentities() throws Exception {
+    withMemoryStorage(storage -> {
+      var storageIdentity = storage.getStorageIdentity();
+      var lineageIdentity = storage.getStorageLineageIdentity();
+      var method = AbstractStorage.class.getDeclaredMethod("readStorageIdentity");
+      method.setAccessible(true);
+
+      method.invoke(storage);
+
+      assertEquals(storageIdentity, storage.getStorageIdentity());
+      assertEquals(lineageIdentity, storage.getStorageLineageIdentity());
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/core/src/test/resources/META-INF/services/com.jetbrains.youtrackdb.internal.core.index.IndexFactory
+++ b/core/src/test/resources/META-INF/services/com.jetbrains.youtrackdb.internal.core.index.IndexFactory
@@ -1,0 +1,1 @@
+com.jetbrains.youtrackdb.internal.core.index.ForeignIndexFactory

--- a/docs-internal/adr/index-histogram/IMPLEMENTATION-PROMPT.md
+++ b/docs-internal/adr/index-histogram/IMPLEMENTATION-PROMPT.md
@@ -85,7 +85,7 @@ Then implement **Step {CURRENT_STEP}** as described in:
 5. **Run tests and verify coverage.** Follow the Pre-Commit Verification section
    from `CLAUDE.md`:
    - Run unit tests for affected modules.
-   - Run integration tests if the step touches storage, WAL, or index code.
+   - The pull request pipeline runs integration tests for storage, WAL, or index changes. A developer machine never runs integration tests. Follow `docs-internal/dev-workflow/track-development.md`.
    - Run coverage check for new code using the `coverage` profile and
      `coverage-gate.py` (see `CLAUDE.md`). If coverage is below the threshold,
      go back to step 3 and add more tests before proceeding.

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -25,10 +25,8 @@ Coverage details live in `docs-internal/dev-workflow/coverage-verification.md`.
 
 ## Verification Gates
 
-Verification rules live in `docs-internal/dev-workflow/track-development.md`.
-Integration command syntax lives in `docs-internal/agents/thread-guidelines.md`.
-Never run the full integration suite locally. The pull request pipeline runs it instead.
-`docs-internal/dev-workflow/track-development.md` owns integration scope.
+A developer machine never runs an integration test. The pull request pipeline runs the integration
+suite. Follow `docs-internal/dev-workflow/track-development.md` for scope and exceptions.
 If in doubt, run the full unit test suite.
 
 ### Serial Maven execution

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -13,17 +13,10 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # Full build with unit tests (in-memory storage, default)
 ./mvnw clean package
 
-# Full build with unit tests on disk storage (as CI does)
-./mvnw clean package -Dyoutrackdb.test.env=ci
+# Disk-mode test scope follows `docs-internal/dev-workflow/track-development.md`.
 
-# Run an affected integration test method without unit tests
-./mvnw -pl core test-compile failsafe:integration-test failsafe:verify \
-  -P ci-integration-tests -Dit.test='FreeSpaceMapTestIT#findSinglePage'
-
-# Run integration tests with dependencies built by Maven
-./mvnw -pl core -am test-compile failsafe:integration-test failsafe:verify \
-  -P ci-integration-tests -Dit.test='FreeSpaceMapTestIT#findSinglePage' \
-  -Dfailsafe.failIfNoSpecifiedTests=false
+# A developer machine never runs integration tests. The pull request pipeline runs them.
+# Integration-test scope follows `docs-internal/dev-workflow/track-development.md`.
 
 # If the test-gate set spans multiple modules, test them all
 ./mvnw -pl core,server clean test
@@ -34,6 +27,10 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 
 # Build with Docker images (requires Docker)
 ./mvnw clean package -P docker-images
+
+# Run targeted disk-mode tests for changed production code and changed tests
+./mvnw -pl core clean test \
+  -Dtest='ChangedProductionTest,ChangedTest' -Dyoutrackdb.test.env=ci
 
 # Run a single test class
 ./mvnw -pl core clean test -Dtest=SomeTestClass
@@ -106,14 +103,11 @@ This rule covers unit, integration, and coverage runs. Separate worktrees may ru
 Maven concurrently. Mid-track tests remain optional. Concurrent runs can also report false
 failures.
 
-Never run the full integration suite locally. The pull request pipeline runs it instead.
-`docs-internal/dev-workflow/track-development.md` owns integration scope.
+A developer machine never runs integration tests. The pull request pipeline runs the integration suite.
+Follow `docs-internal/dev-workflow/track-development.md` for integration-gate scope and exceptions.
 
 ### Test Modules at a Glance
 - **Unit tests**: `./mvnw -pl <module> clean test`. Core/server use JUnit 4 (`surefire-junit47` runner); the `tests` module uses JUnit 5 with `EmbeddedTestSuite` (shared DB, fixed class/method order via `@SelectClasses` / `@Order`).
-- **Integration test selection**: Integration classes use Failsafe's default `*IT.java` naming pattern. Select affected classes with a comma-separated `-Dit.test='SomeIT,OtherIT'` list. Patterns such as `-Dit.test='*Histogram*IT'` select several classes. Use `-Dit.test='SomeIT#someMethod'` for one method. Run `test-compile` before direct Failsafe goals because a clean checkout has no compiled test classes. Keep `failsafe:verify`, which makes integration failures fail the build.
-- **Module scope**: Add `-pl <module>` to limit the run. Failsafe uses `-Dit.test=`. Surefire uses `-Dtest=`, which does not select integration tests.
-- **Dependency builds**: Adding `-am` propagates the selector to upstream modules. Those modules fail when no test matches. Add `-Dfailsafe.failIfNoSpecifiedTests=false` to prevent that failure.
 - **Test utilities**: `test-commons` provides `TestBuilder`, `TestFactory`, `ConcurrentTestHelper`.
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -102,6 +102,13 @@ compiles against a changed API is already covered by the compile gate, and re-ru
 suites costs tens of minutes for no new signal. When the changed behavior does reach a
 dependent's tests, name that dependent in `-pl` explicitly.
 
+A developer machine never runs the full unit suite in disk mode. Disk mode means starting the
+run with `-Dyoutrackdb.test.env=ci`. The targeted subset includes tests covering changed
+production code and tests changed by the same work. The pull request pipeline runs the full disk-mode suite.
+
+A developer machine never runs an integration test. The pipeline skips integration tests for four cases: draft, fork, `[no-it-tests]`, and Markdown-only changes.
+Local verification relies on the pipeline for wider disk-mode coverage.
+
 **Integration-gate set** — the integration test classes covering the subsystems touched by the
 changed files. This set names classes, not modules, because module scope alone still runs the
 whole module suite.
@@ -190,10 +197,10 @@ At the end of each track's implementation, and **before** that track's agent cod
 full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
-2. **Integration tests** for the integration-gate set, green. Follow
-   `docs-internal/agents/thread-guidelines.md` for command syntax. If the set remains uncertain,
-   record the searches and results in the thread report. The orchestrator then chooses the
-   verification path.
+2. **Integration tests** for the integration-gate set run in the pull request pipeline unless an
+   exception listed above applies. A developer machine never runs an integration test. If the set
+   remains uncertain, record the searches and results in the thread report. The orchestrator then
+   chooses the verification path.
 3. **The coverage gate** over the changed lines, at the thresholds owned by
    orchestrator-guidelines § Test Policy. **Read
    `docs-internal/dev-workflow/coverage-verification.md` and follow it before producing the
@@ -201,15 +208,10 @@ full verification runs:
    not be reported as one: its report-set assertion is what separates a measured pass from a
    vacuous one, and nothing in this section can tell them apart.
 
-The full local integration suite is no longer a gate for any change class. It takes about five
-hours.
-Integration tests run unless the pull request is a draft. Worker threads do most work during the
-draft phase. The pipeline skips integration tests for a pull request whose branch lives in a
-fork.
+Integration tests run in the pull request pipeline unless an exception listed above applies. A
+developer machine never runs an integration test.
 
-A title tag is a bracketed keyword in the pull request title. The `[no-it-tests]` title tag means
-no integration tests and skips that pipeline run. Use it only when the change cannot affect
-integration tests.
+Use the `[no-it-tests]` title tag only when the change cannot affect integration tests.
 
 Gating only at the track's closing event would have reviewers reviewing unverified code; gating
 only before the review would let review-fix commits land unverified. Both holes are closed by

--- a/server/src/main/java/com/jetbrains/youtrackdb/internal/server/YouTrackDBServer.java
+++ b/server/src/main/java/com/jetbrains/youtrackdb/internal/server/YouTrackDBServer.java
@@ -52,10 +52,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -68,7 +68,8 @@ public class YouTrackDBServer {
   public static final String GUEST_USER = "guest";
   public static final String DEFAULT_GUEST_PASSWORD = "!!!TheGuestPw123";
 
-  public static final String DEFAULT_CONFIG_CLASSPATH = "classpath:com/jetbrains/youtrackdb/server/conf/youtrackdb-server.yaml";
+  public static final String DEFAULT_CONFIG_CLASSPATH =
+      "classpath:com/jetbrains/youtrackdb/server/conf/youtrackdb-server.yaml";
   public static final String PROPERTY_CONFIG_FILE = "youtrackdb.config.file";
   public static final String DEFAULT_CONFIG_LOCATION = "conf/youtrackdb-server.yaml";
   private static final String ROOT_PASSWORD_FILE = "secrets/root_password";
@@ -137,7 +138,6 @@ public class YouTrackDBServer {
     }
     return server;
   }
-
 
   public SecuritySystem getSecurity() {
     return databases.getSecuritySystem();
@@ -413,7 +413,6 @@ public class YouTrackDBServer {
     return serverRootDirectory;
   }
 
-
   public YTDBSettings getConfiguration() {
     return serverCfg.getConfiguration();
   }
@@ -531,7 +530,8 @@ public class YouTrackDBServer {
             .error(this,
                 "Root password is not set and root user does not exist. "
                     + "Root user credentials has to provided either by server settings or "
-                    + "in secrets/root_password file. Exiting...", null);
+                    + "in secrets/root_password file. Exiting...",
+                null);
         return false;
       } else {
         LogManager.instance()
@@ -586,7 +586,6 @@ public class YouTrackDBServer {
           return security.getUser(user) != null;
         }));
   }
-
 
   protected void defaultSettings() {
   }
@@ -670,7 +669,6 @@ public class YouTrackDBServer {
       }
 
     }
-
 
     @Override
     public boolean exists(String name) {
@@ -772,6 +770,26 @@ public class YouTrackDBServer {
       }
     }
 
+    /**
+     * Delegates the destructive restart of an interrupted restore to the embedded factory.
+     *
+     * <p>The restart deletes the whole target of the interrupted restore and restores the backup
+     * again. The database name stays in the server name cache, because the restart ends with a
+     * restored database of that same name. A refused restart changes no file, so the cached name
+     * stays correct in that case as well.
+     */
+    @Override
+    public void restartInterruptedRestore(String name, String path,
+        @Nullable String expectedUUID, YouTrackDBConfig config) {
+      dbNamesCacheLock.lock();
+      try {
+        internal.restartInterruptedRestore(name, path, expectedUUID, config);
+        dbNamesCache.add(name);
+      } finally {
+        dbNamesCacheLock.unlock();
+      }
+    }
+
     @Override
     public void close() {
       internal.close();
@@ -818,7 +836,6 @@ public class YouTrackDBServer {
         dbNamesCacheLock.unlock();
       }
     }
-
 
     @Override
     public YouTrackDBConfigImpl getConfiguration() {


### PR DESCRIPTION
#### Motivation:

Transactions cannot create indexes for populated classes. This blocks transactional schema changes.

Background work adds existing records after the schema transaction finishes. This limits interruption and preserves correctness, durability, and restart recovery.

Recovery and incremental restore can advance logical operation identifiers after the operation table is created. Its dense integer-indexed representation can allocate a numerical gap, overflow an array index, or address the wrong entry. The table also protects snapshot visibility and WAL retention, so a bounded representation must preserve live operations and ordering.

Top-level creation uses this lifecycle but waits for index usability.

#### Planned changes:

##### Current state

Lifecycle and recovery ownership protect index creation across writes, crashes, restarts, restores, rollbacks, and repairs. They replace legacy-migration and one-unit birth designs.

Tracks 6, 23, 24, 26, 27, and 32 are complete. Track 27 is approved and pushed. Track 31 Revision 4 passed final adversarial review and is user-approved for implementation. Track 25 is waived.

##### What changes

Background index creation requires a new-format database. Legacy databases and backups fail before Write-Ahead Log (WAL) recovery, without migration.

Tracks 6, 23–24, 26–27, 31, and 32 cover activation, authority, birth, admission, backup, restore, operation-id continuity, and bounded table alignment before Track 4. Track 25 is waived and remains recorded for traceability.

A developer machine never runs the full unit test suite in disk mode. The `-Dyoutrackdb.test.env=ci` setting selects disk storage instead of memory storage. A developer machine never runs an integration test. The pull request pipeline runs the integration suite, with four documented exceptions. A developer machine runs only a targeted disk-mode subset covering changed production code and tests changed by the same work.

Initial authority establishment is the sole exception to preserving another valid authority. It applies only to new storage with no accepted authority. The first durable state is `BIRTH_IN_PROGRESS` in fixed redundant locations. It precedes foundation creation and WAL activity. First-write or file-name-barrier failure rejects creation. Readable residue cannot authorize use.

The fail-closed rule applies when an operation finds an existing durable `BIRTH_IN_PROGRESS` authority record. It applies only if the same creation call did not create that record.

The creation call that just made its own record durable continues normally. It creates storage foundations, records genesis completion, and publishes `ACTIVE`. A later open and a later creation attempt always report an error before WAL processing. Any retry after a process restart also always reports an error. No later operation can continue an interrupted storage birth or overwrite its birth authority.

Only explicit removal permits a new storage birth with a new storage identity and lineage. Existing automatic cleanup for an in-process creation failure remains unchanged. The new error rule applies only if a partial database remains on disk.

From `ACTIVE` publication onward, publication never overwrites the only valid authority. It stops unless another verified durable authority remains complete. One storage-wide exclusion covers cooperating publishers and path aliases.

Selection occurs only after all durability barriers succeed. An unconfirmed candidate needs fresh validation and a successful barrier. Reusing an older location needs a selected newer authority and another valid authority. Recovery selects the newest unambiguous legal authority or fails closed.

Accepted feature-format `ACTIVE` gates admission. Missing build state first blocks admission, then quarantines only the affected index.

`ACTIVE` visibility requires a valid complete image, recoverable pages, the WAL prefix, and durable sequence-floor continuity.

Build-state authority covers supported schema-bound durable local indexes, including genesis security indexes. It records lifecycle, completion cut, incarnation, source scope, progress, suspension, and failure. Manual indexes fail before lifecycle or engine state exists. Lucene and manual-index background builds remain excluded.

A logical completion cut records atomic apply completion and commit registration. It is not wall-clock time or a raw WAL LSN. Usability needs a durable cut and activation. Writers and builder share one lifecycle and lineage rule.

Restore remains fresh-target-only by design. Each new backup unit identifies storage features, storage layout, and completed database creation. This semantic identity is separate from archive encoding. Admission requires accepted creation completion evidence from every selected header. That evidence is an independent admission condition before any target mutation. Header evidence does not replace final content and genesis validation.

Both path and stream restores keep existing cheap nonmutating checks and source selection before copying. One request owns the validated temporary copies through final admission, restart deletion and recreation, replay, final checks, and cleanup. Restart repeats target eligibility and the existing non-waiting normal database lock probe immediately before mutation. Space or validation failure leaves the target unchanged.

The existing database-manager exclusion stays continuous across every target-changing phase. It spans final admission, discard, deletion, recreation, replay, final checks, and activation. The narrower authority-lock and deletion-lock scopes keep their existing extent and order.

Rollback to a validated image also creates a fresh target lineage. This covers failed-restore recovery and operator-selected image rollback, not transaction rollback. Future repair uses the same rule.

The target-monotonic sequence floor includes destination high-water, validated-image, and controlled-recovery values. A lineage change cannot lower it. Old lineages cannot publish into the new lineage.

Failed or interrupted activation selects no lineage. Storage remains unavailable until validated recovery, rollback, or repair completes activation.

Track 7 is abandoned. Track 10 precedes Track 11, which remains blocked by Tracks 4 and 10.

##### How

Track 6 adds durable identity, states, transitions, floors, redundant authority, and selection. Track 23 adds build-state authority, stable index identity, owner epochs, incarnations, and lineages.

Track 24 makes storage open decide admission before WAL recovery. Admission accepts only a supported, active, complete new-format image. Birth publishes `ACTIVE` after genesis and a durability barrier covering every genesis artifact. The authority record's spare field carries the storage layout version, and older images receive an unsupported-version cause.

Restore creates its target without genesis or activation, publishes `RESTORE_IN_PROGRESS`, validates completeness, then publishes `ACTIVE`. Destructive restart holds one exclusive acceptance check and attempts the normal database lock without waiting before mutation. It refuses unavailable or busy locks, holds the lock through deletion, never creates or replaces `dirty.fl`, and removes authority copies last. Missing lock-file handling remains an implementer-owned low-level detail. Existing file-lock-disabled behavior remains unchanged.

Track 25 is waived. Current production restore does not replace image contents in an already-open database. This change does not build an unused active-work fence or add in-place restore.

Track 26 makes both backup writers emit semantic headers naming storage features, layout, and completed creation. Every selected header needs accepted completion evidence. Unreadable or unclassifiable headers remain preserved, block incremental extension, and avoid automatic cleanup. Cleanup applies only to recognized incomplete supported output.

Selected files are staged before target mutation and outside the deletion lock. Existing listing and naming rules remain. Names must be distinct, and destinations use exclusive creation without following symbolic links. One request owns validated copies through mutation, replay, final checks, and cleanup. Replay reads only those copies.

Every observed exit triggers cleanup. Preparation keeps its primary failure and suppresses cleanup failures. Later cleanup failures are logged without changing restore results. A sudden stop can leave an orphan.

Restart rechecks target eligibility and the normal file lock before deletion or recreation. Existing manager, authority, and deletion exclusions retain their order and extent. Final content, genesis, durability, and activation checks remain.

Only `AtomicOperationsTable` internals change. `AtomicOperationIdGen`, `AtomicOperationsManager`, readers, persistence callbacks, checkpoint, and WAL cleanup retain their roles and interactions.

```text
AtomicOperationIdGen [unchanged]
  -> AtomicOperationsManager [unchanged]
  -> AtomicOperationsTable [CHANGED]
       ordered range directory -> bounded dense ranges
       -> snapshots through manager [unchanged]
       <- persistence callbacks [unchanged]
       -> checkpoint and WAL cleanup limits [unchanged]
```

Track 32 changes the table from one dense interval to an ordered directory of bounded dense ranges. Large jumps create ranges lazily. Full `long` comparisons precede array-index conversion. Point lookup is worst-case logarithmic in range count. Scans and compaction are linear in stored entries plus ranges.

The stable table object and existing synchronization contract remain. New registrations are globally monotonic, while older retained entries can still change status. Snapshot scans preserve descending identifier order. Retention scans traverse all ranges in ascending order. The cached minimum resolves upward or falls back to a full retained scan.

Only live entries block leading compaction. Terminal entries and never-registered positions below the high-water mark are droppable. Range capacity splits before the backing-array index limit. Directory publication exposes only initialized ranges, and growth avoids repeated whole-directory copying. Space follows stored entries, bounded slack, and descriptors rather than identifier distance.

Track 27 protects commit timestamps issued before supported fresh-target restore activation. A commit timestamp is an internal logical operation identifier, not wall-clock time. Existing exclusion spans the final barrier and capture. After barrier work, restore publishes the greater authority or issued floor with `ACTIVE` in one record.

Disk open takes the greatest authority, startup, or recovery evidence. Restore and open refuse signed 64-bit exhaustion.

```text
replay -> barrier -> floor capture -> ACTIVE record -> open -> recovery
```

Memory startup and restored index progress stay unchanged. In-place restore remains excluded.

Track 31 has five goals. They preserve stored-change ordering across full and fuzzy checkpoints with recovery-log cleanup. They also cover background histograms, database creation, and unchanged Track 27 restore protection.

Maintenance saves the required timestamp floor before removing protected evidence. Checkpoints coordinate with starting and running writes while avoiding circular waits. Before clearing a recovery indication, affected stored changes retain a saved floor or recovery information. Later writes protect themselves before storing changes. Failed floor saving retains both required recovery records and the recovery indication.

Histogram work records possible recovery before allocating a timestamp. Creation publishes a floor covering final work before availability. Read-only operations storing no changes have no restart-uniqueness guarantee.

The builder scans committed state while writers maintain lifecycle. Usability requires completeness, validation, durable sequence floors, and activation. A unique conflict records invalid state instead of dropping the index.

##### Key decisions

- Support new-format databases and reject legacy content without migration.
- Use accepted feature-format `ACTIVE` admission, not a migration marker. Missing per-index state gets one quarantine boundary.
- Use staged birth and fixed redundant authority. Permit no prior authority only at initial establishment. Reject residue until removal permits a new identity and lineage.
- Use a logical completion cut, not wall-clock time or a raw WAL LSN.
- Keep a target-monotonic sequence floor. Track 27 publishes it at activation.
- Keep one stable operation table with ordered bounded ranges. Reject table replacement, jump-site alignment calls, identifier-keyed hash storage, configurable gap caps, and an exclusive registration lock.
- Compare identity before sequence value. A source lineage or selected image never becomes the target lineage.
- Apply one activation and lineage-retirement rule to restore, image rollback, and repair.
- Waive Track 25. Current production restore is fresh-target-only by design, so no active-work fence is built for unsupported in-place restore. Track 26 and Track 27 remain in scope.
- Require semantic backup headers and whole-chain preparation. Admit a chain only when every selected header carries accepted creation completion evidence. Preserve ambiguous files, reject their extension, and use the same prepared bytes for replay.
- Support schema-bound durable local indexes. Exclude manual and Lucene indexes.
- Keep Track 11 after Track 10 and blocked by Tracks 4 and 10.
- Support Windows disk databases without filesystem restrictions or crash-atomic replacement. Barriers fail closed. Unix directory-barrier failures propagate. Reject best-effort durability.
- Keep RG17 freezer accounting, Windows long paths, and Windows ARM64 in Track 6.
- Keep passive corruption, accidental residue, and cooperating YTDB process races in Track 6.

- D244: Tracks 29 and 30 run before Track 24.
- D245: CQ29 is should-fix, and Track 29 carries the repair.
- D246: Track 29 repairs two additional scheduler log sites.
- D247: Track 29 reuses the scalar logging repair pattern.
- D248: Track 29 carries the class medium, and Track 30 carries the class risky.

##### Out of scope

- Legacy database or backup migration, conversion, or fallback, including Track 7.
- Cross-format restore, automatic process-crash orphan reclamation, and automatic corruption repair.
- Crash-safe replacement of existing backups. Existing full-backup overwrite semantics remain unchanged.
- Global sequence order across branches, lineages, databases, or targets. Track 27 is restore-specific.
- Reuse of a source or retired lineage as the new target lineage.
- General transaction migration, cancellation, replay, or repair.
- In-place restore, meaning image replacement in an already-open database, and the active-work fence required only for that unsupported scenario.
- Ordinary transaction rollback behavior.
- Manual-index background builds and Lucene reimplementation.
- Memory-storage backup and restore.
- Forced synchronization for ordinary lifecycle transitions.
- General rebuild replacement or durable engine swaps. They belong to YTDB-1268.
- Stable engine identifiers and unrelated index or schema defects.
- Remote file systems, custom providers, dishonest flush reports, and physical power-loss certification.
- Active external file replacement in an open database directory. Track 26 adds no new tampering, authenticity, or hostile-storage trust model. Descriptor-level host-tampering protection remains a follow-up security issue candidate.
- Media failure, for the whole change. The stated remedy is a backup or a redundant filesystem such as a RAID-like array. RAID means redundant array of independent disks.
- Retirement of the stale birth-slot authority copy that the birth publication wrote.
- An expected storage identity check. Track 24 performs none.
- Track 32 worker cleanup beyond timeout reporting and bounded cooperation. Forced termination in genuine uninterruptible lock waits and disposable-process isolation are excluded.

##### Risks & accepted trade-offs

- Required prerequisite tracks delay Track 4 but separate reviews and isolate operation-id continuity from restore activation.
- Interrupted restore can leave storage unavailable and require operator action.
- An incomplete birth requires explicit removal. Existing in-process creation cleanup remains unchanged.
- Track 25 active-work draining and old-lineage retirement remain waived for unsupported in-place restore.
- Old-format backups cannot be restored or extended. Migration creates a new full backup in a new, empty location. It leaves the old chain intact.
- Unreadable backup files need manual handling. Automatic cleanup cannot safely classify every ambiguous file. An interrupted backup can leave output without readable format evidence. That output stays preserved and blocks incremental extension until an operator resolves it. Track 26 promises no guaranteed recognition and adds no leading-field policy.
- A sudden process stop can leave staged orphans for manual cleanup.
- Staging adds input and output work. Peak space can include an interrupted target plus the selected chain.
- Target-monotonic floors prevent rewind, but repeated restores consume sequence space.
- Target high-water differences can give equivalent restores different floors.
- Diagnostics and recovery must qualify sequence values by identity.
- Logical completion and sequence-floor continuity cross transaction and recovery.
- Shared build-state can limit parallel builds.
- Broad index support can raise validation and build costs.
- Manual and Lucene exclusions limit use.
- Ordinary lifecycle transitions need no forced synchronization.
- Filesystem and barrier behavior remain unproved.
- The publication helper serves Track 8 export promotion. Platform changes risk compatibility.
- BG12 and CS119 share one cause: sole-authority replacement cannot fail closed after an unconfirmed barrier.
- Special lock resources fail promptly. Local lock retention is bounded. Path aliases share publication exclusion. Maximum operation identifiers do not wrap visibility.
- Redundant selection adds complexity. Ambiguity can require operator recovery when one authority appears usable. Finite redundancy cannot survive loss of all authority records.
- Under D317, a non-daemon Track 32 worker in an uninterruptible wait may survive the five-second grace period. It may keep the test process alive. Reporting it is not termination. The user accepts this residual risk without lowering T32-TS4 from open `should-fix`.
- Track 27 verdict: Design review (pre-implementation): user-approved — 2026-09-15.
- Track 31 Revision 4 received user approval on 2026-09-16. Final adversarial review passed on 2026-09-16. The user approved the design for implementation on 2026-09-16.

Size exception: 44,535 bytes, 28,151 above the 16,384-byte target. Canonical UTF-8 counts: Planned changes 38,369, Tracks 5,439, Motivation 727.

Before the proposed Track 31 amendment, the body was 42,896 bytes. Planned changes were 36,806 bytes. Tracks were 5,363 bytes. Motivation was 727 bytes.

Before the Track 27 amendment, body was 42,739. Planned changes were 36,528. Tracks were 5,484. Motivation was 727. Prior accepted before-counts follow.

Prior body counts: 42,898, 41,448, 39,678, 39,109. Planned changes: 37,660, 36,106, 34,390, 33,850, 29,670. Tracks: 4,884, 4,988, 4,934, 4,905, 4,913. Motivation: 354.

A pre-recondensing candidate measured 45,445 overall and 39,227 for Planned changes. Prior condensation covered Tracks 24, 26, and 30 and preserved decisions. This interim-draft exception is not final approval. Delivery removes Tracks.

Design review, pre-adversarial: user-approved — 2026-08-27

Track 26 Revision 3, adversarial review: passed, 1 accepted risk — 2026-09-11. The one accepted risk is the unclassifiable interrupted backup output policy. It is not a count of the other recorded non-goals.

Two fresh review gates verified all 20 accumulated Track 26 design findings at design level. T26D-CS4 remains a separately accounted accepted-risk item under D276, not a code fix or severity reduction. Design review (pre-implementation): user-approved — 2026-09-11. Track 26 implementation is complete and pushed.

Track 32 adversarial review passed after both targeted gates verified all eight findings, with no accepted risks or new findings — 2026-09-14. Design review (pre-implementation): user-approved — 2026-09-14. Track 32 implementation is complete, user-approved, and pushed.

Adversarial review: PASS. Closed DS109–DS116, CN149–CN150, CS132–CS142, and N1–N29. No finding remains — 2026-08-27.

Design review, pre-implementation: user-approved. Implementation may start — 2026-08-27.

Expanded Track 6 split: user-approved. Feature-format `ACTIVE` admission and the target-monotonic sequence floor are final — 2026-08-27.

Platform durability amendment, adversarial review: PASS. No findings. Platform verification limits and Track 8 compatibility risk remain — 2026-08-27.

Platform durability amendment, pre-implementation: user-approved. Implementation may start — 2026-08-27.

Track 6 regression-scope amendment, pre-adversarial: user-approved — 2026-08-27.

D182 adversarial review: PASS. No substantive findings — 2026-08-27.

D182 final pre-implementation: user-approved — 2026-08-27.

Track 6 design history: The publication update and initial-authority exception received pre-adversarial approval on 2026-08-28. Publication review round one was REVISE for DS117, DS118, DS130, DS131, and DS132 on 2026-08-28. The interrupted-birth fail-closed rule received pre-adversarial approval and DS150 resolution on 2026-09-01. DS151 resolved the creating-call clarification on 2026-09-01. The final gate passed and received final pre-implementation approval on 2026-09-01.

The final gate covered redundant-authority publication, the initial-authority exception, interrupted-birth fail-closed behavior, and creating-call clarification. Each passed adversarial review and received final pre-implementation approval. DS117, DS118, DS130, DS131, DS132, DS150, and DS151 are verified and closed as of 2026-09-01. Evidence included bounded authority models, exact prose checks, publisher interleaving, candidate recovery, and storage-birth lifecycle analysis.

No high-level design question remains open for Track 6. Remaining findings remain listed under Suggestions. Goals and non-goals do not change. Windows support, track order, and the external directory-writer non-goal remain unchanged.

Track 6 completion: user-approved and complete — 2026-09-04.

Track 28 high-level design received user approval before implementation on 2026-09-07.

Track 28 is complete in commit `9016152931`, titled `Track 28: lifecycle value types and bootstrap wiring`. The branch head equals the remote head.

Track 28 adds index lifecycle value types. Track 28 wires durable bootstrap authority into disk storage creation, storage open, and restore. Bootstrap authority is a durable file pair that records one storage identity and the current lineage identity for one storage. Storage open reads the pair before crash recovery. Storage creation writes the pair before the write-ahead log starts. Restore rotates the lineage identity and drops stale index lifecycle holders.

The in-memory storage engine uses a volatile identity source.

Decision D229 added four late Track 28 goals on 2026-09-08 with user approval. The storage identity pair is never observable before the durable identity read completes. Production code removes a publication candidate file, which is a temporary file written before an authority record becomes active. The bootstrap wiring test uses accessors instead of reflection. The failed-birth test asserts the injected failure cause.

Decision D229 also added five Track 28 non-goals. Track 28 does not own the operation identifier floor rule because decisions D179 and D193 own that rule. Track 28 does not advance the durable sequence floor from an issued operation identifier. Track 23 owns lifecycle writers, so Track 28 adds no descriptor guard to lifecycle snapshot publication. Track 28 does not make bootstrap failure messages uniform. Track 28 does not add a live-token guard when a pending restore record is reused.

**Done.** Track 23 provides one durable lifecycle record for every supported local schema index. A local schema index belongs to the database schema and uses local storage. A lifecycle record tracks the build and readiness state of one index. Track 23 runs after Track 28.

**Done.** Track 23 keys each lifecycle record by the record identifier of the index descriptor. An index descriptor is the durable record that describes one index. Track 23 creates the index descriptor, engine configuration, manager link, and lifecycle record in one atomic unit. Track 23 deletes the lifecycle record when the index is deleted.

**Done.** Track 23 recovers lifecycle records during storage open. A missing record quarantines only the affected index. Quarantine keeps the index present and unusable and records a stable diagnostic reason. Track 23 adds no writer gate or reader gate. Track 23 changes no user-visible lifecycle policy.

**Done.** Track 23 uses the lifecycle value types, publication machinery, lineage checks, and metadata validation delivered by Track 28. Every publication validates descriptor identity and compares the expected snapshot by value. A restore adopts stored build progress without rewriting lifecycle records or resetting progress. The Track 23 implementer owns the low-level design and records that design in the track report.

Track 23 outcome:

Every supported local schema index now has one durable lifecycle record.
Index creation writes the descriptor, the lifecycle record, and the durable link inside one atomic operation.
Deletion, recovery, and quarantine follow the durable link.
Publication compares the expected snapshot by value and excludes the owner epoch field.

Logical export and logical import exclude the build state collection.
Logical import preserves the lifecycle records of the target database.
The commit debug log no longer formats whole entities.
The commit debug log resolves no link.

The full unit suite ran in the default in-memory mode.
The full unit suite covered 19,970 tests.
The full unit suite had zero failures, zero errors, and 95 skipped tests.
The targeted disk-mode subset covered 137 tests.
The targeted disk-mode subset had zero failures, zero errors, and one skipped test.

Changed-line coverage reached 92.6 percent.
Changed-branch coverage reached 83.3 percent.
The coverage gate passed.
Decisions D232 through D243 shaped Track 23.

Track 29 removes logging that formats a whole record after its transaction ends. A record read needs an active transaction, so logging can throw. Track 29 repairs three sites and prints scalar summaries instead.

Track 29 is complete in commit `435c3cf8c1`, titled `Prevent unsafe scheduler logging`.
Track 29 touches eight files in the core module.
The remote branch `index-rebuild` points to commit `435c3cf8c1`.
The full unit suite ran in the default in-memory mode.
The full unit suite covered 23,812 tests.
The full unit suite had zero failures and 529 skipped tests.

The targeted disk-mode subset covered 110 tests.
The targeted disk-mode subset had zero failures.
Changed-line coverage reached 91.7 percent.
Changed-branch coverage reached 100 percent.

The coverage gate passed.
Two guard bodies remain uncovered.
`MultiValue.java` line 176 remains uncovered.
`SchedulerImpl.java` lines 132 to 133 remain uncovered.

Track 30 establishes one lock order for lifecycle-record creation, update, and deletion. It resolves CN209, CN210, CN215, and CQ28. Adversarial review covered concurrency, crash recovery, and coherence. A second re-check followed the amendment. The user approved the design and implementation.

Standalone writes acquire the backend monitor and storage state read lock first. They then acquire the atomic operation and lifecycle-collection exclusive lock. Release happens in reverse. Commit-time creation reuses its commit protections without the backend monitor. Schema commits take the metadata-write mutex, schema write lock, and index-manager lock before the state lock. This metadata prefix prevents lock cycles.

Standalone calls already owning storage protection are rejected. The final implementation uses `StorageStateContextException`, outside `HighLevelException`, for invalid storage-state contexts. The global error marker exempts exactly that type, so rejection does not poison later writes. Ownership checks occur before the backend monitor and identity validation. They cover creation, update, deletion, and the public publication path's internal read.

Track 30 repairs a pre-existing pure-data commit defect. A shared collection lookup reacquired and released state-read protection, allowing a writer between commit phases. Self-routing now avoids nested acquisition when the caller already has protection. A predicate reports current-thread state-write ownership, and five incorrect lock comments were fixed.

Track 30 does not add reader-depth tracking, commit-time update or deletion, or state-lock reentrancy. It changes no durability timing, freezer waiting, backend monitor, lifecycle read semantics, or commit sequencing. Existing engine ownership checks and assertions remain unchanged.

Track 30 is complete in commit `9c6bee8960`, titled `Unify lifecycle write lock order`. It changed eight core files, including one new file, and was pushed to `index-rebuild`. The default-memory suite passed 31,809 tests with 752 skipped. The targeted disk subset passed 132 tests with two skipped. No integration test ran locally. Changed-line coverage was 100.0 percent, changed-branch coverage was 94.4 percent, and the coverage gate passed.

Five review perspectives found three blockers and five should-fix findings. Two later gates found two more findings. Every finding was verified fixed. Nine suggestions remain open under CN219, CN223, CN224, CN225, TS40, and PF13. They include an uncovered lock-release ownership branch, a missing lifecycle-read rejection guard, and absent production callers for publication and deletion.

CQ29 is now should-fix, and Track 29 carries the repair. CN209, CN210, CN215, and CQ28 leave Suggestions because Track 30 carries their repair.

Track 24 is complete and pushed in commit `5492da358a819556915171e68a0cbd155fc07584`. Birth publishes `ACTIVE` only after durable genesis, and admission makes the true no-artifact decision before recovery. Destructive restart attempts the existing `dirty.fl` lock without waiting and holds it through content deletion. The final verification passed 31,888 memory tests and 182 targeted disk tests.

Changed-line coverage passed at 85.8 percent and changed-branch coverage passed at 76.2 percent. Coverage used a disposable clone with a clone-only server instrumentation workaround. The live pipeline configuration remains unchanged. Relevant final findings are closed.

Three pre-existing defects remain unfixed and have follow-up issues: YTDB-1302, YTDB-1300, and YTDB-1301.

Track 26 is complete and pushed. Its commit changes 17 paths. Git reports seven added paths and ten modified paths. The final approved source is byte-identical to the committed source. A fresh compile gate passed on 2026-09-14.

The default unit suite covered 31,967 tests, with zero failures, zero errors, and 752 skipped tests. The targeted disk suite covered 267 tests, with zero failures, zero errors, and zero skipped tests. Track 26 coverage reached 95.1 percent line coverage and 90.1 percent branch coverage. No integration test ran locally. Historical raw logs were not recovered.

Track 23 high-level design received user approval before implementation on 2026-09-04.

Decision D231 approved the revised Track 23 design on 2026-09-08. The revision reflects work already delivered by Track 28. Implementation starts after the approval.

Track 6 delivers durable bootstrap authority records and monotonic sequence primitives for new-format disk databases. A bootstrap authority record is data readable before format-specific recovery that identifies the storage image allowed to proceed toward activation.

- D190: A failed publication removes the candidate file that the same call created.
- D191: Forward compatibility is not supported, and a record of a different size is not read.
- D192: The Windows durable move falls back to the portable move when the native helper cannot load.
- D193: Disk corruption is not protected against, and backups cover that case. The effective sequence floor at startup is a rule recorded for later tracks.
- D194: The error-state transition keeps its split by call path, and YTDB-1292 tracks the consistent rule.
- D195: Review cleanups of the bootstrap metadata class include choosing the new lineage identity in that class.

Verification of the squashed Track 28 commit covered 31,741 default-mode unit tests. Failures and errors were zero. A targeted disk-mode subset covered 54 tests. Failures and errors were zero. Changed-line coverage reached 99.3 percent. Changed-branch coverage reached 93.1 percent.

Both coverage results exceed targets of 85 percent line coverage and 70 percent branch coverage. The full disk-mode suite and the integration suite run in the pull request pipeline. The full disk-mode suite and the integration suite do not run on a developer machine. One changed line in the index lifecycle registry has no test. One changed line in the bootstrap metadata class has no test. Both coverage gaps remain above the coverage targets.

YTDB-1292 and YTDB-1293 were filed and remain outside this pull request.


##### Suggestions:

The following T32 suggestions are workflow-deferred, not user-approved.

- T32-WC1: operation-table cost model. Define N as entries and R as ranges.
- T32-RG90: cleanup-fixture startup failure. Release blocked workers during cleanup.
- T32-RG101: verification report label clarity. Explain MT and RG50 at first use.
- CN76/CS71 — AbstractStorage create-side delta discard — Document its defense-in-depth role.
- CS69 — CommitTimeIndexBuildTest — Add a durable close-and-reopen assertion.
- CS70 — CommitTimeIndexBuildTest — Cover natural different-name slot reuse.
- CS72 — IndexRecoveryPathsTest — Extend persistent-staleness coverage beyond IndexOneValue.
- CS74 — CommitTimeIndexBuildTest — Match the histogram test flag to the engine type.
- CN80 — AbstractStorage Hook A and Hook B comments — Document the component-lock lifetime.
- CN131 — IndexHistogramManager forced-close path — Make detach check and act atomically.
- CN133 — IndexHistogramManager merge path — Document declined non-null merge semantics.
- CN134 — IndexHistogramManager publication sites — Align post-remap detach handling.
- CQ17 — AbstractStorage test seam — Narrow persistent production test-hook exposure. Follow-up YTDB-1287: https://youtrack.jetbrains.com/issue/YTDB-1287.
- CN148 — Index handle and storage locks — Reconcile lock ordering. Follow-up YTDB-1286: https://youtrack.jetbrains.com/issue/YTDB-1286.
- TS33 — StorageIdentityHolderTest — Relax exact-message assertions. This suggestion remains open after Track 28.
- CQ22 — StorageBootstrapMetadata — Replace the thread-local move strategy hook with an injectable factory. This suggestion remains open after Track 28.
- Coverage gap — IndexLifecycleRegistry — Add coverage for one changed line. This suggestion remains open after Track 28.
- Coverage gap — StorageBootstrapMetadata — Add coverage for one changed line. This suggestion remains open after Track 28.
- T24Q-CN2 — Bootstrap lock-name ownership — Share one durable lock-name constant and add a rename-resistant test. This suggestion remains open.
- Track 24 observation — server coverage instrumentation — Fix the pipeline argument override. Follow-up issue: https://youtrack.jetbrains.com/issue/YTDB-1302.
- Track 24 observation — unopened-storage drop extensions — Remove all supported component files. Follow-up issue: https://youtrack.jetbrains.com/issue/YTDB-1300.
- Track 24 observation — duplicate creation callbacks — Invoke creation callbacks once. Follow-up issue: https://youtrack.jetbrains.com/issue/YTDB-1301.
- T26-CS4 — Backup header writing in DiskStorage — Read source semantic values instead of build constants.
- T26-CN10 — Backup extension in DiskStorage — Bound header-admission reads without weakening whole-chain admission.
- T26-BG10 — Backup sequence diagnostics in DiskStorage — Remove the duplicated word from the refusal message.
- T26-BG11 — Backup preparation in DiskStorage — Validate encryption-key length before chain-sized copying when safe.
- T26-CN101 — Restore test seam in YouTrackDBInternalEmbedded — Add safe publication if cross-thread installation becomes supported.
- T26-CS100 — Backup hashing in DiskStorage — Correct nonzero-offset length semantics before that path becomes reachable.

##### Verification approach

- Completed tracks passed Spotless, compilation, 6,024 core unit tests, and 129 bounded integration tests.
- Changed-line coverage is 86.1 percent. Changed-branch coverage is 77.5 percent.
- Tracks 6 and 23 verify durable transitions and lifecycle authority. Track 24 verifies birth, genesis, WAL rejection, and `ACTIVE` admission.
- Track 26 verified both writers and both source forms. Tests cover classification, selection, cleanup, final restart admission, unchanged targets, and replay from prepared copies. Path and stream restore reject missing or incomplete creation evidence before target mutation.
- Track 32 passed its completed local gates. The full disk-mode suite and four identified integration tests remain pipeline obligations.
- Its default core suite, focused tests, and coverage gates passed locally. Track-only coverage reached 95.0 percent line and 87.5 percent branch coverage.
- Track 27 review and local gates passed. Full disk mode and five integration classes await pipeline. T27D-CS3 remains assigned to Track 31. Track 25 has no implementation scope.
- Track 31 tests cover abrupt restarts, concurrency, and publication failures for every goal. Later timestamps must exceed earlier stored-change timestamps. Performance comparison against the current branch covers continuous writes, frequent cleanup checkpoints, and histogram-triggering writes. It reports throughput, transaction latency, and longest maintenance-induced write pauses. Meaningful slowdown returns to the user before acceptance. No numeric target is set.
- Crash tests cover each durable transition. Restore tests use executable phase controls, not source-text checks.
- The writing checker found no failures. Earlier reviews closed all findings.

#### Tracks:

| # | Track | Scope | Status |
|---|-------|-------|--------|
| 1 | Core primitives | Component locks, state-lock resolver, record writes, page accounting, and YTDB-1267 | complete, commit `68fe1274f5` |
| 2 | Engine foundations | Lifecycle registry, descriptor identity, generation-bearing references, and owner binding | complete, commit `1aff432bc7` |
| 3 | Identity-bound resolution | Owner-based recovery in the twenty-five recovery paths, with no per-dereference validation | complete, commit `2f0d600df3` |
| 21 | Counter-delta isolation | Discard count and histogram deltas across commit-window engine replacement; runs before track 20, and both run before track 4 | complete, commit `8505ffbce0` |
| 22 | Histogram publication liveness | Detach latch, gated remapping publication, and detach coverage; runs after track 21 and before track 20 | complete, commit `16d4e3411a` |
| 20 | Handle state consolidation | One immutable handle-state carrier, CAS publication, fused validation, and same-slot reuse closure; runs after track 3 and before track 4 | complete, commit `fedb06a1ec` |
| 4 | Validation boundaries | Writer commit validation, builder validation, and retryable mismatches; runs after Tracks 6, 23, 24, 26, 27, 31, and 32 | planned |
| 5 | Writer registry | Potentially-writing registry, token barriers, release, and diagnostics | planned |
| 6 | Durable activation primitives | Durable bootstrap authority records and monotonic sequence primitives for new-format disk databases; runs before Track 23 | complete, commit `9c44acf1dd` |
| 28 | index lifecycle value types and bootstrap authority wiring | Value types, bootstrap authority creation, storage open, restore wiring, and volatile in-memory identity; runs before Track 23 | complete, commit `9016152931` |
| 23 | durable index lifecycle persistence, atomic creation and recovery | Durable lifecycle records, atomic creation, and recovery; runs after Track 28 | complete, commit `bed601cae83e67bfa54dc57aedb21ba00cbdc71e` |
| 29 | Safe logging after a transaction ends | Remove whole-record logging after transaction end; repair three sites with scalar summaries | complete, commit `435c3cf8c1` |
| 30 | One lock order for lifecycle writes | Approved lock order and lifecycle ownership enforcement | complete, commit `9c6bee8960` |
| 24 | New-format birth and admission | Pre-recovery admission decision, durable genesis before activation, layout version in the authority record, ordered restore, and a destructive restart; runs after Track 23 | complete |
| 25 | All-work lineage fence | ~~Admission fence, quiescence, durable interruption, authority retirement, and stale-lineage exclusion~~ | waived by D269 |
| 26 | Backup admission and staging | Semantic headers with creation completion evidence, complete-chain preparation before target mutation, request-owned replay, and phase cleanup; runs after Track 24 and before Track 27 | complete |
| 27 | Restore activation and lineage rotation | Commit-timestamp floor before activation | complete; user-approved, committed, pushed; T27D-CS3 stays with Track 31 |
| 31 | Postactivation timestamp continuity | Preserve stored-change ordering across checkpoints, cleanup, histograms, and creation while retaining Track 27 protection. See [YTDB-1305](https://youtrack.jetbrains.com/issue/YTDB-1305). | Required before Track 4. Revision 4 review passed. User-approved for implementation |
| 32 | Bounded operation-table alignment | Bound operation-table cost across recovery and restore jumps while preserving live entries, visibility, and WAL retention; required before Tracks 27 and 4 | complete; user-approved and pushed |
| 7 | Migration | ~~Abandoned. Legacy migration left the goal.~~ | abandoned |
| 8 | Maintenance resolution | Live registry, generation memoization, transaction cache, and lifecycle gating | planned |
| 9 | Key derivation | Prepared derivation, LINK probes, multivalue iteration, and staleness recovery | planned |
| 10 | Build ownership | Ownership map, epochs, phases, cancellation, and start-path claims; runs before Track 11 | planned |
| 11 | Resumable cursor | Scanner, record-and-key cursor, exact puts, bounds, and chunk hygiene; blocked until Tracks 4 and 10 finish | planned |
| 12 | Readiness gating | Template methods, count gating, caches, fallbacks, and bypasses | planned |
| 13 | Operator commands | Lifecycle guards, atomic drop, publication, membership, rebuild and analyze guards | planned |
| 14 | Index engine fixes | Multivalue idempotence, unique removal, and containsExact | planned |
| 15 | Builder controls | Failure isolation, suspension, resume, throttling, bounds, logging, and shutdown | planned |
| 16 | Recovery scheduling | Event-driven recovery, open discovery, and lifecycle-based resume | planned |
| 17 | Invalid handling | Duplicate revalidation, invalid transition, and reporting | planned |
| 18 | Status and metrics | Lifecycle, suspension, barriers, ownership, throttling, cache, pages, and apply metrics | planned |
| 19 | Integration and tests | Top-level lifecycle, manual-index rejection, scheduling, documentation, benchmarks, and tests | planned |

Documentation synchronization commit `86a8524521`: `Docs: local test scope for disk mode and integration`. Decision D230 approved the documentation change on 2026-09-08. The change corrected ten documentation files and touched no code, test, or pipeline configuration.








