### PR TITLE
YTDB-1279: fix gremlin benhcmarks descriptions

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -12,8 +12,10 @@ on:
           Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
           Leave empty to run the full jmh-ldbc suite: SQL LDBC
           (LdbcSingleThread / LdbcMultiThread) plus
-          LdbcGremlinTranslatorBenchmark. Gremlin arms are controlled by
-          gremlin_arms (default on-only). Full empty-filter with both arms
+          LdbcGremlinTranslatorBenchmark. Gremlin rows compare head against
+          the fork-point with translator on both sides (gremlin_arms default
+          on). Pass gremlin_arms=both only for an optional on/off A/B on one
+          commit (~doubles Gremlin wall). Full empty-filter with both arms
           was ~21h on CCX33; on-only is shorter. Job timeout is 30h.
         required: false
         type: string
@@ -21,9 +23,10 @@ on:
       gremlin_arms:
         description: >
           Which LdbcGremlinTranslatorBenchmark arms to run and report.
-          'on' (default) = production path only
-          (-p translatorEnabled=true). 'both' = full translator on/off A/B
-          (roughly doubles Gremlin wall time).
+          'on' (default) = production path on base and head
+          (-p translatorEnabled=true) for head-vs-develop compare.
+          'both' = optional same-commit translator on/off A/B (roughly doubles
+          Gremlin wall time; not the default PR comment framing).
         required: false
         type: choice
         options:
@@ -59,9 +62,9 @@ jobs:
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
     # Full empty-filter suite = SQL LDBC (single+multi) + Gremlin translator.
-    # Default gremlin_arms=on runs only the production arm; both ≈ doubles
-    # Gremlin wall (~21h observed for full A/B on CCX33). 30h timeout leaves
-    # margin for variance and new shapes.
+    # Default gremlin_arms=on: head vs fork-point, translator on both sides.
+    # gremlin_arms=both ≈ doubles Gremlin wall (~21h observed on CCX33).
+    # 30h timeout leaves margin for variance and new shapes.
     timeout-minutes: 1800
 
     steps:

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
@@ -11,37 +11,48 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 /**
- * The Gremlin traversal shapes the on/off translator benchmark measures, plus the two engagement
- * checks that decide whether a measurement is an arm of that A/B or a mislabelled repeat of the
- * same path.
+ * Named Gremlin traversal shapes measured by {@link LdbcGremlinTranslatorBenchmark} on the LDBC
+ * schema, plus engagement checks ({@link #requireTranslated}, {@link #requireNotTranslated}) that
+ * pin whether a shape compiles through the translator.
  *
- * <p>The shapes are named methods here rather than inline expressions in the {@code @Benchmark}
- * bodies so the JMH harness and the in-track JUnit test measure and assert over byte-identical
- * traversals. A benchmark whose shape drifted from the shape the test verified would report an
- * A/B over something nobody checked engages the translator.
+ * <p>The shapes are named methods rather than inline {@code @Benchmark} expressions so the harness
+ * and {@link LdbcGremlinShapeTranslationTest} assert over byte-identical traversals.
  *
- * <h2>Two groups, and why the group a shape sits in is asserted</h2>
+ * <h2>How the numbers are read in CI</h2>
  *
- * <p><b>Translating shapes</b> carry one {@link AbstractMatchPlanStep} with the kill-switch on and
- * none with it off, so their A/B measures MATCH against the native pipeline. <b>Declining shapes</b>
- * carry none on either arm. Their A/B still measures something: {@code GremlinToMatchStrategy} runs,
- * walks the traversal and only then declines, so the on-arm pays a per-compile walk the off-arm does
- * not. Nobody on this branch has priced that walk. A recorded zero today is also the baseline the
- * day the shape starts translating — including the case where the new MATCH plan turns out slower
- * than the native pipeline it replaced.
+ * <p>The {@code ldbc-jmh-compare} workflow compares <b>head against the fork-point with
+ * {@code develop}</b>, with {@code translatorEnabled=true} on both sides — the production Gremlin
+ * path. A PR delta on a translating shape therefore means "this branch changed MATCH-plan
+ * throughput vs {@code develop}", the same framing as the SQL IC/IS benchmarks beside it. The
+ * workflow passes {@code -p translatorEnabled=true}; local runs should do the same when reproducing
+ * a PR comment.
  *
- * <p>Every declining shape asserts {@link #requireNotTranslated} on <em>both</em> arms. A reader
- * cannot then mistake a 0% delta for "MATCH does not help here" when it means "MATCH never ran
- * here", and the assertion is a tripwire: the day a recogniser claims that shape, the test fails and
- * says the recorded baseline needs re-reading.
+ * <h2>Optional axis: translator on vs off (same commit)</h2>
+ *
+ * <p>{@link LdbcGremlinTranslatorBenchmark} still exposes {@code translatorEnabled} as a JMH
+ * {@code @Param} for a secondary A/B: MATCH against the native pipeline on one tree. Run both arms
+ * with {@code -Djmh.args=".*LdbcGremlinTranslator.*"} and no {@code -p} filter, or pass {@code
+ * --gremlin-arms both} to {@code jmh-compare.py}. That axis is for recogniser and kill-switch work,
+ * not for the default PR regression comment.
+ *
+ * <h2>Two shape groups</h2>
+ *
+ * <p><b>Translating shapes</b> carry one {@link AbstractMatchPlanStep} with the kill-switch on. In
+ * CI (translator on both sides) their head-vs-base delta is a regression on the MATCH pipeline. In
+ * the optional on/off A/B, the same shape's delta is MATCH vs native on one commit.
+ *
+ * <p><b>Declining shapes</b> carry no boundary step even with the kill-switch on — the translator
+ * walks and declines, or vetoes before the walk ({@code RepeatDeclineStrategy}). Both CI arms
+ * therefore run native; head-vs-base measures native-pipeline or decline-overhead changes, not MATCH
+ * plan improvements. {@link #requireNotTranslated} on both arms in
+ * {@link LdbcGremlinShapeTranslationTest} is the tripwire when a recogniser starts claiming the
+ * shape.
  *
  * <h2>Relation to the SQL IC / IS benchmarks</h2>
  *
- * <p><b>These numbers are not comparable to this module's IC / IS figures.</b> Those measure SQL
- * MATCH text; these measure a Gremlin traversal with the translator on against the same traversal
- * with it off. The LDBC-derived shapes below are named after the query they follow and carry that
- * query's SQL in their Javadoc, which makes the correspondence auditable — not a claim that the two
- * timings can be divided.
+ * <p><b>Throughput is not comparable across SQL and Gremlin rows</b> — different entry points. The
+ * LDBC-derived shapes below are named after the query they echo; per-method Javadoc carries the SQL
+ * for auditable correspondence, not a claim that timings can be divided.
  *
  * <p>Three of the twenty-one queries in {@code ldbc-queries/} use {@code LET}; most of the rest are
  * plain MATCH patterns. What blocks them is the recogniser set rather than Gremlin's expressiveness,
@@ -84,7 +95,8 @@ public final class GremlinTraversalShapes {
   }
 
   // ---------------------------------------------------------------------------------------------
-  // Translating shapes: one boundary step with the kill-switch on, none with it off.
+  // Translating shapes: boundary step with kill-switch on. CI delta = head vs base (translator on).
+  // Optional on/off A/B on one commit = MATCH vs native.
   // ---------------------------------------------------------------------------------------------
 
   /**
@@ -352,9 +364,8 @@ public final class GremlinTraversalShapes {
   }
 
   // ---------------------------------------------------------------------------------------------
-  // Declining shapes: no boundary step on either arm. The A/B prices the decline path and reserves
-  // a baseline for the day the shape starts translating. Each asserts requireNotTranslated on both
-  // arms, so it cannot drift into the translating group unnoticed.
+  // Declining shapes: no boundary step with kill-switch on. CI: both sides native — head-vs-base
+  // is not a MATCH win/loss. Optional on/off A/B prices decline overhead on one commit.
   // ---------------------------------------------------------------------------------------------
 
   /**
@@ -387,9 +398,8 @@ public final class GremlinTraversalShapes {
    * why the group changed rather than the spelling.
    *
    * <p>The spelling is kept as authored rather than nudged into something translatable. Paging a
-   * sorted hop is what the LDBC read queries actually ask for, so its A/B is the baseline for the
-   * day a recogniser claims a slice after a sort — and the both-arms assertion fails on that day
-   * and says so.
+   * sorted hop is what the LDBC read queries actually ask for. The both-arms assertion fails the
+   * day a recogniser claims a slice after a sort and signals that CI baselines need re-reading.
    */
   public static YTDBGraphTraversal<Vertex, String> knowsOrderedPage(
       YTDBGraphTraversalSource g, long personId) {

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
@@ -22,34 +22,49 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 /**
- * Translator-on against translator-off over the Gremlin shapes in {@link GremlinTraversalShapes}, on
- * the LDBC schema.
+ * Gremlin translator benchmarks over {@link GremlinTraversalShapes} on the LDBC schema.
  *
- * <p>The A/B axis is a JMH {@code @Param} on {@link TranslatorArm}, so each arm gets its own
- * forks and the kill-switch is flipped once per trial in-process. Nothing is set through
+ * <h2>Primary use: head vs {@code develop} (translator on both sides)</h2>
+ *
+ * <p>The {@code ldbc-jmh-compare} workflow checks out the fork-point and the branch tip, runs this
+ * class on each, and compares throughput — with {@code -p translatorEnabled=true} so base and head
+ * both measure the production MATCH path. Read PR deltas on translating shapes as "did this branch
+ * change Gremlin+translator performance vs {@code develop}?", the same way as {@code
+ * LdbcSingleThread*} / {@code LdbcMultiThread*} SQL rows beside them.
+ *
+ * <h2>Secondary use: translator on vs off (same commit)</h2>
+ *
+ * <p>{@link TranslatorArm} exposes {@code translatorEnabled} as a JMH {@code @Param}. Each value
+ * gets its own forks; the kill-switch is flipped once per trial in-process. Nothing is set through
  * {@code -DargLine=}: on some modules a CLI {@code argLine} replaces the POM's block wholesale
  * (taking {@code -ea}, the heap sizing and every {@code --add-opens} with it) and on others plugin
  * configuration wins and the CLI value is inert. Neither failure is visible in the numbers.
  *
- * <p><b>Two groups of benchmark, read differently.</b> A translating shape's delta is MATCH against
- * the native pipeline. A declining shape's delta is the cost of the decline itself —
- * {@code GremlinToMatchStrategy} runs on the on-arm, walks the traversal and only then hands it back
- * — and doubles as the baseline for the day a recogniser claims that shape. The two groups are
- * separated below and each declining shape's Javadoc says so, because a 0% delta means opposite
- * things in the two groups.
+ * <p>Run both arms locally with {@code -Djmh.args=".*LdbcGremlinTranslator.*"} (no {@code -p}
+ * filter). For {@code jmh-compare.py}, pass {@code --gremlin-arms both} to include off-arm rows in
+ * the markdown comment.
  *
- * <p><b>What these numbers are not.</b> They are not comparable to this module's IC / IS figures —
- * see {@link GremlinTraversalShapes}. The baseline is Hetzner-scoped; a local run measures the
- * harness, not the feature.
+ * <h2>Two benchmark groups, read differently</h2>
  *
- * <p><b>Why the trial setup checks engagement and throws.</b> An A/B whose two arms both ran the
- * same path reports a difference of zero and looks like a clean result. {@link
- * TranslatorArm#setUp} therefore builds two witness traversals — one from each group — applies
- * strategies, and throws unless the boundary step is present exactly where the arm says it should
- * be. It throws rather than asserting because the launcher at {@code jmh-ldbc/pom.xml} runs
- * {@code java} without {@code -ea} — see {@link GremlinTraversalShapes#requireTranslated}.
+ * <p><b>Translating shapes</b> — in CI, head-vs-base delta is MATCH throughput. In the optional
+ * on/off A/B, delta is MATCH vs native on one commit.
  *
- * <p>Run one arm only with {@code -Djmh.args=".*LdbcGremlinTranslator.* -p translatorEnabled=true"}.
+ * <p><b>Declining shapes</b> — in CI, both sides run native; head-vs-base is not evidence that
+ * MATCH helped or hurt. In the optional on/off A/B, delta prices decline overhead ({@code
+ * GremlinToMatchStrategy} runs on the on-arm, walks, then hands back). A ~0% PR delta here usually
+ * means "still declining on both sides", not "translator made no difference".
+ *
+ * <p><b>What these numbers are not.</b> Not comparable to this module's IC/IS SQL throughput — see
+ * {@link GremlinTraversalShapes}. Hetzner-scoped baselines; a local run validates the harness, not
+ * a production regression gate.
+ *
+ * <p><b>Trial setup witness.</b> An arm whose kill-switch failed to flip reports ~0% vs the other
+ * arm and looks clean. {@link TranslatorArm#setUp} builds witness traversals from each group,
+ * applies strategies, and throws unless the boundary step matches the arm — see {@link
+ * GremlinTraversalShapes#requireTranslated}.
+ *
+ * <p>Reproduce the CI arm only: {@code -Djmh.args=".*LdbcGremlinTranslator.* -p
+ * translatorEnabled=true"}.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -87,8 +102,8 @@ public class LdbcGremlinTranslatorBenchmark {
   public static class TranslatorArm {
 
     /**
-     * The A/B axis. JMH runs a separate set of forks per value, so a trial never sees both
-     * positions of the kill-switch.
+     * Kill-switch position for this fork. JMH runs separate forks per value; {@code ldbc-jmh-compare}
+     * defaults to {@code true} only so base and head both measure the production path.
      */
     @Param({"true", "false"})
     public boolean translatorEnabled;
@@ -245,7 +260,7 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   // ---------------------------------------------------------------------------------------------
-  // Translating shapes. Delta = MATCH against the native pipeline.
+  // Translating shapes. CI: head vs base with translator on. Optional A/B: MATCH vs native.
   // ---------------------------------------------------------------------------------------------
 
   /** Shape 2 — the {@code KNOWS} walk under {@code values}: one row per friend. */
@@ -379,18 +394,15 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   // ---------------------------------------------------------------------------------------------
-  // Declining shapes. Delta = the cost of the decline path, and the baseline for the day the shape
-  // starts translating. A 0% delta here means "MATCH never ran", not "MATCH did not help" — the
-  // both-arms requireNotTranslated in the trial witness and in
-  // LdbcGremlinShapeTranslationTest is what keeps that reading true.
+  // Declining shapes. CI: both sides native — PR delta is not a MATCH regression. Optional on/off
+  // A/B prices decline overhead; LdbcGremlinShapeTranslationTest keeps groups honest.
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * A bare {@code g.V(rid)} point-lookup. Native resolves the id without a query, while a translated
-   * bare lookup would compile an uncached MATCH plan (a RID-bearing walk sets {@code
-   * cacheEligible=false}) with no join to optimise, so the translator DECLINES it — both arms run
-   * natively. The A/B measures the decline-path cost and is the baseline for the day a bare RID
-   * lookup starts translating again. A RID start followed by a hop still translates.
+   * A bare {@code g.V(rid)} point-lookup. Native resolves the id without a query; the translator
+   * declines a bare RID walk ({@code cacheEligible=false}, no join to optimise), so both CI arms
+   * run native. Optional on/off A/B prices decline overhead; a RID start followed by a hop still
+   * translates.
    */
   @Benchmark
   public List<Vertex> gremlinVertexByRidDeclines(LdbcBenchmarkState state, TranslatorArm arm) {

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinShapeTranslationTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinShapeTranslationTest.java
@@ -25,7 +25,11 @@ import org.junit.Test;
 
 /**
  * Drives every {@link GremlinTraversalShapes} builder the JMH harness measures, on both kill-switch
- * arms, so a broken A/B is caught by an ordinary build instead of on Hetzner.
+ * arms, so a broken engagement check is caught by an ordinary build instead of on Hetzner.
+ *
+ * <p>This class validates the optional translator on/off axis ({@code translatorEnabled}). The
+ * {@code ldbc-jmh-compare} PR comment instead compares head vs {@code develop} with translator on
+ * both sides — see {@link GremlinTraversalShapes} and {@link LdbcGremlinTranslatorBenchmark}.
  *
  * <p>The {@code @Benchmark} bodies themselves are dataset-bound and cannot run here. What can run
  * is the part that silently goes wrong: whether flipping


### PR DESCRIPTION
#### PR Title:

YTDB-1279: fix gremlin benhcmarks descriptions [no-it-tests] [no-test-number-check]`

#### Motivation:

The old gremlin benhcmarks comments described translator on/off logic that is now develop vs new branch test (with on/off as option) 

