### PR TITLE
YTDB-1275: Add Gremlin translation telemetry

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -10,7 +10,10 @@ on:
       queries:
         description: >
           Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
-          Leave empty to run the full suite.
+          Leave empty to run the full jmh-ldbc suite, including
+          LdbcGremlinTranslatorBenchmark (translator on/off A/B) as well as
+          LdbcSingleThread / LdbcMultiThread SQL LDBC. Full empty-filter
+          compares need ~21h on CCX33 after Gremlin landed; job timeout is 30h.
         required: false
         type: string
         default: ''
@@ -42,7 +45,10 @@ jobs:
       - type-ccx33
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
-    timeout-minutes: 1200
+    # Full empty-filter suite = SQL LDBC (single+multi) + LdbcGremlinTranslator
+    # A/B. Observed wall after Gremlin landed: ~21h on CCX33 (20h timeout killed
+    # head ~50 min early). 30h leaves margin for variance and new shapes.
+    timeout-minutes: 1800
 
     steps:
       # ── Setup ────────────────────────────────────────────────────────────

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/CoreMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/CoreMetrics.java
@@ -124,6 +124,55 @@ public class CoreMetrics {
               TimeInterval.of(1, TimeUnit.SECONDS),
               TimeUnit.SECONDS));
 
+  // --- Gremlin-to-MATCH translation outcomes (fed by GremlinTranslationMetrics) ---
+
+  /**
+   * Share of translation attempts that succeed. Numerator = successes; denominator = successes +
+   * declines + errors. Early strategy gates (kill-switch, non-vertex start, etc.) are not attempts.
+   */
+  public static final MetricDefinition<MetricScope.Global,
+      Ratio> GREMLIN_TRANSLATION_SUCCESS_RATIO =
+          new MetricDefinition<>(
+              "GremlinTranslationSuccessRatio",
+              "Gremlin Translation Success Ratio",
+              "The ratio of successful Gremlin-to-MATCH translations to translation attempts (in"
+                  + " percents) for the last 60 seconds",
+              MetricType.ratio(
+                  TimeInterval.of(60, TimeUnit.SECONDS),
+                  TimeInterval.of(1, TimeUnit.SECONDS),
+                  100.0));
+
+  /**
+   * Share of translation attempts that decline (unsupported shape or cached decline). Same attempt
+   * denominator as {@link #GREMLIN_TRANSLATION_SUCCESS_RATIO}.
+   */
+  public static final MetricDefinition<MetricScope.Global,
+      Ratio> GREMLIN_TRANSLATION_DECLINE_RATIO =
+          new MetricDefinition<>(
+              "GremlinTranslationDeclineRatio",
+              "Gremlin Translation Decline Ratio",
+              "The ratio of declined Gremlin-to-MATCH translations to translation attempts (in"
+                  + " percents) for the last 60 seconds",
+              MetricType.ratio(
+                  TimeInterval.of(60, TimeUnit.SECONDS),
+                  TimeInterval.of(1, TimeUnit.SECONDS),
+                  100.0));
+
+  /**
+   * Share of translation attempts that hit the throw-safety net. Same attempt denominator as
+   * {@link #GREMLIN_TRANSLATION_SUCCESS_RATIO}.
+   */
+  public static final MetricDefinition<MetricScope.Global, Ratio> GREMLIN_TRANSLATION_ERROR_RATIO =
+      new MetricDefinition<>(
+          "GremlinTranslationErrorRatio",
+          "Gremlin Translation Error Ratio",
+          "The ratio of Gremlin-to-MATCH translation failures (throw-safety net) to translation"
+              + " attempts (in percents) for the last 60 seconds",
+          MetricType.ratio(
+              TimeInterval.of(60, TimeUnit.SECONDS),
+              TimeInterval.of(1, TimeUnit.SECONDS),
+              100.0));
+
   public static final Set<MetricDefinition<MetricScope.Global, ?>> GLOBAL_METRICS = Set.of(
       FILE_EVICTION_RATE,
       CACHE_HIT_RATIO,
@@ -135,7 +184,10 @@ public class CoreMetrics {
       QUERY_CACHE_MULTI_INVALIDATION_RATE,
       QUERY_CACHE_OVERFLOW_RATE,
       GREMLIN_PLAN_CACHE_HIT_RATE,
-      GREMLIN_PLAN_CACHE_MISS_RATE);
+      GREMLIN_PLAN_CACHE_MISS_RATE,
+      GREMLIN_TRANSLATION_SUCCESS_RATIO,
+      GREMLIN_TRANSLATION_DECLINE_RATIO,
+      GREMLIN_TRANSLATION_ERROR_RATIO);
 
   // ===================== DATABASE ===================== //
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/CoreMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/CoreMetrics.java
@@ -128,7 +128,8 @@ public class CoreMetrics {
 
   /**
    * Share of translation attempts that succeed. Numerator = successes; denominator = successes +
-   * declines + errors. Early strategy gates (kill-switch, non-vertex start, etc.) are not attempts.
+   * declines + errors. Kill-switch / missing session and idempotent re-applies are not attempts;
+   * edge starts and repeat vetoes are declines (and therefore attempts).
    */
   public static final MetricDefinition<MetricScope.Global,
       Ratio> GREMLIN_TRANSLATION_SUCCESS_RATIO =
@@ -143,8 +144,8 @@ public class CoreMetrics {
                   100.0));
 
   /**
-   * Share of translation attempts that decline (unsupported shape or cached decline). Same attempt
-   * denominator as {@link #GREMLIN_TRANSLATION_SUCCESS_RATIO}.
+   * Share of translation attempts that decline (unsupported shape, edge / non-vertex start, repeat
+   * veto, or cached decline). Same attempt denominator as {@link #GREMLIN_TRANSLATION_SUCCESS_RATIO}.
    */
   public static final MetricDefinition<MetricScope.Global,
       Ratio> GREMLIN_TRANSLATION_DECLINE_RATIO =

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/SharedContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/SharedContext.java
@@ -9,6 +9,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.GenesisIncompleteExcepti
 import com.jetbrains.youtrackdb.internal.core.gql.executor.GqlExecutionPlanCache;
 import com.jetbrains.youtrackdb.internal.core.gql.parser.GqlStatementCache;
 import com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy.GremlinPlanCache;
+import com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy.GremlinTranslationMetrics;
 import com.jetbrains.youtrackdb.internal.core.index.IndexException;
 import com.jetbrains.youtrackdb.internal.core.index.IndexManagerEmbedded;
 import com.jetbrains.youtrackdb.internal.core.index.Indexes;
@@ -72,6 +73,7 @@ public class SharedContext extends ListenerManger<MetadataUpdateListener> {
   protected YqlExecutionPlanCache yqlExecutionPlanCache;
   protected GqlExecutionPlanCache gqlExecutionPlanCache;
   protected GremlinPlanCache gremlinPlanCache;
+  protected GremlinTranslationMetrics gremlinTranslationMetrics;
   protected volatile boolean loaded = false;
   protected Map<String, Object> resources;
   protected StringCache stringCache;
@@ -149,6 +151,7 @@ public class SharedContext extends ListenerManger<MetadataUpdateListener> {
                 .getContextConfiguration()
                 .getValueAsInteger(GlobalConfiguration.STATEMENT_CACHE_SIZE));
     this.registerListener(gremlinPlanCache);
+    gremlinTranslationMetrics = new GremlinTranslationMetrics();
 
     storage
         .setStorageConfigurationUpdateListener(
@@ -385,6 +388,10 @@ public class SharedContext extends ListenerManger<MetadataUpdateListener> {
 
   public GremlinPlanCache getGremlinPlanCache() {
     return gremlinPlanCache;
+  }
+
+  public GremlinTranslationMetrics getGremlinTranslationMetrics() {
+    return gremlinTranslationMetrics;
   }
 
   public AbstractStorage getStorage() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprint.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprint.java
@@ -13,14 +13,17 @@ import javax.annotation.Nonnull;
 
 /**
  * Synthesises a value-independent fingerprint from post-walk {@link MatchPlanInputs} for the
- * {@link GremlinPlanCache}. The key enumerates the positive pattern topology, alias classes, alias
- * filters, detached NOT expressions, return projection, and result-shaping clauses ({@code GROUP
- * BY} / {@code ORDER BY} / {@code LIMIT} / {@code SKIP} / {@code DISTINCT}) — never {@link
+ * {@link GremlinPlanCache}. The key enumerates every planner-visible field on the record: positive
+ * pattern topology (including per-node {@code optional}), alias classes, alias filters, positive
+ * {@code matchExpressions}, detached NOT expressions, return projection (items / aliases / nested
+ * projections), result-shaping ({@code GROUP BY} / {@code ORDER BY} / {@code UNWIND} / {@code LIMIT}
+ * / {@code SKIP} / {@code DISTINCT}), and return-mode flags ({@code $elements} / {@code $paths} /
+ * {@code $patterns} / {@code $pathElements}). It never uses {@link
  * com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement#toGenericStatement()}, which
  * omits {@code notMatchExpressions}. Positional parameters render as {@code ?}; structural tokens
- * (class names, {@code ~label}, RIDs) stay verbatim so distinct labels and NOT shapes do not
- * collide. Limit / skip literals stay in the key (they are not positional slots), so {@code
- * limit(2)} and {@code limit(5)} cannot share a cached plan.
+ * (class names, {@code ~label}, RIDs, type-guard literals) stay verbatim so distinct labels and NOT
+ * shapes do not collide. Limit / skip literals stay in the key (they are not positional slots), so
+ * {@code limit(2)} and {@code limit(5)} cannot share a cached plan.
  *
  * <p><b>Every variable-length token is length-prefixed</b> ({@code len:content}) through {@link
  * #appendToken} / {@link #appendRendered}. The key is shared across sessions on one database and
@@ -47,9 +50,11 @@ final class GremlinPlanFingerprint {
     var sb = new StringBuilder(256);
     appendPattern(sb, inputs);
     appendAliasFilters(sb, inputs.aliasFilters());
+    appendMatchExpressions(sb, inputs.matchExpressions());
     appendNotExpressions(sb, inputs.notMatchExpressions());
     appendReturnProjection(sb, inputs);
     appendResultShaping(sb, inputs);
+    appendReturnModes(sb, inputs);
     return sb.toString();
   }
 
@@ -81,6 +86,9 @@ final class GremlinPlanFingerprint {
       appendToken(sb, entry.getKey());
       var cls = aliasClasses.get(entry.getKey());
       appendToken(sb, cls == null ? "" : cls);
+      // optional:true changes scheduler / null-row behaviour; omitting it would let a required
+      // hop and an optional hop share a plan.
+      sb.append(entry.getValue().optional ? '1' : '0');
     }
     sb.append(";E:");
     for (PatternNode node : pattern.aliasToNode.values()) {
@@ -144,6 +152,20 @@ final class GremlinPlanFingerprint {
     }
   }
 
+  /**
+   * Positive MATCH expression list. Gremlin today leaves this empty and builds {@link
+   * MatchPlanInputs#pattern()} directly; SQL still carries the expressions. Fingerprinting them
+   * keeps two inputs that differ only in {@code matchExpressions} from sharing a plan if a future
+   * front-end sets them without regenerating an equivalent pattern topology.
+   */
+  private static void appendMatchExpressions(StringBuilder sb,
+      List<SQLMatchExpression> matchExprs) {
+    sb.append(";M:");
+    for (var expr : matchExprs) {
+      appendRendered(sb, scratch -> appendMatchExpressionStructural(scratch, expr));
+    }
+  }
+
   private static void appendReturnProjection(StringBuilder sb, MatchPlanInputs inputs) {
     sb.append(";R:");
     var items = inputs.returnItems();
@@ -180,8 +202,8 @@ final class GremlinPlanFingerprint {
    * Appends Track 6 result-shaping clauses. Limit / skip use {@code toString} (not
    * {@code toGenericStatement}): {@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNumber}
    * collapses every integer to {@code ?}, which would let {@code limit(2)} and {@code limit(5)}
-   * collide. Group / order keep {@code toGenericStatement} — their discriminators are property
-   * names and directions, not rebound literals.
+   * collide. Group / order / unwind keep {@code toGenericStatement} — their discriminators are
+   * property names and directions, not rebound literals.
    */
   private static void appendResultShaping(StringBuilder sb, MatchPlanInputs inputs) {
     sb.append(";G:");
@@ -192,6 +214,10 @@ final class GremlinPlanFingerprint {
     if (inputs.orderBy() != null) {
       appendRendered(sb, scratch -> inputs.orderBy().toGenericStatement(scratch));
     }
+    sb.append(";U:");
+    if (inputs.unwind() != null) {
+      appendRendered(sb, scratch -> inputs.unwind().toGenericStatement(scratch));
+    }
     sb.append(";L:");
     if (inputs.limit() != null) {
       appendRendered(sb, scratch -> inputs.limit().toString(NO_PARAMS, scratch));
@@ -201,5 +227,19 @@ final class GremlinPlanFingerprint {
       appendRendered(sb, scratch -> inputs.skip().toString(NO_PARAMS, scratch));
     }
     sb.append(";D:").append(inputs.returnDistinct());
+  }
+
+  /**
+   * Return-mode flags ({@code RETURN $elements} / {@code $paths} / {@code $patterns} /
+   * {@code $pathElements}). These select different planner projection paths; omitting them would
+   * let e.g. {@code RETURN a} and {@code RETURN $paths} collide when both happen to carry empty
+   * return-item lists after normalisation.
+   */
+  private static void appendReturnModes(StringBuilder sb, MatchPlanInputs inputs) {
+    sb.append(";RM:")
+        .append(inputs.returnElements() ? '1' : '0')
+        .append(inputs.returnPaths() ? '1' : '0')
+        .append(inputs.returnPatterns() ? '1' : '0')
+        .append(inputs.returnPathElements() ? '1' : '0');
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprint.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprint.java
@@ -148,9 +148,11 @@ final class GremlinPlanFingerprint {
     sb.append(";R:");
     var items = inputs.returnItems();
     var aliases = inputs.returnAliases();
+    var nestedProjections = inputs.returnNestedProjections();
     for (int i = 0; i < items.size(); i++) {
       var item = items.get(i);
       var alias = aliases.get(i);
+      var nestedProjection = nestedProjections.get(i);
       appendRendered(sb, item::toGenericStatement);
       // Mark alias presence with a fixed byte, then length-prefix the alias itself, so a null alias
       // and an empty-string alias stay distinct and an alias embedding delimiters cannot merge with
@@ -160,6 +162,16 @@ final class GremlinPlanFingerprint {
       } else {
         sb.append('+');
         appendRendered(sb, alias::toGenericStatement);
+      }
+      // Nested projections are planner-visible output shape, stored parallel to the return item.
+      // Omitting them would let `RETURN a` and `RETURN a:{name}` (or two different nested
+      // projections on the same item) share a cached plan key even though the planner carries the
+      // projection structure through MatchPlanInputs.
+      if (nestedProjection == null) {
+        sb.append('-');
+      } else {
+        sb.append('+');
+        appendRendered(sb, nestedProjection::toGenericStatement);
       }
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
@@ -158,13 +158,13 @@ import org.slf4j.LoggerFactory;
  *
  * <h2>Translation telemetry</h2>
  *
- * Outcomes that reach a translation attempt (past the gating cascade above) feed
- * {@link GremlinTranslationMetrics} on the database {@code SharedContext}: successes, declines
- * (unsupported shape or cached decline), and throw-safety-net errors. Each recording also updates
- * the matching {@link com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics}
- * success / decline / error {@code Ratio} metrics. Declined shapes are retained (bounded) so
- * operators can ask which unsupported step lists dominate. Early gate exits are not counted —
- * they are not translator coverage failures.
+ * Outcomes that reach a translation attempt feed {@link GremlinTranslationMetrics} on the
+ * database {@code SharedContext}: successes, declines (unsupported shape, edge / non-vertex start,
+ * repeat veto, or cached decline), and throw-safety-net errors. Each recording also updates the
+ * matching {@link com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics} success /
+ * decline / error {@code Ratio} metrics. Declined shapes are retained (bounded) so operators can
+ * ask which unsupported step lists dominate. Kill-switch / missing session and idempotent
+ * re-applies (boundary already present) are not attempts — those are not coverage failures.
  *
  * <h2>Testability</h2>
  *
@@ -281,13 +281,15 @@ public final class GremlinToMatchStrategy
     if (session == null) {
       return;
     }
-    // Run the O(1) start-step gate before the O(steps) boundary scan, so a traversal that does not
-    // start at a vertex GraphStep declines without walking the whole step list. Idempotency still
-    // holds: an already-translated traversal's start step is a boundary step (an
-    // AbstractMatchPlanStep subtype, not a GraphStep), so hasVertexGraphStart declines it here
-    // anyway; the boundary scan below stays as the guard for the defensive case where an ordinary
-    // step is prepended in front of the boundary.
+    // Start-shape gate is O(1). Already-translated traversals also fail hasVertexGraphStart
+    // (start is a boundary, not a GraphStep), so check containsBoundaryStep before counting a
+    // decline — re-applies must stay outside attempts. Fresh edge / non-vertex starts are product
+    // gaps and count as declines; kill-switch / missing session already returned above.
     if (!hasVertexGraphStart(traversal)) {
+      if (containsBoundaryStep(traversal)) {
+        return;
+      }
+      GremlinTranslationMetrics.of(session).recordDecline(stepShape(traversal));
       return;
     }
     // Honour a per-traversal veto. RepeatDeclineStrategy marks a repeat-bearing traversal at
@@ -297,8 +299,10 @@ public final class GremlinToMatchStrategy
     // traversal's own strategy list never carries a provider strategy during the strategy pass, so
     // an absence test would decline every sub-traversal rather than the vetoed ones. See
     // RepeatDeclineStrategy for why the decision has to be taken that early, and for why the marker
-    // lives on the strategies reference's type rather than in the list itself.
+    // lives on the strategies reference's type rather than in the list itself. Variable-depth
+    // repeat is out of scope — count as a decline like any other unsupported shape.
     if (RepeatDeclineStrategy.isVetoed(traversal)) {
+      GremlinTranslationMetrics.of(session).recordDecline(stepShape(traversal));
       return;
     }
     if (containsBoundaryStep(traversal)) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
@@ -156,6 +156,16 @@ import org.slf4j.LoggerFactory;
  * {@code MatchExecutionPlanner} applies for the YQL/GQL plan cache. Cache-backed single-plan
  * steps copy the stored template on first open rather than during {@code apply}.
  *
+ * <h2>Translation telemetry</h2>
+ *
+ * Outcomes that reach a translation attempt (past the gating cascade above) feed
+ * {@link GremlinTranslationMetrics} on the database {@code SharedContext}: successes, declines
+ * (unsupported shape or cached decline), and throw-safety-net errors. Each recording also updates
+ * the matching {@link com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics}
+ * success / decline / error {@code Ratio} metrics. Declined shapes are retained (bounded) so
+ * operators can ask which unsupported step lists dominate. Early gate exits are not counted —
+ * they are not translator coverage failures.
+ *
  * <h2>Testability</h2>
  *
  * The translator and plan builder are injected as the {@link TraversalTranslator} and {@link
@@ -257,6 +267,7 @@ public final class GremlinToMatchStrategy
       // JVM Error or an -ea invariant violation must surface loudly, never degrade to a silent
       // decline.
       declineOnThrow(traversal, e);
+      recordTranslationError(traversal);
     }
   }
 
@@ -294,14 +305,17 @@ public final class GremlinToMatchStrategy
       return;
     }
     var extraction = GremlinStepWalker.extractShape(traversal, session);
+    var metrics = GremlinTranslationMetrics.of(session);
     if (populateTranslationCache && extraction.complete()) {
       var cached = GremlinPlanCache.getTranslation(extraction.key(), session);
       if (cached instanceof GremlinTranslationTemplate.Decline) {
+        metrics.recordDecline(stepShape(traversal));
         return;
       }
       if (cached instanceof GremlinTranslationTemplate.Translate translate
           && extraction.bindings().size() == translate.bindingCount()) {
         spliceFromTranslationCache(traversal, translate, extraction.bindings());
+        metrics.recordSuccess();
         return;
       }
     }
@@ -315,9 +329,11 @@ public final class GremlinToMatchStrategy
         GremlinPlanCache.putTranslation(
             extraction.key(), GremlinTranslationTemplate.DECLINE, session);
       }
+      metrics.recordDecline(stepShape(traversal));
       return;
     }
     applyTranslation(traversal, session, translation, planningStart, extraction);
+    metrics.recordSuccess();
   }
 
   /**
@@ -344,6 +360,20 @@ public final class GremlinToMatchStrategy
             LOGGER,
             cause,
             stepShape(traversal));
+  }
+
+  /**
+   * Feeds {@link GremlinTranslationMetrics#recordError} when a session is still attached. The
+   * throw-safety net may fire after the session gate (walk/plan throw) or, rarely, during session
+   * resolution itself — missing session means we cannot attribute the error to a database, so the
+   * counter is skipped and the DEBUG log in {@link #declineOnThrow} remains the sole signal.
+   */
+  private static void recordTranslationError(Traversal.Admin<?, ?> traversal) {
+    var session = YTDBStrategyUtil.resolveYtdbSession(traversal);
+    if (session == null) {
+      return;
+    }
+    GremlinTranslationMetrics.of(session).recordError(stepShape(traversal));
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetrics.java
@@ -17,10 +17,10 @@ import javax.annotation.Nullable;
 
 /**
  * Per-database counters for Gremlin-to-MATCH translation outcomes. Lives on {@code SharedContext}
- * beside {@link GremlinPlanCache}. Counts only translation <em>attempts</em>: shapes that passed
- * the strategy gates (session present, kill-switch on, vertex start, not vetoed, no boundary yet)
- * and then either translated, declined (unsupported or cached decline), or hit the throw-safety
- * net. Early gate exits are not attempts.
+ * beside {@link GremlinPlanCache}. Counts translation <em>attempts</em>: shapes the strategy tried
+ * to cover — successes, declines (unsupported walk, edge / non-vertex start, repeat veto, cached
+ * decline), and throw-safety-net errors. Kill-switch / missing session and idempotent re-applies
+ * (boundary already present) are not attempts.
  *
  * <p>Each recording also feeds three engine-global {@link Ratio} metrics in {@link CoreMetrics}
  * (success / decline / error share of attempts). Shape frequencies for declines are bounded

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetrics.java
@@ -1,0 +1,195 @@
+package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
+
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricDefinition;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricScope.Global;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricsRegistry;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
+import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import javax.annotation.Nullable;
+
+/**
+ * Per-database counters for Gremlin-to-MATCH translation outcomes. Lives on {@code SharedContext}
+ * beside {@link GremlinPlanCache}. Counts only translation <em>attempts</em>: shapes that passed
+ * the strategy gates (session present, kill-switch on, vertex start, not vetoed, no boundary yet)
+ * and then either translated, declined (unsupported or cached decline), or hit the throw-safety
+ * net. Early gate exits are not attempts.
+ *
+ * <p>Each recording also feeds three engine-global {@link Ratio} metrics in {@link CoreMetrics}
+ * (success / decline / error share of attempts). Shape frequencies for declines are bounded
+ * ({@link #MAX_TRACKED_SHAPES}) so a long-running process cannot grow an unbounded map of rare
+ * shapes.
+ */
+public final class GremlinTranslationMetrics {
+
+  /** Cap on distinct step-shape keys retained for frequency reporting. */
+  static final int MAX_TRACKED_SHAPES = 256;
+
+  private final LongAdder successes = new LongAdder();
+  private final LongAdder declines = new LongAdder();
+  private final LongAdder errors = new LongAdder();
+
+  private final ConcurrentHashMap<String, LongAdder> declineShapes = new ConcurrentHashMap<>();
+
+  private final Ratio successRatio;
+  private final Ratio declineRatio;
+  private final Ratio errorRatio;
+
+  public GremlinTranslationMetrics() {
+    this(YouTrackDBEnginesManager.instance().getMetricsRegistry());
+  }
+
+  /**
+   * Package-visible so tests can inject a registry (or null) without standing up the engine.
+   */
+  GremlinTranslationMetrics(@Nullable MetricsRegistry registry) {
+    this.successRatio = globalRatio(registry, CoreMetrics.GREMLIN_TRANSLATION_SUCCESS_RATIO);
+    this.declineRatio = globalRatio(registry, CoreMetrics.GREMLIN_TRANSLATION_DECLINE_RATIO);
+    this.errorRatio = globalRatio(registry, CoreMetrics.GREMLIN_TRANSLATION_ERROR_RATIO);
+  }
+
+  /** Resolves the metrics holder for {@code session}'s shared context. */
+  public static GremlinTranslationMetrics of(DatabaseSessionEmbedded session) {
+    return session.getSharedContext().getGremlinTranslationMetrics();
+  }
+
+  public void recordSuccess() {
+    successes.increment();
+    // One attempt: success numerator advances; decline and error numerators stay zero.
+    successRatio.record(1, 1);
+    declineRatio.record(0, 1);
+    errorRatio.record(0, 1);
+  }
+
+  /**
+   * Records a decline (walker returned null, or a cached decline template was reused). {@code
+   * shape} is the step-class list (no literal values); null/blank shapes are counted but not
+   * tracked in the frequency map.
+   */
+  public void recordDecline(@Nullable String shape) {
+    declines.increment();
+    successRatio.record(0, 1);
+    declineRatio.record(1, 1);
+    errorRatio.record(0, 1);
+    trackShape(declineShapes, shape);
+  }
+
+  /**
+   * Records a throw-safety-net failure (unexpected {@link RuntimeException} during walk/plan).
+   * {@code shape} is the step-class list at the time of the failure.
+   */
+  public void recordError(@Nullable String shape) {
+    errors.increment();
+    successRatio.record(0, 1);
+    declineRatio.record(0, 1);
+    errorRatio.record(1, 1);
+  }
+
+  public long getSuccesses() {
+    return successes.sum();
+  }
+
+  public long getDeclines() {
+    return declines.sum();
+  }
+
+  public long getErrors() {
+    return errors.sum();
+  }
+
+  /** Successes + declines + errors. */
+  public long getAttempts() {
+    return getSuccesses() + getDeclines() + getErrors();
+  }
+
+  /**
+   * Lifetime success share of attempts in {@code [0, 1]}, or {@code 0} when no attempts have been
+   * recorded yet.
+   */
+  public double successShare() {
+    return share(getSuccesses());
+  }
+
+  /**
+   * Lifetime decline share of attempts in {@code [0, 1]}, or {@code 0} when no attempts have been
+   * recorded yet.
+   */
+  public double declineShare() {
+    return share(getDeclines());
+  }
+
+  /**
+   * Lifetime error share of attempts in {@code [0, 1]}, or {@code 0} when no attempts have been
+   * recorded yet.
+   */
+  public double errorShare() {
+    return share(getErrors());
+  }
+
+  /**
+   * Top declined step shapes by count, highest first, at most {@code limit} entries. Answers which
+   * unsupported shapes dominate declines.
+   */
+  public List<ShapeCount> topDeclinedShapes(int limit) {
+    return topShapes(declineShapes, limit);
+  }
+
+  private double share(long numerator) {
+    var attempts = getAttempts();
+    return attempts == 0 ? 0.0 : (double) numerator / (double) attempts;
+  }
+
+  private static void trackShape(ConcurrentHashMap<String, LongAdder> map, @Nullable String shape) {
+    if (shape == null || shape.isBlank()) {
+      return;
+    }
+    var existing = map.get(shape);
+    if (existing != null) {
+      existing.increment();
+      return;
+    }
+    if (map.size() >= MAX_TRACKED_SHAPES) {
+      // At capacity: keep counting totals, but do not retain a new rare shape key.
+      return;
+    }
+    map.computeIfAbsent(shape, ignored -> new LongAdder()).increment();
+  }
+
+  private static List<ShapeCount> topShapes(ConcurrentHashMap<String, LongAdder> map, int limit) {
+    if (limit <= 0 || map.isEmpty()) {
+      return List.of();
+    }
+    var entries = new ArrayList<Map.Entry<String, LongAdder>>(map.size());
+    entries.addAll(map.entrySet());
+    entries.sort(
+        Comparator.<Map.Entry<String, LongAdder>>comparingLong(e -> e.getValue().sum())
+            .reversed()
+            .thenComparing(Map.Entry::getKey));
+    var n = Math.min(limit, entries.size());
+    var out = new ArrayList<ShapeCount>(n);
+    for (int i = 0; i < n; i++) {
+      var e = entries.get(i);
+      out.add(new ShapeCount(e.getKey(), e.getValue().sum()));
+    }
+    return List.copyOf(out);
+  }
+
+  private static Ratio globalRatio(
+      @Nullable MetricsRegistry registry, MetricDefinition<Global, Ratio> definition) {
+    return registry != null ? registry.globalMetric(definition) : Ratio.NOOP;
+  }
+
+  /**
+   * One step-shape key and its lifetime count. Shape strings use step class simple names only (no
+   * predicate literals).
+   */
+  public record ShapeCount(String shape, long count) {
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/PrefilterMetricsDefinitionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/PrefilterMetricsDefinitionTest.java
@@ -36,8 +36,8 @@ public class PrefilterMetricsDefinitionTest {
 
   /**
    * GLOBAL_METRICS must contain the disk-cache / prefilter originals, the tx-result-cache rates,
-   * and the Gremlin plan-cache hit/miss rates. This catches both accidental additions and
-   * accidental removals.
+   * the Gremlin plan-cache hit/miss rates, and the Gremlin translation success/decline/error
+   * ratios. This catches both accidental additions and accidental removals.
    */
   @Test
   public void globalMetricsContainsExactlyExpectedMetrics() {
@@ -52,7 +52,10 @@ public class PrefilterMetricsDefinitionTest {
         CoreMetrics.QUERY_CACHE_MULTI_INVALIDATION_RATE,
         CoreMetrics.QUERY_CACHE_OVERFLOW_RATE,
         CoreMetrics.GREMLIN_PLAN_CACHE_HIT_RATE,
-        CoreMetrics.GREMLIN_PLAN_CACHE_MISS_RATE);
+        CoreMetrics.GREMLIN_PLAN_CACHE_MISS_RATE,
+        CoreMetrics.GREMLIN_TRANSLATION_SUCCESS_RATIO,
+        CoreMetrics.GREMLIN_TRANSLATION_DECLINE_RATIO,
+        CoreMetrics.GREMLIN_TRANSLATION_ERROR_RATIO);
   }
 
   // ---- Config entry assertions ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
@@ -1,0 +1,68 @@
+package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.internal.core.sql.executor.match.MatchPlanInputs;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.ParseException;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.Pattern;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.YouTrackDBSql;
+import java.io.ByteArrayInputStream;
+import org.junit.Test;
+
+/**
+ * Low-level fingerprint regression tests for planner-visible distinctions that are easier to pin on
+ * raw {@link MatchPlanInputs} than through a full Gremlin traversal.
+ */
+public class GremlinPlanFingerprintTest {
+
+  /**
+   * Nested projections are carried in {@link MatchPlanInputs#returnNestedProjections()} and affect
+   * the planner's output shaping. Two MATCH inputs that differ only in the nested projection must
+   * not share a Gremlin plan-cache fingerprint.
+   */
+  @Test
+  public void nestedProjections_distinguishFingerprint() {
+    var withName = parse("MATCH {class: V, as: a} RETURN a:{name}");
+    var withSurname = parse("MATCH {class: V, as: a} RETURN a:{surname}");
+
+    var fpName = fingerprintForProjection(withName);
+    var fpSurname = fingerprintForProjection(withSurname);
+
+    assertThat(fpName).isNotEqualTo(fpSurname);
+  }
+
+  /**
+   * A plain return and a nested-projection return must not collide even when the return item itself
+   * is the same identifier.
+   */
+  @Test
+  public void plainReturn_and_nestedProjection_distinguishFingerprint() {
+    var plain = parse("MATCH {class: V, as: a} RETURN a");
+    var nested = parse("MATCH {class: V, as: a} RETURN a:{name}");
+
+    var fpPlain = fingerprintForProjection(plain);
+    var fpNested = fingerprintForProjection(nested);
+
+    assertThat(fpPlain).isNotEqualTo(fpNested);
+  }
+
+  private static String fingerprintForProjection(SQLMatchStatement statement) {
+    var inputs =
+        MatchPlanInputs.builder(new Pattern())
+            .returnItems(statement.getReturnItems())
+            .returnAliases(statement.getReturnAliases())
+            .returnNestedProjections(statement.getReturnNestedProjections())
+            .build();
+    return GremlinPlanFingerprint.fingerprint(inputs);
+  }
+
+  private static SQLMatchStatement parse(String query) {
+    try {
+      var parser = new YouTrackDBSql(new ByteArrayInputStream(query.getBytes()));
+      return (SQLMatchStatement) parser.parse();
+    } catch (ParseException e) {
+      throw new RuntimeException("Failed to parse MATCH statement: " + query, e);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jetbrains.youtrackdb.internal.core.sql.executor.match.MatchPlanInputs;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.match.PatternNode;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.ParseException;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.Pattern;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement;
@@ -12,7 +13,9 @@ import org.junit.Test;
 
 /**
  * Low-level fingerprint regression tests for planner-visible distinctions that are easier to pin on
- * raw {@link MatchPlanInputs} than through a full Gremlin traversal.
+ * raw {@link MatchPlanInputs} than through a full Gremlin traversal. Covers fields that Gremlin
+ * currently leaves at defaults but the planner still reads — so a future front-end setting them
+ * cannot collide with today's empty/default shapes.
  */
 public class GremlinPlanFingerprintTest {
 
@@ -47,12 +50,148 @@ public class GremlinPlanFingerprintTest {
     assertThat(fpPlain).isNotEqualTo(fpNested);
   }
 
+  /**
+   * {@code PatternNode.optional} changes whether a missing hop drops the row. Required vs optional
+   * on the same alias topology must not share a fingerprint.
+   */
+  @Test
+  public void optionalNode_distinguishesFingerprint() {
+    var required = patternWithOptional("friend", false);
+    var optional = patternWithOptional("friend", true);
+
+    assertThat(GremlinPlanFingerprint.fingerprint(required))
+        .isNotEqualTo(GremlinPlanFingerprint.fingerprint(optional));
+  }
+
+  /**
+   * Positive {@code matchExpressions} are planner inputs even when the pattern graph is empty.
+   * Two different expression lists must not collide.
+   */
+  @Test
+  public void matchExpressions_distinguishFingerprint() {
+    var knows = parse("MATCH {class: V, as: a}.out('knows'){as: b} RETURN a");
+    var likes = parse("MATCH {class: V, as: a}.out('likes'){as: b} RETURN a");
+
+    var fpKnows =
+        MatchPlanInputs.builder(new Pattern())
+            .matchExpressions(knows.getMatchExpressions())
+            .returnItems(knows.getReturnItems())
+            .returnAliases(knows.getReturnAliases())
+            .returnNestedProjections(knows.getReturnNestedProjections())
+            .build();
+    var fpLikes =
+        MatchPlanInputs.builder(new Pattern())
+            .matchExpressions(likes.getMatchExpressions())
+            .returnItems(likes.getReturnItems())
+            .returnAliases(likes.getReturnAliases())
+            .returnNestedProjections(likes.getReturnNestedProjections())
+            .build();
+
+    assertThat(GremlinPlanFingerprint.fingerprint(fpKnows))
+        .isNotEqualTo(GremlinPlanFingerprint.fingerprint(fpLikes));
+  }
+
+  /** UNWIND expands collections; present vs absent must not share a fingerprint. */
+  @Test
+  public void unwind_distinguishesFingerprint() {
+    var withUnwind = parse("MATCH {class: V, as: a} RETURN a.name AS x UNWIND x");
+    var withoutUnwind = parse("MATCH {class: V, as: a} RETURN a.name AS x");
+
+    assertThat(fingerprintFromStatementClauses(withUnwind))
+        .isNotEqualTo(fingerprintFromStatementClauses(withoutUnwind));
+  }
+
+  /**
+   * Return-mode flags select different planner projection paths. {@code RETURN a} and {@code
+   * RETURN $paths} must not share a fingerprint.
+   */
+  @Test
+  public void returnPathsMode_distinguishesFingerprint() {
+    var items = parse("MATCH {class: V, as: a} RETURN a");
+    var paths = parse("MATCH {class: V, as: a} RETURN $paths");
+
+    assertThat(fingerprintFromStatementClauses(items))
+        .isNotEqualTo(fingerprintFromStatementClauses(paths));
+  }
+
+  /** {@code RETURN $elements} vs plain item return must not collide. */
+  @Test
+  public void returnElementsMode_distinguishesFingerprint() {
+    var items = parse("MATCH {class: V, as: a} RETURN a");
+    var elements = parse("MATCH {class: V, as: a} RETURN $elements");
+
+    assertThat(fingerprintFromStatementClauses(items))
+        .isNotEqualTo(fingerprintFromStatementClauses(elements));
+  }
+
+  /**
+   * Each return-mode flag is independent: flipping only {@code returnPatterns} must change the
+   * fingerprint even when return-item lists stay empty/default.
+   */
+  @Test
+  public void returnPatternsFlag_alone_distinguishesFingerprint() {
+    var base =
+        MatchPlanInputs.builder(new Pattern()).returnPatterns(false).build();
+    var patterns =
+        MatchPlanInputs.builder(new Pattern()).returnPatterns(true).build();
+
+    assertThat(GremlinPlanFingerprint.fingerprint(base))
+        .isNotEqualTo(GremlinPlanFingerprint.fingerprint(patterns));
+  }
+
+  /** Same for {@code returnPathElements}. */
+  @Test
+  public void returnPathElementsFlag_alone_distinguishesFingerprint() {
+    var base =
+        MatchPlanInputs.builder(new Pattern()).returnPathElements(false).build();
+    var pathElements =
+        MatchPlanInputs.builder(new Pattern()).returnPathElements(true).build();
+
+    assertThat(GremlinPlanFingerprint.fingerprint(base))
+        .isNotEqualTo(GremlinPlanFingerprint.fingerprint(pathElements));
+  }
+
+  private static MatchPlanInputs patternWithOptional(String alias, boolean optional) {
+    var pattern = new Pattern();
+    var node = new PatternNode();
+    node.alias = alias;
+    node.optional = optional;
+    pattern.aliasToNode.put(alias, node);
+    return MatchPlanInputs.builder(pattern).build();
+  }
+
   private static String fingerprintForProjection(SQLMatchStatement statement) {
     var inputs =
         MatchPlanInputs.builder(new Pattern())
             .returnItems(statement.getReturnItems())
             .returnAliases(statement.getReturnAliases())
             .returnNestedProjections(statement.getReturnNestedProjections())
+            .build();
+    return GremlinPlanFingerprint.fingerprint(inputs);
+  }
+
+  /**
+   * Builds a fingerprint from the statement's clause fields (expressions, unwind, return modes)
+   * without running the planner's pattern-build pass — enough to pin clause-level distinctions.
+   */
+  private static String fingerprintFromStatementClauses(SQLMatchStatement statement) {
+    var inputs =
+        MatchPlanInputs.builder(new Pattern())
+            .matchExpressions(statement.getMatchExpressions())
+            .notMatchExpressions(statement.getNotMatchExpressions())
+            .returnItems(statement.getReturnItems())
+            .returnAliases(statement.getReturnAliases())
+            .returnNestedProjections(statement.getReturnNestedProjections())
+            .groupBy(statement.getGroupBy())
+            .orderBy(statement.getOrderBy())
+            .unwind(statement.getUnwind())
+            .limit(statement.getLimit())
+            .skip(statement.getSkip())
+            .returnDistinct(statement.isReturnDistinct())
+            .returnElements(statement.returnsElements())
+            .returnPaths(statement.returnsPaths())
+            .returnPatterns(statement.returnsPatterns())
+            .returnPathElements(statement.returnsPathElements())
             .build();
     return GremlinPlanFingerprint.fingerprint(inputs);
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinPlanFingerprintTest.java
@@ -151,6 +151,118 @@ public class GremlinPlanFingerprintTest {
         .isNotEqualTo(GremlinPlanFingerprint.fingerprint(pathElements));
   }
 
+  /**
+   * Sweep: each planner-visible {@link MatchPlanInputs} distinction that the fingerprint claims to
+   * cover must actually change the key when flipped in isolation. Catches a future edit that drops a
+   * section while leaving the Javadoc claiming full coverage.
+   */
+  @Test
+  public void everyCoveredField_inIsolation_changesFingerprint() {
+    assertDistinct(
+        "optional node",
+        patternWithOptional("n", false),
+        patternWithOptional("n", true));
+
+    var knows = parse("MATCH {class: V, as: a}.out('knows'){as: b} RETURN a");
+    var likes = parse("MATCH {class: V, as: a}.out('likes'){as: b} RETURN a");
+    assertDistinct(
+        "matchExpressions",
+        MatchPlanInputs.builder(new Pattern())
+            .matchExpressions(knows.getMatchExpressions())
+            .returnItems(knows.getReturnItems())
+            .returnAliases(knows.getReturnAliases())
+            .returnNestedProjections(knows.getReturnNestedProjections())
+            .build(),
+        MatchPlanInputs.builder(new Pattern())
+            .matchExpressions(likes.getMatchExpressions())
+            .returnItems(likes.getReturnItems())
+            .returnAliases(likes.getReturnAliases())
+            .returnNestedProjections(likes.getReturnNestedProjections())
+            .build());
+
+    var withNot =
+        parse("MATCH {class: V, as: a}, NOT {as: a}.out('knows'){as: b} RETURN a");
+    var withoutNot = parse("MATCH {class: V, as: a} RETURN a");
+    assertDistinct(
+        "notMatchExpressions",
+        fingerprintInputsFromClauses(withNot),
+        fingerprintInputsFromClauses(withoutNot));
+
+    assertDistinct(
+        "unwind",
+        fingerprintInputsFromClauses(
+            parse("MATCH {class: V, as: a} RETURN a.name AS x UNWIND x")),
+        fingerprintInputsFromClauses(
+            parse("MATCH {class: V, as: a} RETURN a.name AS x")));
+
+    assertDistinct(
+        "returnDistinct",
+        MatchPlanInputs.builder(new Pattern()).returnDistinct(false).build(),
+        MatchPlanInputs.builder(new Pattern()).returnDistinct(true).build());
+
+    assertDistinct(
+        "returnElements",
+        MatchPlanInputs.builder(new Pattern()).returnElements(false).build(),
+        MatchPlanInputs.builder(new Pattern()).returnElements(true).build());
+    assertDistinct(
+        "returnPaths",
+        MatchPlanInputs.builder(new Pattern()).returnPaths(false).build(),
+        MatchPlanInputs.builder(new Pattern()).returnPaths(true).build());
+    assertDistinct(
+        "returnPatterns",
+        MatchPlanInputs.builder(new Pattern()).returnPatterns(false).build(),
+        MatchPlanInputs.builder(new Pattern()).returnPatterns(true).build());
+    assertDistinct(
+        "returnPathElements",
+        MatchPlanInputs.builder(new Pattern()).returnPathElements(false).build(),
+        MatchPlanInputs.builder(new Pattern()).returnPathElements(true).build());
+
+    var plain = parse("MATCH {class: V, as: a} RETURN a");
+    var nested = parse("MATCH {class: V, as: a} RETURN a:{name}");
+    assertDistinct(
+        "returnNestedProjections",
+        fingerprintInputsFromProjection(plain),
+        fingerprintInputsFromProjection(nested));
+
+    var limit2 = parse("MATCH {class: V, as: a} RETURN a LIMIT 2");
+    var limit5 = parse("MATCH {class: V, as: a} RETURN a LIMIT 5");
+    assertDistinct(
+        "limit",
+        fingerprintInputsFromClauses(limit2),
+        fingerprintInputsFromClauses(limit5));
+
+    var skip1 = parse("MATCH {class: V, as: a} RETURN a SKIP 1");
+    var skip2 = parse("MATCH {class: V, as: a} RETURN a SKIP 2");
+    assertDistinct(
+        "skip",
+        fingerprintInputsFromClauses(skip1),
+        fingerprintInputsFromClauses(skip2));
+
+    var personClass =
+        MatchPlanInputs.builder(patternWithAlias("a"))
+            .aliasClasses(java.util.Map.of("a", "Person"))
+            .build();
+    var companyClass =
+        MatchPlanInputs.builder(patternWithAlias("a"))
+            .aliasClasses(java.util.Map.of("a", "Company"))
+            .build();
+    assertDistinct("aliasClasses", personClass, companyClass);
+  }
+
+  private static void assertDistinct(String field, MatchPlanInputs left, MatchPlanInputs right) {
+    assertThat(GremlinPlanFingerprint.fingerprint(left))
+        .as("fingerprints must differ when only %s changes", field)
+        .isNotEqualTo(GremlinPlanFingerprint.fingerprint(right));
+  }
+
+  private static Pattern patternWithAlias(String alias) {
+    var pattern = new Pattern();
+    var node = new PatternNode();
+    node.alias = alias;
+    pattern.aliasToNode.put(alias, node);
+    return pattern;
+  }
+
   private static MatchPlanInputs patternWithOptional(String alias, boolean optional) {
     var pattern = new Pattern();
     var node = new PatternNode();
@@ -161,39 +273,43 @@ public class GremlinPlanFingerprintTest {
   }
 
   private static String fingerprintForProjection(SQLMatchStatement statement) {
-    var inputs =
-        MatchPlanInputs.builder(new Pattern())
-            .returnItems(statement.getReturnItems())
-            .returnAliases(statement.getReturnAliases())
-            .returnNestedProjections(statement.getReturnNestedProjections())
-            .build();
-    return GremlinPlanFingerprint.fingerprint(inputs);
+    return GremlinPlanFingerprint.fingerprint(fingerprintInputsFromProjection(statement));
+  }
+
+  private static MatchPlanInputs fingerprintInputsFromProjection(SQLMatchStatement statement) {
+    return MatchPlanInputs.builder(new Pattern())
+        .returnItems(statement.getReturnItems())
+        .returnAliases(statement.getReturnAliases())
+        .returnNestedProjections(statement.getReturnNestedProjections())
+        .build();
   }
 
   /**
-   * Builds a fingerprint from the statement's clause fields (expressions, unwind, return modes)
-   * without running the planner's pattern-build pass — enough to pin clause-level distinctions.
+   * Builds inputs from the statement's clause fields (expressions, unwind, return modes) without
+   * running the planner's pattern-build pass — enough to pin clause-level distinctions.
    */
   private static String fingerprintFromStatementClauses(SQLMatchStatement statement) {
-    var inputs =
-        MatchPlanInputs.builder(new Pattern())
-            .matchExpressions(statement.getMatchExpressions())
-            .notMatchExpressions(statement.getNotMatchExpressions())
-            .returnItems(statement.getReturnItems())
-            .returnAliases(statement.getReturnAliases())
-            .returnNestedProjections(statement.getReturnNestedProjections())
-            .groupBy(statement.getGroupBy())
-            .orderBy(statement.getOrderBy())
-            .unwind(statement.getUnwind())
-            .limit(statement.getLimit())
-            .skip(statement.getSkip())
-            .returnDistinct(statement.isReturnDistinct())
-            .returnElements(statement.returnsElements())
-            .returnPaths(statement.returnsPaths())
-            .returnPatterns(statement.returnsPatterns())
-            .returnPathElements(statement.returnsPathElements())
-            .build();
-    return GremlinPlanFingerprint.fingerprint(inputs);
+    return GremlinPlanFingerprint.fingerprint(fingerprintInputsFromClauses(statement));
+  }
+
+  private static MatchPlanInputs fingerprintInputsFromClauses(SQLMatchStatement statement) {
+    return MatchPlanInputs.builder(new Pattern())
+        .matchExpressions(statement.getMatchExpressions())
+        .notMatchExpressions(statement.getNotMatchExpressions())
+        .returnItems(statement.getReturnItems())
+        .returnAliases(statement.getReturnAliases())
+        .returnNestedProjections(statement.getReturnNestedProjections())
+        .groupBy(statement.getGroupBy())
+        .orderBy(statement.getOrderBy())
+        .unwind(statement.getUnwind())
+        .limit(statement.getLimit())
+        .skip(statement.getSkip())
+        .returnDistinct(statement.isReturnDistinct())
+        .returnElements(statement.returnsElements())
+        .returnPaths(statement.returnsPaths())
+        .returnPatterns(statement.returnsPatterns())
+        .returnPathElements(statement.returnsPathElements())
+        .build();
   }
 
   private static SQLMatchStatement parse(String query) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationCacheTest.java
@@ -316,6 +316,84 @@ public class GremlinTranslationCacheTest extends GraphBaseTest {
     assertThat(intThirty).isNotEqualTo(longThirty);
   }
 
+  /**
+   * Row-level guard on limit literals: after {@code limit(1)} is cached, {@code limit(2)} must still
+   * return two rows. A fingerprint that collapsed both limits to {@code ?} would serve the first
+   * plan and silently truncate.
+   */
+  @Test
+  public void differentLimits_afterCacheWarm_returnCorrectCardinality() {
+    graph.addVertex(T.label, "Person", "name", "Alice", "age", 1);
+    graph.addVertex(T.label, "Person", "name", "Bob", "age", 2);
+    graph.addVertex(T.label, "Person", "name", "Carol", "age", 3);
+    graph.tx().commit();
+
+    assertThat(apply(() -> graph.traversal().V().limit(1))).hasSize(1);
+    assertThat(apply(() -> graph.traversal().V().limit(2)))
+        .as("limit(2) must not reuse a cached limit(1) plan")
+        .hasSize(2);
+  }
+
+  /**
+   * Row-level guard on projection keys: after {@code values("name")} is cached, {@code values("age")}
+   * must emit ages, not names.
+   */
+  @Test
+  public void differentValuesKeys_afterCacheWarm_doNotCrossContaminate() {
+    graph.addVertex(T.label, "Person", "name", "Alice", "age", 30);
+    graph.addVertex(T.label, "Person", "name", "Bob", "age", 40);
+    graph.tx().commit();
+
+    var names = apply(() -> graph.traversal().V().order().by("name").values("name"));
+    assertThat(names).isEqualTo(List.of("Alice", "Bob"));
+
+    var ages = apply(() -> graph.traversal().V().order().by("name").values("age"));
+    assertThat(ages)
+        .as("values(age) must not reuse a cached values(name) plan")
+        .isEqualTo(List.of(30, 40));
+  }
+
+  /**
+   * Integer vs Long {@code has(age)} partitions the shape key; after warming the Integer entry, the
+   * Long walk must still answer correctly for its own binding (and must not be served the Integer
+   * plan).
+   */
+  @Test
+  public void integerThenLongAge_afterCacheWarm_bothReturnCorrectRows() {
+    graph.addVertex(T.label, "Person", "name", "Alice", "age", 30);
+    graph.addVertex(T.label, "Person", "name", "Bob", "age", 40);
+    graph.tx().commit();
+
+    assertThat(sortedNames(apply(() -> graph.traversal().V().has("age", 30))))
+        .containsExactly("Alice");
+    assertThat(sortedNames(apply(() -> graph.traversal().V().has("age", 30L))))
+        .as("Long 30 must not reuse the Integer-30 cached plan incorrectly")
+        .containsExactly("Alice");
+    assertThat(sortedNames(apply(() -> graph.traversal().V().has("age", 40L))))
+        .containsExactly("Bob");
+  }
+
+  /**
+   * Predicate order can differ between Gremlin shapes that still compile to one PQD. Warm with
+   * {@code has(age).has(name)}, then run {@code has(name).has(age)} with different bindings — both
+   * must return their own row (walk + PQD hit + shape backfill must not cross-bind).
+   */
+  @Test
+  public void swappedHasOrder_afterCacheWarm_returnsOwnRow() {
+    graph.addVertex(T.label, "Person", "name", "Alice", "age", 30);
+    graph.addVertex(T.label, "Person", "name", "Bob", "age", 40);
+    graph.tx().commit();
+
+    assertThat(
+        sortedNames(
+            apply(() -> graph.traversal().V().has("age", 30).has("name", "Alice"))))
+        .containsExactly("Alice");
+    assertThat(
+        sortedNames(apply(() -> graph.traversal().V().has("name", "Bob").has("age", 40))))
+        .as("swapped has() order must not return the previously cached person's row")
+        .containsExactly("Bob");
+  }
+
   private String shapeKey(
       java.util.function.Supplier<
           org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<?, ?>> supplier) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationCacheTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.core.gremlin.GraphBaseTest;
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBTransaction;
 import com.jetbrains.youtrackdb.internal.core.gremlin.translator.step.YTDBMatchPlanStep;
@@ -293,6 +294,28 @@ public class GremlinTranslationCacheTest extends GraphBaseTest {
     assertThat(cache.getTranslationMisses()).isEqualTo(missesBefore);
   }
 
+  /** The per-session polymorphism flag is part of the shape key; toggling it must split entries. */
+  @Test
+  public void polymorphismFlag_discriminatesShapeKeys() {
+    final var polyOn = captureShapeKeyWithPolymorphic(true);
+    final var polyOff = captureShapeKeyWithPolymorphic(false);
+    assertThat(polyOn).isNotEqualTo(polyOff);
+  }
+
+  /**
+   * Translation-cache shape keys are value-independent only within one runtime class. Different
+   * String values share a key, but an Integer and a Long do not.
+   */
+  @Test
+  public void runtimeValueClass_partitionsShapeKey() {
+    var intThirty = shapeKey(() -> graph.traversal().V().has("age", P.eq(30)));
+    var intNinetyNine = shapeKey(() -> graph.traversal().V().has("age", P.eq(99)));
+    var longThirty = shapeKey(() -> graph.traversal().V().has("age", P.eq(30L)));
+
+    assertThat(intThirty).isEqualTo(intNinetyNine);
+    assertThat(intThirty).isNotEqualTo(longThirty);
+  }
+
   private String shapeKey(
       java.util.function.Supplier<
           org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal<?, ?>> supplier) {
@@ -324,4 +347,17 @@ public class GremlinTranslationCacheTest extends GraphBaseTest {
     tx.readWrite();
     return tx.getDatabaseSession();
   }
+
+  private String captureShapeKeyWithPolymorphic(boolean value) {
+    var config = graphSession().getConfiguration();
+    var previous =
+        config.getValueAsBoolean(GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT);
+    config.setValue(GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT, value);
+    try {
+      return shapeKey(() -> graph.traversal().V().hasLabel("Person"));
+    } finally {
+      config.setValue(GlobalConfiguration.QUERY_GREMLIN_POLYMORPHIC_BY_DEFAULT, previous);
+    }
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetricsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationMetricsTest.java
@@ -1,0 +1,99 @@
+package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricsRegistry;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.StubTicker;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link GremlinTranslationMetrics}: lifetime counters and shares, shape-frequency
+ * ranking, the soft cap on tracked shapes, and the three CoreMetrics Ratio sinks.
+ */
+public class GremlinTranslationMetricsTest {
+
+  /** Success, decline, and error each advance their own counter and the shared attempt total. */
+  @Test
+  public void recordOutcomes_advanceLifetimeCountersAndShares() {
+    var metrics = new GremlinTranslationMetrics((MetricsRegistry) null);
+
+    metrics.recordSuccess();
+    metrics.recordDecline("[GraphStep, LambdaMapStep]");
+    metrics.recordDecline("[GraphStep, RepeatStep]");
+    metrics.recordError("[GraphStep, HasStep]");
+
+    assertThat(metrics.getSuccesses()).isEqualTo(1);
+    assertThat(metrics.getDeclines()).isEqualTo(2);
+    assertThat(metrics.getErrors()).isEqualTo(1);
+    assertThat(metrics.getAttempts()).isEqualTo(4);
+    assertThat(metrics.successShare()).isCloseTo(0.25, within(1e-9));
+    assertThat(metrics.declineShare()).isCloseTo(0.5, within(1e-9));
+    assertThat(metrics.errorShare()).isCloseTo(0.25, within(1e-9));
+  }
+
+  /** topDeclinedShapes ranks by count descending and breaks ties by shape string. */
+  @Test
+  public void topDeclinedShapes_ranksByCount() {
+    var metrics = new GremlinTranslationMetrics((MetricsRegistry) null);
+    metrics.recordDecline("[GraphStep, RepeatStep]");
+    metrics.recordDecline("[GraphStep, LambdaMapStep]");
+    metrics.recordDecline("[GraphStep, RepeatStep]");
+    metrics.recordDecline("[GraphStep, RepeatStep]");
+
+    assertThat(metrics.topDeclinedShapes(2))
+        .containsExactly(
+            new GremlinTranslationMetrics.ShapeCount("[GraphStep, RepeatStep]", 3),
+            new GremlinTranslationMetrics.ShapeCount("[GraphStep, LambdaMapStep]", 1));
+  }
+
+  /**
+   * When the shape map is at capacity, new distinct shapes are not retained, but the decline
+   * counter still advances so totals stay honest.
+   */
+  @Test
+  public void trackShape_stopsAddingKeysAtCap() {
+    var metrics = new GremlinTranslationMetrics((MetricsRegistry) null);
+    for (int i = 0; i < GremlinTranslationMetrics.MAX_TRACKED_SHAPES; i++) {
+      metrics.recordDecline("[GraphStep, Extra" + i + "]");
+    }
+    metrics.recordDecline("[GraphStep, OverflowShape]");
+
+    assertThat(metrics.getDeclines())
+        .isEqualTo(GremlinTranslationMetrics.MAX_TRACKED_SHAPES + 1L);
+    assertThat(metrics.topDeclinedShapes(Integer.MAX_VALUE))
+        .hasSize(GremlinTranslationMetrics.MAX_TRACKED_SHAPES)
+        .noneMatch(s -> s.shape().contains("OverflowShape"));
+  }
+
+  /** Blank shapes count toward declines but do not enter the frequency map. */
+  @Test
+  public void blankShape_countsWithoutFrequencyEntry() {
+    var metrics = new GremlinTranslationMetrics((MetricsRegistry) null);
+    metrics.recordDecline(" ");
+    metrics.recordDecline(null);
+
+    assertThat(metrics.getDeclines()).isEqualTo(2);
+    assertThat(metrics.topDeclinedShapes(10)).isEmpty();
+  }
+
+  /** Recording through a live registry feeds the three global Ratio definitions. */
+  @Test
+  public void recordThroughRegistry_feedsGlobalRatios() {
+    var registry = new MetricsRegistry(new StubTicker(1));
+    var metrics = new GremlinTranslationMetrics(registry);
+
+    metrics.recordSuccess();
+    metrics.recordDecline("[GraphStep]");
+    metrics.recordError("[GraphStep, HasStep]");
+
+    Ratio successes = registry.globalMetric(CoreMetrics.GREMLIN_TRANSLATION_SUCCESS_RATIO);
+    Ratio declines = registry.globalMetric(CoreMetrics.GREMLIN_TRANSLATION_DECLINE_RATIO);
+    Ratio errors = registry.globalMetric(CoreMetrics.GREMLIN_TRANSLATION_ERROR_RATIO);
+    assertThat(successes).isInstanceOf(Ratio.Impl.class);
+    assertThat(declines).isInstanceOf(Ratio.Impl.class);
+    assertThat(errors).isInstanceOf(Ratio.Impl.class);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationTelemetryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationTelemetryTest.java
@@ -6,12 +6,14 @@ import static org.mockito.Mockito.mock;
 import com.jetbrains.youtrackdb.internal.core.gremlin.GraphBaseTest;
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBTransaction;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 import org.junit.Test;
 
 /**
  * End-to-end wiring of {@link GremlinTranslationMetrics} through {@link GremlinToMatchStrategy}:
- * successful translation, unsupported decline, and throw-safety-net error each advance the
- * per-database counters on the session's shared context.
+ * success, walker decline, edge start, repeat veto, throw-safety error, kill-switch skip, and
+ * idempotent re-apply.
  */
 public class GremlinTranslationTelemetryTest extends GraphBaseTest {
 
@@ -97,5 +99,54 @@ public class GremlinTranslationTelemetryTest extends GraphBaseTest {
               com.jetbrains.youtrackdb.api.config.GlobalConfiguration.QUERY_GREMLIN_TO_MATCH_TRANSLATOR_ENABLED,
               true);
     }
+  }
+
+  /**
+   * Edge starts ({@code g.E()}) are an unsupported product surface (vertex-only milestone) and
+   * count as declines, not silent gate exits.
+   */
+  @Test
+  public void apply_edgeStart_recordsDecline() {
+    var beforeDeclines = metrics().getDeclines();
+    var beforeSuccesses = metrics().getSuccesses();
+    var admin = graph.traversal().E().asAdmin();
+
+    GremlinToMatchStrategy.instance().apply(admin);
+
+    assertThat(metrics().getDeclines()).isEqualTo(beforeDeclines + 1);
+    assertThat(metrics().getSuccesses()).isEqualTo(beforeSuccesses);
+    assertThat(metrics().topDeclinedShapes(5))
+        .anyMatch(s -> s.shape().contains("GraphStep") && s.count() >= 1);
+  }
+
+  /**
+   * Re-applying the strategy to an already-translated traversal is idempotency, not a new attempt —
+   * counters must not move.
+   */
+  @Test
+  public void apply_alreadyTranslated_reapply_doesNotCountAsAttempt() {
+    var admin = graph.traversal().V().asAdmin();
+    GremlinToMatchStrategy.instance().apply(admin);
+    var afterFirst = metrics().getAttempts();
+
+    GremlinToMatchStrategy.instance().apply(admin);
+
+    assertThat(metrics().getAttempts()).isEqualTo(afterFirst);
+  }
+
+  /**
+   * A {@code repeat(...)}-bearing traversal marked by {@link RepeatDeclineStrategy} counts as a
+   * decline (out of scope), not a silent gate exit.
+   */
+  @Test
+  public void apply_repeatVeto_recordsDecline() {
+    var beforeDeclines = metrics().getDeclines();
+    var admin = graph.traversal().V().repeat(__.out()).times(2).asAdmin();
+    TraversalHelper.applyTraversalRecursively(RepeatDeclineStrategy.instance()::apply, admin);
+    assertThat(RepeatDeclineStrategy.isVetoed(admin)).isTrue();
+
+    GremlinToMatchStrategy.instance().apply(admin);
+
+    assertThat(metrics().getDeclines()).isEqualTo(beforeDeclines + 1);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationTelemetryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinTranslationTelemetryTest.java
@@ -1,0 +1,101 @@
+package com.jetbrains.youtrackdb.internal.core.gremlin.translator.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.jetbrains.youtrackdb.internal.core.gremlin.GraphBaseTest;
+import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBTransaction;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
+import org.junit.Test;
+
+/**
+ * End-to-end wiring of {@link GremlinTranslationMetrics} through {@link GremlinToMatchStrategy}:
+ * successful translation, unsupported decline, and throw-safety-net error each advance the
+ * per-database counters on the session's shared context.
+ */
+public class GremlinTranslationTelemetryTest extends GraphBaseTest {
+
+  private GremlinTranslationMetrics metrics() {
+    return GremlinTranslationMetrics.of(graphSession());
+  }
+
+  private com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded graphSession() {
+    var tx = (YTDBTransaction) graph.tx();
+    tx.readWrite();
+    return tx.getDatabaseSession();
+  }
+
+  /** A bare {@code g.V()} that translates increments the success counter once. */
+  @Test
+  public void apply_translatedShape_recordsSuccess() {
+    var before = metrics().getSuccesses();
+    var admin = graph.traversal().V().asAdmin();
+
+    GremlinToMatchStrategy.instance().apply(admin);
+
+    assertThat(metrics().getSuccesses()).isEqualTo(before + 1);
+  }
+
+  /**
+   * An unrecognized trailing step declines whole and records a decline with the step-class shape,
+   * without counting as a success or error.
+   */
+  @Test
+  public void apply_unsupportedShape_recordsDecline() {
+    var beforeDeclines = metrics().getDeclines();
+    var beforeSuccesses = metrics().getSuccesses();
+    // Lambda map is permanently out of scope — forces a walker decline.
+    var admin = graph.traversal().V().map(t -> t.get()).asAdmin();
+
+    GremlinToMatchStrategy.instance().apply(admin);
+
+    assertThat(metrics().getDeclines()).isEqualTo(beforeDeclines + 1);
+    assertThat(metrics().getSuccesses()).isEqualTo(beforeSuccesses);
+    assertThat(metrics().topDeclinedShapes(5))
+        .anyMatch(s -> s.shape().contains("GraphStep") && s.count() >= 1);
+  }
+
+  /**
+   * A translator that throws is caught by the throw-safety net and recorded as an error, not a
+   * plain decline.
+   */
+  @Test
+  public void apply_throwingTranslator_recordsError() {
+    var beforeErrors = metrics().getErrors();
+    var beforeDeclines = metrics().getDeclines();
+    var admin = graph.traversal().V().asAdmin();
+    var strategy =
+        new GremlinToMatchStrategy(
+            t -> {
+              throw new IllegalStateException("simulated translator bug");
+            },
+            (s, tr, planningStart) -> mock(InternalExecutionPlan.class));
+
+    strategy.apply(admin);
+
+    assertThat(metrics().getErrors()).isEqualTo(beforeErrors + 1);
+    assertThat(metrics().getDeclines()).isEqualTo(beforeDeclines);
+  }
+
+  /** Kill-switch off declines before a translation attempt, so counters stay unchanged. */
+  @Test
+  public void apply_killSwitchOff_doesNotCountAsAttempt() {
+    var beforeAttempts = metrics().getAttempts();
+    graphSession()
+        .getConfiguration()
+        .setValue(
+            com.jetbrains.youtrackdb.api.config.GlobalConfiguration.QUERY_GREMLIN_TO_MATCH_TRANSLATOR_ENABLED,
+            false);
+    try {
+      var admin = graph.traversal().V().asAdmin();
+      GremlinToMatchStrategy.instance().apply(admin);
+      assertThat(metrics().getAttempts()).isEqualTo(beforeAttempts);
+    } finally {
+      graphSession()
+          .getConfiguration()
+          .setValue(
+              com.jetbrains.youtrackdb.api.config.GlobalConfiguration.QUERY_GREMLIN_TO_MATCH_TRANSLATOR_ENABLED,
+              true);
+    }
+  }
+}


### PR DESCRIPTION
#### PR Title:

YTDB-1275: Add Gremlin translation telemetry

#### Motivation:
Operators cannot see how often the Gremlin-to-MATCH translator succeeds, declines, or throws. After the translator landed, production needs coverage ratios and a bounded view of declined step shapes, without counting strategy-gate skips as attempts.

The same branch hardens the two-tier plan caches. Nested projections and other planner-visible MatchPlanInputs fields were missing from the PQD fingerprint, so distinct shapes could share a cached plan. Extra warm-cache tests and a 20h→30h LDBC JMH compare timeout follow from that: empty-filter compares now include LdbcGremlinTranslatorBenchmark (~5h base+head) and were timing out near the finish.

#### Planned changes:

#### Current state
-Translator outcomes are invisible in metrics.
-Plan-cache fingerprint omitted several planner-visible inputs (optional nodes, match/NOT expressions, unwind, return-mode flags, nested projections).
-LDBC JMH compare job timeout (20h) is too tight for SQL + Gremlin empty-filter runs.

#### What changes (contract/behavior)
-Three engine-global rolling ratios: success / decline / error share of translation attempts.
-Per-database lifetime counters plus capped top declined shapes (256).
-Only shapes that pass strategy gates count as attempts; early exits do not.
-PQD fingerprint covers the full planner-visible MatchPlanInputs surface used for cache keys.
-Nested projection differences partition the fingerprint (and translation-cache tests guard warm-cache cross-contamination).
-LDBC JMH compare job timeout is 30h; queries input docs note that empty = full jmh-ldbc including Gremlin A/B.
-Top declined shapes are queryable via GremlinTranslationMetrics.topDeclinedShapes on the database shared context; they are not exported as profiler/CoreMetrics series in this PR