### PR TITLE
YTDB-1278: Include Gremlin translator results in JMH compare PR comments [no-it-tests]

### DIFF
--- a/.github/workflows/jmh-alerter-tests.yml
+++ b/.github/workflows/jmh-alerter-tests.yml
@@ -9,11 +9,13 @@ on:
     branches: [develop, main]
     paths:
       - 'jmh-ldbc/jmh-regression-alert.py'
+      - 'jmh-ldbc/jmh-compare.py'
       - 'jmh-ldbc/tests/**'
       - '.github/workflows/jmh-alerter-tests.yml'
   pull_request:
     paths:
       - 'jmh-ldbc/jmh-regression-alert.py'
+      - 'jmh-ldbc/jmh-compare.py'
       - 'jmh-ldbc/tests/**'
       - '.github/workflows/jmh-alerter-tests.yml'
   # Allow manual re-runs (e.g. after a transient GitHub Actions outage)

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -10,13 +10,26 @@ on:
       queries:
         description: >
           Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
-          Leave empty to run the full jmh-ldbc suite, including
-          LdbcGremlinTranslatorBenchmark (translator on/off A/B) as well as
-          LdbcSingleThread / LdbcMultiThread SQL LDBC. Full empty-filter
-          compares need ~21h on CCX33 after Gremlin landed; job timeout is 30h.
+          Leave empty to run the full jmh-ldbc suite: SQL LDBC
+          (LdbcSingleThread / LdbcMultiThread) plus
+          LdbcGremlinTranslatorBenchmark. Gremlin arms are controlled by
+          gremlin_arms (default on-only). Full empty-filter with both arms
+          was ~21h on CCX33; on-only is shorter. Job timeout is 30h.
         required: false
         type: string
         default: ''
+      gremlin_arms:
+        description: >
+          Which LdbcGremlinTranslatorBenchmark arms to run and report.
+          'on' (default) = production path only
+          (-p translatorEnabled=true). 'both' = full translator on/off A/B
+          (roughly doubles Gremlin wall time).
+        required: false
+        type: choice
+        options:
+          - on
+          - both
+        default: on
       base_branch:
         description: >
           Base branch to compare against (fork-point is computed with
@@ -45,9 +58,10 @@ jobs:
       - type-ccx33
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
-    # Full empty-filter suite = SQL LDBC (single+multi) + LdbcGremlinTranslator
-    # A/B. Observed wall after Gremlin landed: ~21h on CCX33 (20h timeout killed
-    # head ~50 min early). 30h leaves margin for variance and new shapes.
+    # Full empty-filter suite = SQL LDBC (single+multi) + Gremlin translator.
+    # Default gremlin_arms=on runs only the production arm; both ≈ doubles
+    # Gremlin wall (~21h observed for full A/B on CCX33). 30h timeout leaves
+    # margin for variance and new shapes.
     timeout-minutes: 1800
 
     steps:
@@ -199,9 +213,11 @@ jobs:
 
       - name: Build JMH filter from query list
         id: filter
+        env:
+          QUERIES: ${{ inputs.queries }}
+          GREMLIN_ARMS: ${{ inputs.gremlin_arms }}
         run: |
           set -euo pipefail
-          QUERIES="${{ inputs.queries }}"
           if [ -n "$QUERIES" ]; then
             # Convert "IS1,IC2,IC13" → ".*is1_.*|.*ic2_.*|.*ic13_.*"
             JMH_FILTER=$(echo "$QUERIES" \
@@ -214,6 +230,18 @@ jobs:
           else
             echo "jmh_filter=" >> "$GITHUB_OUTPUT"
             echo "Filter: (all benchmarks)"
+          fi
+
+          # Default production arm only. JMH -p applies to benches that declare
+          # the @Param; SQL LDBC classes without translatorEnabled are unchanged.
+          ARMS="${GREMLIN_ARMS:-on}"
+          echo "gremlin_arms=$ARMS" >> "$GITHUB_OUTPUT"
+          if [ "$ARMS" = "on" ]; then
+            echo "jmh_param_arg=-p translatorEnabled=true" >> "$GITHUB_OUTPUT"
+            echo "Gremlin arms: on (-p translatorEnabled=true)"
+          else
+            echo "jmh_param_arg=" >> "$GITHUB_OUTPUT"
+            echo "Gremlin arms: both (on/off A/B)"
           fi
 
       - name: Save helper scripts
@@ -338,14 +366,19 @@ jobs:
       - name: 'Base: warm OS page cache'
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+          JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
         run: |
           FILTER_ARG=""
+          PARAM_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
+          if [ -n "$JMH_PARAM" ]; then
+            PARAM_ARG="$JMH_PARAM "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
+            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
             2>&1 | tee /tmp/jmh-warm-base-${{ github.run_id }}.txt
 
           # JMH exits 0 even when all benchmarks fail with -f 0.
@@ -365,14 +398,19 @@ jobs:
       - name: 'Base: run benchmarks'
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+          JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
         run: |
           FILTER_ARG=""
+          PARAM_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
+          if [ -n "$JMH_PARAM" ]; then
+            PARAM_ARG="$JMH_PARAM "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}-rf json -rff /tmp/jmh-base-${{ github.run_id }}.json" \
+            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-base-${{ github.run_id }}.json" \
             2>&1 | tee /tmp/jmh-base-log-${{ github.run_id }}.txt
 
           # Validate that JMH produced results (it exits 0 even on total failure)
@@ -452,14 +490,19 @@ jobs:
       - name: 'Head: warm OS page cache'
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+          JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
         run: |
           FILTER_ARG=""
+          PARAM_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
+          if [ -n "$JMH_PARAM" ]; then
+            PARAM_ARG="$JMH_PARAM "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
+            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
             2>&1 | tee /tmp/jmh-warm-head-${{ github.run_id }}.txt
 
           # JMH exits 0 even when all benchmarks fail with -f 0.
@@ -477,14 +520,19 @@ jobs:
       - name: 'Head: run benchmarks'
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+          JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
         run: |
           FILTER_ARG=""
+          PARAM_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
+          if [ -n "$JMH_PARAM" ]; then
+            PARAM_ARG="$JMH_PARAM "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}-rf json -rff /tmp/jmh-head-${{ github.run_id }}.json" \
+            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-head-${{ github.run_id }}.json" \
             2>&1 | tee /tmp/jmh-head-log-${{ github.run_id }}.txt
 
           # Validate that JMH produced results
@@ -512,6 +560,7 @@ jobs:
             --repo-url "${{ github.server_url }}/${{ github.repository }}" \
             --base-load-time "${{ steps.base_load.outputs.load_time }}" \
             --head-load-time "${{ steps.head_load.outputs.load_time }}" \
+            --gremlin-arms "${{ steps.filter.outputs.gremlin_arms }}" \
             --output "/tmp/jmh-comparison-${{ github.run_id }}.md"
 
       - name: Upload artifacts

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -91,6 +91,35 @@ def parse_jmh_results(data):
     return results
 
 
+def filter_gremlin_arms(results, arms="on"):
+    """Keep only the requested Gremlin translator arms.
+
+    Default ``on`` matches production
+    (``QUERY_GREMLIN_TO_MATCH_TRANSLATOR_ENABLED`` defaults to true). Off-arm
+    rows are dropped, and the `` [on]`` suffix is stripped so each shape is
+    one bare row — same shape as SQL LDBC. Pass ``both`` to keep the full A/B.
+    """
+    if arms == "both":
+        return results
+
+    filtered = {}
+    for (label, suite), value in results.items():
+        if suite != "Gremlin":
+            filtered[(label, suite)] = value
+            continue
+        if label.endswith(" [off]"):
+            continue
+        if label.endswith(" [on]"):
+            bare = label[: -len(" [on]")]
+            entry = dict(value)
+            entry["query"] = bare
+            filtered[(bare, suite)] = entry
+        else:
+            # Unexpected param label — keep rather than drop silently.
+            filtered[(label, suite)] = value
+    return filtered
+
+
 def compute_scalability(results):
     """Compute MT/ST throughput ratio per query with error propagation.
 
@@ -309,6 +338,15 @@ def main():
                         help="Base database load time in seconds")
     parser.add_argument("--head-load-time", type=float, default=None,
                         help="Head database load time in seconds")
+    parser.add_argument(
+        "--gremlin-arms",
+        choices=("on", "both"),
+        default="on",
+        help=(
+            "Which Gremlin translator arms to report: 'on' (default, "
+            "production path only) or 'both' (translator on/off A/B)"
+        ),
+    )
     parser.add_argument("--output", default="-", help="Output file (- for stdout)")
     args = parser.parse_args()
 
@@ -317,8 +355,8 @@ def main():
     with open(args.head) as f:
         head_data = json.load(f)
 
-    base = parse_jmh_results(base_data)
-    head = parse_jmh_results(head_data)
+    base = filter_gremlin_arms(parse_jmh_results(base_data), args.gremlin_arms)
+    head = filter_gremlin_arms(parse_jmh_results(head_data), args.gremlin_arms)
 
     base_scal = compute_scalability(base)
     head_scal = compute_scalability(head)
@@ -418,10 +456,19 @@ def main():
         lines.append(f"### {label} Results")
         lines.append("")
         if suite == "Gremlin":
-            lines.append(
-                "Translator on/off A/B from `LdbcGremlinTranslatorBenchmark`. "
-                "Each row is one shape \u00d7 arm (`[on]` / `[off]`)."
-            )
+            if args.gremlin_arms == "both":
+                lines.append(
+                    "Translator on/off A/B from "
+                    "`LdbcGremlinTranslatorBenchmark`. "
+                    "Each row is one shape \u00d7 arm (`[on]` / `[off]`)."
+                )
+            else:
+                lines.append(
+                    "Translator-on arm from "
+                    "`LdbcGremlinTranslatorBenchmark` "
+                    "(production default). Pass `--gremlin-arms both` "
+                    "for the off arm too."
+                )
             lines.append("")
         lines.append(
             "| Benchmark | Base ops/s | Base err | Head ops/s | Head err | \u0394% |"

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -29,8 +29,44 @@ def _safe_score_error(value):
         return 0
 
 
+def _suite_for_class(class_name):
+    """Map a JMH class simple name to a comparison suite label."""
+    if "SingleThread" in class_name:
+        return "SingleThread"
+    if "MultiThread" in class_name:
+        return "MultiThread"
+    # LdbcGremlinTranslatorBenchmark (and any future *Gremlin* class) share one
+    # suite so the PR comment can render them as a dedicated section.
+    if "Gremlin" in class_name:
+        return "Gremlin"
+    return class_name
+
+
+def _param_label(params):
+    """Build a short suffix for JMH @Param values, or empty if none.
+
+    ``translatorEnabled`` is the Gremlin A/B arm — render as ``[on]`` / ``[off]``
+    so both arms survive as distinct rows. Without this, parse would key only by
+    method name and the second arm would overwrite the first.
+    """
+    if not params:
+        return ""
+    parts = []
+    for key in sorted(params):
+        value = str(params[key])
+        if key == "translatorEnabled":
+            parts.append("on" if value == "true" else "off")
+        else:
+            parts.append(f"{key}={value}")
+    return f" [{', '.join(parts)}]"
+
+
 def parse_jmh_results(data):
-    """Parse JMH JSON into dict keyed by (query, suite)."""
+    """Parse JMH JSON into dict keyed by (query, suite).
+
+    ``query`` is the benchmark method name, plus a param suffix when JMH
+    ``params`` are present (e.g. ``gremlinKnowsFirstNames [on]``).
+    """
     results = {}
     for entry in data:
         benchmark_full = entry["benchmark"]
@@ -38,20 +74,16 @@ def parse_jmh_results(data):
             continue
         class_name_full, method_name = benchmark_full.rsplit(".", 1)
         class_name = class_name_full.rsplit(".", 1)[-1]
+        suite = _suite_for_class(class_name)
 
-        if "SingleThread" in class_name:
-            suite = "SingleThread"
-        elif "MultiThread" in class_name:
-            suite = "MultiThread"
-        else:
-            suite = class_name
+        label = method_name + _param_label(entry.get("params") or {})
 
         primary = entry.get("primaryMetric", {})
         score = primary.get("score", 0)
         score_error = _safe_score_error(primary.get("scoreError"))
 
-        results[(method_name, suite)] = {
-            "query": method_name,
+        results[(label, suite)] = {
+            "query": label,
             "suite": suite,
             "score": score,
             "score_error": score_error,
@@ -378,12 +410,19 @@ def main():
         lines.append("")
 
     for suite, label in [("SingleThread", "Single-Thread"),
-                         ("MultiThread", "Multi-Thread")]:
+                         ("MultiThread", "Multi-Thread"),
+                         ("Gremlin", "Gremlin Translator")]:
         rows = build_suite_table(base, head, suite)
         if not rows:
             continue
         lines.append(f"### {label} Results")
         lines.append("")
+        if suite == "Gremlin":
+            lines.append(
+                "Translator on/off A/B from `LdbcGremlinTranslatorBenchmark`. "
+                "Each row is one shape \u00d7 arm (`[on]` / `[off]`)."
+            )
+            lines.append("")
         lines.append(
             "| Benchmark | Base ops/s | Base err | Head ops/s | Head err | \u0394% |"
         )

--- a/jmh-ldbc/tests/test_jmh_compare.py
+++ b/jmh-ldbc/tests/test_jmh_compare.py
@@ -1,6 +1,8 @@
 """Unit tests for jmh-compare.py — suite detection, Gremlin @Param arms, tables."""
 
 import importlib.util
+import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -34,6 +36,67 @@ ST_CLS = "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcSingleThreadISBenchmark"
 MT_CLS = "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcMultiThreadISBenchmark"
 
 
+def _gremlin_on_off_fixture():
+    """Minimal base/head JSON with Gremlin on+off and one SQL ST row."""
+    base = [
+        _entry(
+            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            100.0,
+            score_error=1.0,
+            params={"translatorEnabled": "true"},
+        ),
+        _entry(
+            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            200.0,
+            score_error=2.0,
+            params={"translatorEnabled": "false"},
+        ),
+        _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
+    ]
+    head = [
+        _entry(
+            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            110.0,
+            score_error=1.0,
+            params={"translatorEnabled": "true"},
+        ),
+        _entry(
+            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            190.0,
+            score_error=2.0,
+            params={"translatorEnabled": "false"},
+        ),
+        _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
+    ]
+    return base, head
+
+
+def _run_compare(base, head, extra_argv=None):
+    with tempfile.TemporaryDirectory() as tmp:
+        base_path = Path(tmp) / "base.json"
+        head_path = Path(tmp) / "head.json"
+        out_path = Path(tmp) / "out.md"
+        base_path.write_text(json.dumps(base))
+        head_path.write_text(json.dumps(head))
+        argv = [
+            "jmh-compare.py",
+            "--base", str(base_path),
+            "--head", str(head_path),
+            "--base-sha", "aaaaaaaaaa",
+            "--head-sha", "bbbbbbbbbb",
+            "--output", str(out_path),
+        ]
+        if extra_argv:
+            argv.extend(extra_argv)
+        argv_backup = sys.argv
+        try:
+            sys.argv = argv
+            cmp.main()
+        finally:
+            sys.argv = argv_backup
+        return out_path.read_text()
+
+
 class TestSuiteDetection(unittest.TestCase):
     def test_single_and_multi_thread(self):
         """ST/MT class names still map to the SQL LDBC suites."""
@@ -62,7 +125,7 @@ class TestSuiteDetection(unittest.TestCase):
 
 class TestGremlinParamArms(unittest.TestCase):
     def test_on_and_off_arms_are_distinct_rows(self):
-        """Both translator arms must survive — previously the second overwrote the first."""
+        """Both translator arms must survive parse — previously the second overwrote."""
         out = cmp.parse_jmh_results([
             _entry(
                 f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
@@ -78,6 +141,44 @@ class TestGremlinParamArms(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertEqual(out[("gremlinKnowsFirstNames [on]", "Gremlin")]["score"], 100.0)
         self.assertEqual(out[("gremlinKnowsFirstNames [off]", "Gremlin")]["score"], 200.0)
+
+    def test_filter_default_keeps_on_only_and_strips_suffix(self):
+        """Default arms=on drops off and strips [on] so each shape is one bare row."""
+        parsed = cmp.parse_jmh_results([
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                100.0,
+                params={"translatorEnabled": "true"},
+            ),
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                200.0,
+                params={"translatorEnabled": "false"},
+            ),
+            _entry(f"{ST_CLS}.is1_personProfile", 10.0),
+        ])
+        filtered = cmp.filter_gremlin_arms(parsed, "on")
+        self.assertIn(("gremlinKnowsFirstNames", "Gremlin"), filtered)
+        self.assertNotIn(("gremlinKnowsFirstNames [on]", "Gremlin"), filtered)
+        self.assertNotIn(("gremlinKnowsFirstNames [off]", "Gremlin"), filtered)
+        self.assertIn(("is1_personProfile", "SingleThread"), filtered)
+
+    def test_filter_both_keeps_arm_labels(self):
+        """arms=both leaves the [on]/[off] labels untouched."""
+        parsed = cmp.parse_jmh_results([
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                100.0,
+                params={"translatorEnabled": "true"},
+            ),
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                200.0,
+                params={"translatorEnabled": "false"},
+            ),
+        ])
+        filtered = cmp.filter_gremlin_arms(parsed, "both")
+        self.assertEqual(filtered, parsed)
 
     def test_unknown_params_keep_key_equals_value(self):
         """Non-translator params stay readable as key=value in the label."""
@@ -99,69 +200,25 @@ class TestGremlinParamArms(unittest.TestCase):
 
 
 class TestGremlinTableInMarkdown(unittest.TestCase):
-    def test_comparison_includes_gremlin_section(self):
-        """Full compare output gets a Gremlin Translator Results section when present."""
-        base = [
-            _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
-                100.0,
-                score_error=1.0,
-                params={"translatorEnabled": "true"},
-            ),
-            _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
-                200.0,
-                score_error=2.0,
-                params={"translatorEnabled": "false"},
-            ),
-            _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
-        ]
-        head = [
-            _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
-                110.0,
-                score_error=1.0,
-                params={"translatorEnabled": "true"},
-            ),
-            _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
-                190.0,
-                score_error=2.0,
-                params={"translatorEnabled": "false"},
-            ),
-            _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
-        ]
-        with tempfile.TemporaryDirectory() as tmp:
-            base_path = Path(tmp) / "base.json"
-            head_path = Path(tmp) / "head.json"
-            out_path = Path(tmp) / "out.md"
-            import json
-            base_path.write_text(json.dumps(base))
-            head_path.write_text(json.dumps(head))
+    def test_default_report_shows_on_arm_only(self):
+        """Default compare (no --gremlin-arms) shows one bare on-arm row per shape."""
+        base, head = _gremlin_on_off_fixture()
+        md = _run_compare(base, head)
+        self.assertIn("### Gremlin Translator Results", md)
+        self.assertIn("gremlinKnowsFirstNames", md)
+        self.assertNotIn("[off]", md)
+        self.assertNotIn("[on]", md)
+        self.assertIn("production default", md)
+        self.assertIn("### Single-Thread Results", md)
+        self.assertNotIn("### Multi-Thread Results", md)
 
-            # Drive main() via argv
-            import sys
-            argv_backup = sys.argv
-            try:
-                sys.argv = [
-                    "jmh-compare.py",
-                    "--base", str(base_path),
-                    "--head", str(head_path),
-                    "--base-sha", "aaaaaaaaaa",
-                    "--head-sha", "bbbbbbbbbb",
-                    "--output", str(out_path),
-                ]
-                cmp.main()
-            finally:
-                sys.argv = argv_backup
-
-            md = out_path.read_text()
-            self.assertIn("### Gremlin Translator Results", md)
-            self.assertIn("gremlinKnowsFirstNames [on]", md)
-            self.assertIn("gremlinKnowsFirstNames [off]", md)
-            self.assertIn("### Single-Thread Results", md)
-            # MT absent → no Multi-Thread section
-            self.assertNotIn("### Multi-Thread Results", md)
+    def test_both_arms_flag_keeps_on_and_off_rows(self):
+        """--gremlin-arms both keeps the full A/B labels in the table."""
+        base, head = _gremlin_on_off_fixture()
+        md = _run_compare(base, head, extra_argv=["--gremlin-arms", "both"])
+        self.assertIn("gremlinKnowsFirstNames [on]", md)
+        self.assertIn("gremlinKnowsFirstNames [off]", md)
+        self.assertIn("`[on]` / `[off]`", md)
 
 
 if __name__ == "__main__":

--- a/jmh-ldbc/tests/test_jmh_compare.py
+++ b/jmh-ldbc/tests/test_jmh_compare.py
@@ -1,0 +1,168 @@
+"""Unit tests for jmh-compare.py — suite detection, Gremlin @Param arms, tables."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_compare():
+    path = Path(__file__).resolve().parents[1] / "jmh-compare.py"
+    spec = importlib.util.spec_from_file_location("jmh_compare", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cmp = _load_compare()
+
+
+def _entry(benchmark, score, score_error=0.1, params=None):
+    entry = {
+        "benchmark": benchmark,
+        "primaryMetric": {"score": score, "scoreError": score_error},
+    }
+    if params is not None:
+        entry["params"] = params
+    return entry
+
+
+GREMLIN_CLS = (
+    "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcGremlinTranslatorBenchmark"
+)
+ST_CLS = "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcSingleThreadISBenchmark"
+MT_CLS = "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcMultiThreadISBenchmark"
+
+
+class TestSuiteDetection(unittest.TestCase):
+    def test_single_and_multi_thread(self):
+        """ST/MT class names still map to the SQL LDBC suites."""
+        out = cmp.parse_jmh_results([
+            _entry(f"{ST_CLS}.is1_personProfile", 10.0),
+            _entry(f"{MT_CLS}.is1_personProfile", 40.0),
+        ])
+        self.assertIn(("is1_personProfile", "SingleThread"), out)
+        self.assertIn(("is1_personProfile", "MultiThread"), out)
+
+    def test_gremlin_class_maps_to_gremlin_suite(self):
+        """Gremlin translator benches land in the Gremlin suite, not the raw class."""
+        out = cmp.parse_jmh_results([
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                100.0,
+                params={"translatorEnabled": "true"},
+            ),
+        ])
+        self.assertIn(("gremlinKnowsFirstNames [on]", "Gremlin"), out)
+        self.assertNotIn(
+            ("gremlinKnowsFirstNames [on]", "LdbcGremlinTranslatorBenchmark"),
+            out,
+        )
+
+
+class TestGremlinParamArms(unittest.TestCase):
+    def test_on_and_off_arms_are_distinct_rows(self):
+        """Both translator arms must survive — previously the second overwrote the first."""
+        out = cmp.parse_jmh_results([
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                100.0,
+                params={"translatorEnabled": "true"},
+            ),
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                200.0,
+                params={"translatorEnabled": "false"},
+            ),
+        ])
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[("gremlinKnowsFirstNames [on]", "Gremlin")]["score"], 100.0)
+        self.assertEqual(out[("gremlinKnowsFirstNames [off]", "Gremlin")]["score"], 200.0)
+
+    def test_unknown_params_keep_key_equals_value(self):
+        """Non-translator params stay readable as key=value in the label."""
+        out = cmp.parse_jmh_results([
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                1.0,
+                params={"threads": "8", "mode": "thrpt"},
+            ),
+        ])
+        self.assertIn(("gremlinKnowsFirstNames [mode=thrpt, threads=8]", "Gremlin"), out)
+
+    def test_no_params_keeps_bare_method_name(self):
+        """SQL LDBC entries without JMH params keep the plain method label."""
+        out = cmp.parse_jmh_results([
+            _entry(f"{ST_CLS}.is1_personProfile", 10.0, params={}),
+        ])
+        self.assertIn(("is1_personProfile", "SingleThread"), out)
+
+
+class TestGremlinTableInMarkdown(unittest.TestCase):
+    def test_comparison_includes_gremlin_section(self):
+        """Full compare output gets a Gremlin Translator Results section when present."""
+        base = [
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                100.0,
+                score_error=1.0,
+                params={"translatorEnabled": "true"},
+            ),
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                200.0,
+                score_error=2.0,
+                params={"translatorEnabled": "false"},
+            ),
+            _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
+        ]
+        head = [
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                110.0,
+                score_error=1.0,
+                params={"translatorEnabled": "true"},
+            ),
+            _entry(
+                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                190.0,
+                score_error=2.0,
+                params={"translatorEnabled": "false"},
+            ),
+            _entry(f"{ST_CLS}.is1_personProfile", 10.0, score_error=0.1),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            base_path = Path(tmp) / "base.json"
+            head_path = Path(tmp) / "head.json"
+            out_path = Path(tmp) / "out.md"
+            import json
+            base_path.write_text(json.dumps(base))
+            head_path.write_text(json.dumps(head))
+
+            # Drive main() via argv
+            import sys
+            argv_backup = sys.argv
+            try:
+                sys.argv = [
+                    "jmh-compare.py",
+                    "--base", str(base_path),
+                    "--head", str(head_path),
+                    "--base-sha", "aaaaaaaaaa",
+                    "--head-sha", "bbbbbbbbbb",
+                    "--output", str(out_path),
+                ]
+                cmp.main()
+            finally:
+                sys.argv = argv_backup
+
+            md = out_path.read_text()
+            self.assertIn("### Gremlin Translator Results", md)
+            self.assertIn("gremlinKnowsFirstNames [on]", md)
+            self.assertIn("gremlinKnowsFirstNames [off]", md)
+            self.assertIn("### Single-Thread Results", md)
+            # MT absent → no Multi-Thread section
+            self.assertNotIn("### Multi-Thread Results", md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### PR Title:

[no-it-tests] YTDB-1278: Include Gremlin translator results in JMH compare PR comments

#### Motivation:

Full-suite LDBC JMH compare already measured `LdbcGremlinTranslatorBenchmark` (translator on/off), but `jmh-compare.py` only rendered SQL SingleThread / MultiThread tables. Gremlin scores stayed in the JSON artifacts and never reached the PR comment; ignoring JMH `params` also collapsed the on and off arms into one row.

Production defaults to translator **on**. Full on/off A/B roughly doubles Gremlin wall time (~21h observed for the full suite with both arms). PR compares should therefore measure and report **on** by default; **both** remains an explicit, longer opt-in.

---

#### Planned changes:

##### Current state
- Empty-filter compare dispatch ran SQL ST/MT plus Gremlin on **and** off.
- The PR comment showed only SQL (plus load time and MT/ST scalability).
- No dispatch control for which Gremlin arms to run.

##### What changes (contract/behavior)
- The PR comment gains a **Gremlin Translator** section using the same gates as SQL (±5%, non-overlapping error bars, relative error <10%, icons).
- New dispatch input **`gremlin_arms`**: `on` (default) | `both`.
- **`on`**: JMH with `-p translatorEnabled=true`; one row per shape in the comment (no off arm).
- **`both`**: full on/off A/B; `[on]` / `[off]` rows in the comment; longer run.
- Comparison semantics unchanged: branch tip vs fork-point with `base_branch` (default `develop`).

##### How (design level)
- The JMH result parser recognizes a Gremlin suite and keeps `translatorEnabled` in the row label.
- Report filtering (and the matching workflow choice) drops the off arm when the default is `on`.
- The workflow passes `-p` into base/head warm and measure steps and `--gremlin-arms` into the compare script.

##### Key decisions
- **Default on, not both** — production path; off is harness A/B, not the default PR signal.
- **Choice input on the existing job**, not a separate workflow — one run, one flag.
- **No ST/MT split for Gremlin** — the axis is on/off at `@Threads(1)`; MT is a separate cost decision, not SQL table parity.

##### Suggestions:
None.

##### Verification approach
- Unit tests for `jmh-compare` (parse, on/both filter, Gremlin section in markdown).
- Alerter/compare unit-test workflow also triggers on `jmh-compare.py`.
- Smoke: dispatch from this branch, empty `queries`, `gremlin_arms=on` → PR comment with SQL + Gremlin on.

---

#### Tracks:

N/A (single-track)