### PR TITLE
Run LDBC JMH compare on CCX53 (32 vCPU) [no-it-tests]

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -16,7 +16,8 @@ on:
           the fork-point with translator on both sides (gremlin_arms default
           on). Pass gremlin_arms=both only for an optional on/off A/B on one
           commit (~doubles Gremlin wall). Full empty-filter with both arms
-          was ~21h on CCX33; on-only is shorter. Job timeout is 30h.
+          was ~21h on CCX33; run on CCX53 (32 vCPU) to match nightly
+          multi-thread core count. Job timeout is 30h.
         required: false
         type: string
         default: ''
@@ -58,13 +59,15 @@ jobs:
   compare:
     runs-on:
       - self-hosted
-      - type-ccx33
+      # CCX53: 32 dedicated vCPUs — same core count as nightly baremetal so
+      # @Threads(Threads.MAX) multi-thread scores are comparable (CCX33 was 8).
+      - type-ccx53
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
     # Full empty-filter suite = SQL LDBC (single+multi) + Gremlin translator.
     # Default gremlin_arms=on: head vs fork-point, translator on both sides.
     # gremlin_arms=both ≈ doubles Gremlin wall (~21h observed on CCX33).
-    # 30h timeout leaves margin for variance and new shapes.
+    # 30h timeout leaves margin for variance and new shapes on CCX53.
     timeout-minutes: 1800
 
     steps:


### PR DESCRIPTION
#### Motivation:

Manual `LDBC JMH Benchmark Compare` was running on TestFlows `type-ccx33` (8 dedicated vCPUs). Multi-thread LDBC classes use `@Threads(Threads.MAX)`, so they only spun 8 worker threads. Nightly already runs on a 32-core baremetal runner; PR compares therefore understated multi-thread load and could miss scalability regressions that only show up at higher concurrency.

This switches the compare job to `type-ccx53` (32 dedicated vCPUs). Ephemeral TestFlows provisioning stays (parallel compares per branch); only the core count changes. Single-thread and Gremlin translator arms stay `@Threads(1)`. CCX53 costs more per hour than CCX33; matching nightly thread count for reproducible multi-thread scores is the accepted trade-off. Job timeout stays 30h.

#### Planned changes:

##### Current state
Compare workflow labels: `self-hosted` + `type-ccx33` + Ubuntu 24.04 image + NBG/FSN/HEL location.

##### What changes
Runner type label only: `type-ccx33` → `type-ccx53`. Workflow inputs, concurrency, timeout, and suite contents are unchanged.

##### Out of scope
Nightly baremetal label, local JMH skill defaults, and non-compare CI runners.

##### Suggestions:
None.

#### Tracks:
N/A (single-track)

#### Test plan
- [ ] After merge, manually dispatch **LDBC JMH Benchmark Compare** on a branch and confirm the job lands on a `type-ccx53` runner
- [ ] Confirm multi-thread JMH output reports ~32 threads (`Threads.MAX`)
- [ ] No product code change — unit/IT suites N/A (`[no-it-tests]`)