### PR TITLE
YTDB-1280: Fix index-ordered IS2 multi-thread regression

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedCostModel.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedCostModel.java
@@ -55,8 +55,11 @@ final class IndexOrderedCostModel {
    * @param histogram            equi-depth histogram for skew correction, or null
    * @param orderAsc             true for ASC scan direction, false for DESC
    * @param downstreamEdgeCount  number of MATCH edges after the target alias.
-   *     With index scan + LIMIT, only K rows traverse these edges; with
-   *     load-all, all N rows do. Each downstream edge costs ~randRead per row.
+   *     Both strategies compared here emit rows in index order under a LIMIT,
+   *     so only K rows traverse these edges in either case. The term is still
+   *     added (at ~randRead per row per edge) so the absolute estimates stay
+   *     comparable with cost numbers produced elsewhere; it cancels out of the
+   *     scan-versus-load-sort comparison itself.
    * @return cost estimate, or null if the index scan should be skipped
    *     (below threshold, zero index, or scan too large)
    */
@@ -126,9 +129,10 @@ final class IndexOrderedCostModel {
 
     // Downstream edge cost: with LIMIT, only K rows traverse downstream
     // edges in BOTH strategies. Index scan produces K rows directly;
-    // loadSortFromRidSet loads all N but sorts and marks PRE_SORTED=true,
+    // loadSortFromLinkBag loads all N but sorts and marks PRE_SORTED=true,
     // so OrderByStep passes through and LimitStep stops after K rows —
-    // only K rows go through downstream MATCH edges.
+    // only K rows go through downstream MATCH edges. Charging both sides
+    // keeps the estimates on the same scale without biasing the choice.
     if (downstreamEdgeCount > 0 && limit > 0) {
       double downstreamPerRow = downstreamEdgeCount * randRead;
       costUnionScan += k * downstreamPerRow;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
@@ -266,7 +266,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   private ExecutionStream loadSortFromLinkBag(
       LinkBag linkBag, CommandContext ctx, Result upstreamRow) {
     var session = ctx.getDatabaseSession();
-    // Resolve once: matchesTargetFilter class-check is per LinkBag entry.
+    // Class filter is per LinkBag entry; resolve the target class once for the scan.
     var targetClass = resolveTargetClass(ctx);
 
     var records = new ArrayList<Result>();
@@ -1051,8 +1051,9 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   }
 
   /**
-   * Resolves the target class from the immutable schema snapshot, or
-   * {@code null} when there is no class constraint / schema / class.
+   * Resolves the MATCH target class from the session's immutable schema
+   * snapshot, or {@code null} when there is no class constraint / schema /
+   * class.
    */
   @Nullable private SchemaClass resolveTargetClass(CommandContext ctx) {
     if (targetClassName == null) {
@@ -1069,11 +1070,11 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
    * Checks if a target record passes the WHERE filter and class constraint.
    * Returns true if the record should be included, false if filtered out.
    *
-   * <p>Class membership uses the session's immutable schema snapshot and
-   * {@code hasPolymorphicCollectionId} on the record RID — same pattern as
-   * {@link #unfilteredBound}. Avoids {@code Entity.getSchemaClass()} /
-   * {@code isSubClassOf}, which take the shared schema RW lock per call and
-   * contend under multi-threaded loadSort (e.g. LDBC IS2).
+   * <p>Class membership uses the immutable schema snapshot and the record's
+   * collection id (the target class and its subclasses). That is equivalent to
+   * an {@code isSubClassOf} check, but does not take the shared schema lock on
+   * every record — important when many targets are filtered under concurrent
+   * queries. Same approach as {@link #unfilteredBound}.
    */
   private boolean matchesTargetFilter(Result targetRecord, CommandContext ctx) {
     return matchesTargetFilter(targetRecord, ctx, resolveTargetClass(ctx));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
@@ -8,6 +8,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.index.Index;
 import com.jetbrains.youtrackdb.internal.core.index.engine.EquiDepthHistogram;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.AbstractExecutionStep;
@@ -265,12 +266,14 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   private ExecutionStream loadSortFromLinkBag(
       LinkBag linkBag, CommandContext ctx, Result upstreamRow) {
     var session = ctx.getDatabaseSession();
+    // Resolve once: matchesTargetFilter class-check is per LinkBag entry.
+    var targetClass = resolveTargetClass(ctx);
 
     var records = new ArrayList<Result>();
     for (RidPair pair : linkBag) {
       var record = loadRecord(ridFromPair(pair), session);
       if (record != null
-          && matchesTargetFilter(record, ctx)
+          && matchesTargetFilter(record, ctx, targetClass)
           && !isAlreadyBoundAndDifferent(upstreamRow, record, session)) {
         records.add(record);
       }
@@ -296,6 +299,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   private ExecutionStream loadFromLinkBag(
       LinkBag linkBag, CommandContext ctx, Result upstreamRow) {
     var session = ctx.getDatabaseSession();
+    var targetClass = resolveTargetClass(ctx);
     var iter = linkBag.iterator();
     return ExecutionStream.resultIterator(new Iterator<Result>() {
       private Result pending;
@@ -305,7 +309,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
         while (pending == null && iter.hasNext()) {
           var record = loadRecord(ridFromPair(iter.next()), session);
           if (record != null
-              && matchesTargetFilter(record, ctx)
+              && matchesTargetFilter(record, ctx, targetClass)
               && !isAlreadyBoundAndDifferent(upstreamRow, record, session)) {
             pending = new MatchResultRow(session, upstreamRow, targetAlias, record);
           }
@@ -1047,27 +1051,56 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   }
 
   /**
+   * Resolves the target class from the immutable schema snapshot, or
+   * {@code null} when there is no class constraint / schema / class.
+   */
+  @Nullable private SchemaClass resolveTargetClass(CommandContext ctx) {
+    if (targetClassName == null) {
+      return null;
+    }
+    var schema = ctx.getDatabaseSession().getMetadata().getImmutableSchemaSnapshot();
+    if (schema == null) {
+      return null;
+    }
+    return schema.getClassInternal(targetClassName);
+  }
+
+  /**
    * Checks if a target record passes the WHERE filter and class constraint.
    * Returns true if the record should be included, false if filtered out.
+   *
+   * <p>Class membership uses the session's immutable schema snapshot and
+   * {@code hasPolymorphicCollectionId} on the record RID — same pattern as
+   * {@link #unfilteredBound}. Avoids {@code Entity.getSchemaClass()} /
+   * {@code isSubClassOf}, which take the shared schema RW lock per call and
+   * contend under multi-threaded loadSort (e.g. LDBC IS2).
    */
   private boolean matchesTargetFilter(Result targetRecord, CommandContext ctx) {
+    return matchesTargetFilter(targetRecord, ctx, resolveTargetClass(ctx));
+  }
+
+  private boolean matchesTargetFilter(
+      Result targetRecord,
+      CommandContext ctx,
+      @Nullable SchemaClass targetClass) {
     if (targetFilter != null
         && !targetFilter.matchesFilters(targetRecord, ctx)) {
       return false;
     }
     if (targetClassName != null) {
+      // Missing class in the snapshot means nothing can match the constraint.
+      if (targetClass == null) {
+        return false;
+      }
       var entity = targetRecord.asEntityOrNull();
       if (entity == null) {
         return false;
       }
-      var schemaClass = entity.getSchemaClass();
-      if (schemaClass == null) {
+      var identity = entity.getIdentity();
+      if (identity == null) {
         return false;
       }
-      if (!schemaClass.getName().equals(targetClassName)
-          && !schemaClass.isSubClassOf(targetClassName)) {
-        return false;
-      }
+      return targetClass.hasPolymorphicCollectionId(identity.getCollectionId());
     }
     return true;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
@@ -101,6 +101,49 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
    */
   private final int downstreamEdgeCount;
 
+  /**
+   * Runtime strategy chosen on the last {@link #internalStart} of this step.
+   * Null until the step runs — EXPLAIN before execution will not show it;
+   * PROFILE / post-query {@link #prettyPrint} will.
+   */
+  @Nullable private volatile RuntimePath chosenRuntimePath;
+
+  /**
+   * Which physical strategy {@link IndexOrderedEdgeStep} actually ran.
+   * Distinct from plan-time {@code multiSourceMode}: that selects the MATCH
+   * binding shape; this records index scan vs local load/sort after the cost
+   * model runs.
+   */
+  public enum RuntimePath {
+    /** Single-source RidSet-filtered B-tree scan ({@code indexScanFiltered}). */
+    INDEX_SCAN("index-scan"),
+    /** Single-source load LinkBag + local sort ({@code loadSortFromLinkBag}). */
+    LOAD_SORT("load-sort"),
+    /** Single-source load LinkBag unsorted ({@code loadFromLinkBag}). */
+    LOAD_UNSORTED("load-unsorted"),
+    /** Multi-source union RidSet + filtered index scan. */
+    UNION_SCAN("union-scan"),
+    /** Multi-source global index scan (no RidSet filter). */
+    GLOBAL_SCAN("global-scan"),
+    /** Multi-source / unbound fallback: stream LinkBags, OrderByStep sorts. */
+    LOAD_UNSORTED_MULTI("load-unsorted-multi");
+
+    private final String label;
+
+    RuntimePath(String label) {
+      this.label = label;
+    }
+
+    String label() {
+      return label;
+    }
+  }
+
+  /** Last runtime path chosen by this step, or null if not started yet. */
+  @Nullable public RuntimePath getChosenRuntimePath() {
+    return chosenRuntimePath;
+  }
+
   public IndexOrderedEdgeStep(
       CommandContext ctx,
       String sourceAlias,
@@ -191,6 +234,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       // Build RidSet only now — it is needed as the bitmap filter for the
       // index-value scan. The fallback paths below iterate the LinkBag
       // directly, so they skip the RidSet allocation.
+      chosenRuntimePath = RuntimePath.INDEX_SCAN;
       ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
       return indexScanFiltered(ridSetFromLinkBag(linkBag), ctx, upstreamRow);
     } else if (downstreamEdgeCount > 0 && limit > 0) {
@@ -199,11 +243,13 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       // pipeline — only K records traverse expensive downstream edges
       // (REPLY_OF chain, HAS_CREATOR, etc.) instead of all N.
       // Sort cost O(N log N) is trivial for typical LinkBag sizes (~50-500).
+      chosenRuntimePath = RuntimePath.LOAD_SORT;
       ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
       return loadSortFromLinkBag(linkBag, ctx, upstreamRow);
     } else {
       // No downstream edges or no LIMIT: stream unsorted to OrderByStep.
       // OrderByStep's bounded heap handles sorting with O(N log K).
+      chosenRuntimePath = RuntimePath.LOAD_UNSORTED;
       ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.FALSE);
       return loadFromLinkBag(linkBag, ctx, upstreamRow);
     }
@@ -370,10 +416,13 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       case FILTERED_BOUND -> filteredBound(ctx);
       case FILTERED_UNBOUND -> filteredUnbound(ctx);
       case UNFILTERED_BOUND -> {
+        // Full index scan + reverse-edge class check; no RidSet filter.
+        chosenRuntimePath = RuntimePath.GLOBAL_SCAN;
         ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
         yield unfilteredBound(ctx);
       }
       case UNFILTERED_UNBOUND -> {
+        chosenRuntimePath = RuntimePath.GLOBAL_SCAN;
         ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
         yield unfilteredUnbound(ctx);
       }
@@ -412,6 +461,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
     int maxSources =
         GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SOURCES.getValueAsInteger();
     if (sourceCount > maxSources) {
+      chosenRuntimePath = RuntimePath.LOAD_UNSORTED_MULTI;
       ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.FALSE);
       return loadFromSourcesUnsorted(sourceMap, ctx);
     }
@@ -424,14 +474,17 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
 
     return switch (strategy) {
       case UNION_RIDSET_SCAN -> {
+        chosenRuntimePath = RuntimePath.UNION_SCAN;
         ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
         yield indexScanWithUnion(sourceMap, ctx);
       }
       case GLOBAL_SCAN -> {
+        chosenRuntimePath = RuntimePath.GLOBAL_SCAN;
         ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
         yield indexScanGlobal(sourceMap, ctx);
       }
       case LOAD_ALL_SORT -> {
+        chosenRuntimePath = RuntimePath.LOAD_UNSORTED_MULTI;
         ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.FALSE);
         yield loadFromSourcesUnsorted(sourceMap, ctx);
       }
@@ -500,10 +553,12 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
     var histogram = index.getHistogram(session);
     if (sourceOverflow || ridSetOverflow || unionRidSet.isEmpty()
         || !shouldUseIndexScan(unionRidSet.size(), indexSize, histogram)) {
+      chosenRuntimePath = RuntimePath.LOAD_UNSORTED_MULTI;
       ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.FALSE);
       return loadFromSourcesUnbound(sourceRids, ctx);
     }
 
+    chosenRuntimePath = RuntimePath.UNION_SCAN;
     ctx.setSystemVariable(CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.TRUE);
     var indexDesc = new IndexSearchDescriptor(index);
     var filteredStep = new RidFilteredIndexValuesStep(
@@ -715,6 +770,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
     }
 
     if (overflow) {
+      chosenRuntimePath = RuntimePath.LOAD_UNSORTED_MULTI;
       ctx.setSystemVariable(
           CommandContext.VAR_INDEX_ORDERED_PRE_SORTED, Boolean.FALSE);
       return loadFromSourcesUnsorted(sourceMap, ctx);
@@ -1117,7 +1173,8 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
     var direction = orderAsc ? "ASC" : "DESC";
     var mode = multiSourceMode != null ? " (" + multiSourceMode + ")" : "";
     var edgeSuffix = edgeTraversal ? "E" : "";
-    return spaces + "+ INDEX ORDERED MATCH" + edgeSuffix + " " + direction + mode + "\n"
+    var path = chosenRuntimePath != null ? " [" + chosenRuntimePath.label() + "]" : "";
+    return spaces + "+ INDEX ORDERED MATCH" + edgeSuffix + " " + direction + mode + path + "\n"
         + spaces + "  {" + sourceAlias + "}." + edgeClassName
         + "{" + targetAlias + "} via " + index.getName();
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStep.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,8 +86,13 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   /** WHERE filter on the target alias (e.g., creationDate < :maxDate). */
   @Nullable private final SQLWhereClause targetFilter;
 
-  /** Class constraint on the target alias (for class-based filtering). */
-  @Nullable private final String targetClassName;
+  /**
+   * Class constraint on the target alias (for class-based filtering). Never
+   * null: {@link IndexOrderedPlanner} rejects the candidate when the target
+   * alias has no resolvable class, so this step is only built with one.
+   */
+  @Nonnull
+  private final String targetClassName;
 
   /**
    * When true, the traversal is .inE()/.outE() and we want edge record RIDs
@@ -158,7 +164,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       @Nullable String reverseFieldName,
       @Nullable String sourceClassName,
       @Nullable SQLWhereClause targetFilter,
-      @Nullable String targetClassName,
+      @Nonnull String targetClassName,
       boolean edgeTraversal,
       int downstreamEdgeCount,
       boolean profilingEnabled) {
@@ -287,7 +293,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       if (targetRecord == null) {
         return null;
       }
-      if (!matchesTargetFilter(targetRecord, mapCtx)) {
+      if (!matchesTargetFilter(targetRecord, rid, mapCtx)) {
         return null;
       }
       if (isAlreadyBoundAndDifferent(upstreamRow, targetRecord, session)) {
@@ -317,9 +323,10 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
 
     var records = new ArrayList<Result>();
     for (RidPair pair : linkBag) {
-      var record = loadRecord(ridFromPair(pair), session);
+      var rid = ridFromPair(pair);
+      var record = loadRecord(rid, session);
       if (record != null
-          && matchesTargetFilter(record, ctx, targetClass)
+          && matchesTargetFilter(record, rid, ctx, targetClass)
           && !isAlreadyBoundAndDifferent(upstreamRow, record, session)) {
         records.add(record);
       }
@@ -353,9 +360,10 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       @Override
       public boolean hasNext() {
         while (pending == null && iter.hasNext()) {
-          var record = loadRecord(ridFromPair(iter.next()), session);
+          var rid = ridFromPair(iter.next());
+          var record = loadRecord(rid, session);
           if (record != null
-              && matchesTargetFilter(record, ctx, targetClass)
+              && matchesTargetFilter(record, rid, ctx, targetClass)
               && !isAlreadyBoundAndDifferent(upstreamRow, record, session)) {
             pending = new MatchResultRow(session, upstreamRow, targetAlias, record);
           }
@@ -573,7 +581,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       if (targetRecord == null) {
         return null;
       }
-      if (!matchesTargetFilter(targetRecord, mapCtx)) {
+      if (!matchesTargetFilter(targetRecord, rid, mapCtx)) {
         return null;
       }
       return new MatchResultRow(session, emptyUpstream, targetAlias, targetRecord);
@@ -616,9 +624,11 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
   private void forEachMatchingTarget(
       LinkBag linkBag, DatabaseSessionEmbedded session, CommandContext ctx,
       java.util.function.Consumer<Result> consumer) {
+    var targetClass = resolveTargetClass(ctx);
     for (RidPair pair : linkBag) {
-      var record = loadRecord(ridFromPair(pair), session);
-      if (record != null && matchesTargetFilter(record, ctx)) {
+      var rid = ridFromPair(pair);
+      var record = loadRecord(rid, session);
+      if (record != null && matchesTargetFilter(record, rid, ctx, targetClass)) {
         consumer.accept(record);
       }
     }
@@ -658,7 +668,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       if (targetRecord == null) {
         return ExecutionStream.empty();
       }
-      if (!matchesTargetFilter(targetRecord, mapCtx)) {
+      if (!matchesTargetFilter(targetRecord, rid, mapCtx)) {
         return ExecutionStream.empty();
       }
 
@@ -716,7 +726,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
       if (targetRecord == null) {
         return null;
       }
-      if (!matchesTargetFilter(targetRecord, mapCtx)) {
+      if (!matchesTargetFilter(targetRecord, rid, mapCtx)) {
         return null;
       }
 
@@ -900,7 +910,7 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
     if (targetRecord == null) {
       return ExecutionStream.empty();
     }
-    if (!matchesTargetFilter(targetRecord, ctx)) {
+    if (!matchesTargetFilter(targetRecord, rid, ctx)) {
       return ExecutionStream.empty();
     }
 
@@ -1108,58 +1118,63 @@ public class IndexOrderedEdgeStep extends AbstractExecutionStep {
 
   /**
    * Resolves the MATCH target class from the session's immutable schema
-   * snapshot, or {@code null} when there is no class constraint / schema /
-   * class.
+   * snapshot. The planner refuses to build this step unless the target class
+   * name resolves at plan time, so {@code null} here means the class was
+   * dropped between planning and execution.
+   *
+   * <p>The snapshot is the required source, not merely a convenient one. Its
+   * classes carry a precomputed polymorphic collection-id set, which is what
+   * makes the per-record membership test in
+   * {@link #matchesTargetFilter(Result, RID, CommandContext, SchemaClass)}
+   * lock-free. Reading the class off the live shared schema instead would
+   * reintroduce the schema lock this step exists to avoid.
    */
   @Nullable private SchemaClass resolveTargetClass(CommandContext ctx) {
-    if (targetClassName == null) {
-      return null;
-    }
     var schema = ctx.getDatabaseSession().getMetadata().getImmutableSchemaSnapshot();
-    if (schema == null) {
-      return null;
-    }
+    assert schema != null;
     return schema.getClassInternal(targetClassName);
+  }
+
+  /**
+   * Convenience overload for call sites that filter a single record and have no
+   * loop to hoist the class resolution out of. Loops should resolve the class
+   * once with {@link #resolveTargetClass} and call the four-argument form.
+   */
+  private boolean matchesTargetFilter(
+      Result targetRecord, RID targetRid, CommandContext ctx) {
+    return matchesTargetFilter(
+        targetRecord, targetRid, ctx, resolveTargetClass(ctx));
   }
 
   /**
    * Checks if a target record passes the WHERE filter and class constraint.
    * Returns true if the record should be included, false if filtered out.
    *
-   * <p>Class membership uses the immutable schema snapshot and the record's
-   * collection id (the target class and its subclasses). That is equivalent to
-   * an {@code isSubClassOf} check, but does not take the shared schema lock on
-   * every record — important when many targets are filtered under concurrent
-   * queries. Same approach as {@link #unfilteredBound}.
+   * <p>Class membership is decided from the record's collection id against
+   * {@code targetClass}, which covers the target class and its subclasses. That
+   * is equivalent to an {@code isSubClassOf} check, but it does not take the
+   * shared schema lock on every record — important when many targets are
+   * filtered under concurrent queries. Same approach as
+   * {@link #unfilteredBound}.
+   *
+   * <p>The caller supplies {@code targetClass} so a filtering loop resolves it
+   * once instead of once per record.
    */
-  private boolean matchesTargetFilter(Result targetRecord, CommandContext ctx) {
-    return matchesTargetFilter(targetRecord, ctx, resolveTargetClass(ctx));
-  }
-
   private boolean matchesTargetFilter(
       Result targetRecord,
+      RID targetRid,
       CommandContext ctx,
       @Nullable SchemaClass targetClass) {
     if (targetFilter != null
         && !targetFilter.matchesFilters(targetRecord, ctx)) {
       return false;
     }
-    if (targetClassName != null) {
-      // Missing class in the snapshot means nothing can match the constraint.
-      if (targetClass == null) {
-        return false;
-      }
-      var entity = targetRecord.asEntityOrNull();
-      if (entity == null) {
-        return false;
-      }
-      var identity = entity.getIdentity();
-      if (identity == null) {
-        return false;
-      }
-      return targetClass.hasPolymorphicCollectionId(identity.getCollectionId());
+    // A class dropped between planning and execution leaves nothing that can
+    // satisfy the constraint.
+    if (targetClass == null) {
+      return false;
     }
-    return true;
+    return targetClass.hasPolymorphicCollectionId(targetRid.getCollectionId());
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedPlanner.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -77,7 +78,7 @@ final class IndexOrderedPlanner {
       @Nullable String sourceClassName,
       boolean multiFieldOrderBy,
       @Nullable SQLWhereClause targetFilter,
-      @Nullable String targetClassName,
+      @Nonnull String targetClassName,
       boolean isEdgeTraversal,
       int downstreamEdgeCount) {
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedPlanner.java
@@ -431,10 +431,13 @@ final class IndexOrderedPlanner {
     }
 
     // 12. Count downstream edges after the matched edge in the schedule.
-    // These edges represent traversal work done PER result row. With index
-    // scan + LIMIT, only K rows go through downstream edges; with load-all,
-    // all N rows do. This cost difference tips the balance toward index scan
-    // when downstream work is significant (e.g., IS2's REPLY_OF chain).
+    // These edges represent traversal work done PER result row. Both
+    // order-preserving strategies stop after K rows under a LIMIT, so this
+    // count does not by itself favour one over the other; the cost model adds
+    // it to both estimates only to keep them on a comparable scale. The count
+    // matters at runtime instead: it is what makes a bounded step prefer
+    // sorting the loaded targets locally over streaming them unsorted, since
+    // an unsorted stream would push all N rows through the downstream edges.
     int downstreamEdgeCount = 0;
     boolean pastMatched = false;
     for (var edge : sortedEdges) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -6393,14 +6393,13 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   // Additional branch-coverage tests for IndexOrderedEdgeStep
   // =====================================================================
 
-  // Class filtering: targetClassName skips unrelated classes in the same LinkBag.
-  // Covers matchesTargetFilter via hasPolymorphicCollectionId (reject path).
+  // Class filter rejects unrelated types that share the source LinkBag.
   @Test
   public void testIndexOrderedMatchTargetClassInheritance() throws Exception {
     // Person1 has in_TEST_HAS_CREATOR edges pointing to both TestMessage and
     // TestComment vertices. The index is on TestMessage.creationDate. The
     // MATCH query targets {class: TestMessage} — TestComment records in the
-    // LinkBag are loaded but fail targetClassName check in matchesTargetFilter.
+    // LinkBag must be dropped by the target class filter.
     session.execute("CREATE CLASS TestPerson EXTENDS V").close();
     session.execute("CREATE CLASS TestMessage EXTENDS V").close();
     session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
@@ -6477,10 +6476,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   /**
-   * Parent class constraint must accept subclass vertices: TestPost EXTENDS
-   * TestMessage linked on the same edge; {@code {class: TestMessage}} returns
-   * both base messages and posts (polymorphic include via
-   * {@code hasPolymorphicCollectionId}).
+   * A parent-class MATCH filter must also accept subclass vertices on the same
+   * edge (e.g. TestPost under TestMessage).
    */
   @Test
   public void testIndexOrderedMatchTargetClassIncludesSubclass() throws Exception {
@@ -6549,8 +6546,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   /**
-   * Concrete subclass constraint must reject base-class siblings: {@code {class:
-   * TestPost}} returns only posts, not base TestMessage rows on the same LinkBag.
+   * A concrete subclass MATCH filter must reject base-class siblings on the
+   * same LinkBag (TestPost only, not plain TestMessage).
    */
   @Test
   public void testIndexOrderedMatchTargetClassConcreteSubclassExcludesBase()
@@ -7602,9 +7599,9 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   /**
-   * Schema for loadSort polymorphic target tests: base TestMessage, subclass
-   * TestPost, unrelated TestNote on the same LinkBag; each has a TestReply so
-   * MAX_SCAN=1 + LIMIT forces {@code loadSortFromLinkBag}.
+   * Graph for class-filter tests on the local-sort fallback: base message,
+   * subclass post, and an unrelated note on the same LinkBag; a downstream
+   * reply edge plus LIMIT forces sort-before-traverse instead of an index scan.
    */
   private void initLoadSortPolymorphicTargetData() {
     session.execute("CREATE CLASS TestPerson EXTENDS V").close();
@@ -7682,8 +7679,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   /**
-   * loadSortFromLinkBag: {@code {class: TestMessage}} includes TestPost subclass
-   * RIDs and excludes unrelated TestNote RIDs on the same LinkBag.
+   * On the local-sort fallback, a parent-class filter still includes subclass
+   * targets and drops unrelated types from the same LinkBag.
    */
   @Test
   public void testIndexOrderedMatchLoadSortIncludesSubclassExcludesUnrelated()
@@ -7711,7 +7708,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             mids.add(((Number) result.next().getProperty("mid")).longValue());
           }
           Assert.assertEquals(
-              "loadSort parent filter should return base+subclass only: " + mids,
+              "Parent class filter should return base+subclass only: " + mids,
               java.util.List.of(11L, 10L, 2L, 1L),
               mids);
         }
@@ -7723,8 +7720,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   /**
-   * loadSortFromLinkBag: {@code {class: TestPost}} returns only subclass rows,
-   * not base TestMessage or unrelated TestNote.
+   * On the local-sort fallback, a concrete subclass filter returns only that
+   * subclass, not base-class or unrelated vertices from the same LinkBag.
    */
   @Test
   public void testIndexOrderedMatchLoadSortConcreteSubclassExcludesBase()
@@ -7752,7 +7749,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             mids.add(((Number) result.next().getProperty("mid")).longValue());
           }
           Assert.assertEquals(
-              "loadSort concrete subclass filter should return only posts: " + mids,
+              "Concrete subclass filter should return only posts: " + mids,
               java.util.List.of(11L, 10L),
               mids);
         }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -3091,7 +3091,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   /**
    * Large single-source setup: 1 person with 200 messages.
    * High edge count relative to index size should make the cost model choose
-   * indexScanFiltered over loadAllAndSort.
+   * indexScanFiltered over loadSortFromLinkBag.
    */
   private void initIndexOrderedMatchLargeData() {
     session.execute("CREATE CLASS TestPerson EXTENDS V").close();
@@ -4467,7 +4467,9 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
-  // Single-source RidSet overflow (ridSet exceeds MAX_RIDSET_SIZE) triggers loadAllAndSort fallback with correct results.
+  // Union RidSet overflow (union exceeds QUERY_PREFILTER_MAX_RIDSET_SIZE) makes the
+  // multi-source path drop the bitmap and stream from the source LinkBags instead;
+  // ORDER BY must still produce correctly sorted results.
   @Test
   public void testIndexOrderedMatchSingleSourceMaxRidSetOverflow() {
     initIndexOrderedMatchData(false);
@@ -5322,8 +5324,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   // True single-source via {rid:} syntax with MAX_SCAN=1 forces the runtime
-  // cost model to reject index scan, exercising the loadFromRidSet fallback path.
-  // Covers the false branch of shouldUseIndexScan → loadFromRidSet with its
+  // cost model to reject index scan, exercising the loadFromLinkBag fallback path.
+  // Covers the false branch of shouldUseIndexScan → loadFromLinkBag with its
   // stream pipeline (filter by targetFilter + targetClassName).
   @Test
   public void testIndexOrderedMatchTrueSingleSourceLoadFromRidSet() throws Exception {
@@ -5342,7 +5344,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         }
 
         // {rid:} → single-source. MAX_SCAN=1 → runtime cost model rejects
-        // → loadFromRidSet (unsorted). OrderByStep sorts with bounded heap.
+        // → loadFromLinkBag (unsorted). OrderByStep sorts with bounded heap.
         var query = "MATCH {class: TestPerson, as: p, rid: " + rid + "}"
             + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
             + "RETURN m.creationDate as cd, m.msgId as mid ORDER BY cd DESC LIMIT 5";
@@ -7229,8 +7231,8 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
-  // True single-source via {rid:} with target WHERE + loadFromRidSet path.
-  // MAX_SCAN=1 forces runtime cost rejection → loadFromRidSet with target filter.
+  // True single-source via {rid:} with target WHERE + loadFromLinkBag path.
+  // MAX_SCAN=1 forces runtime cost rejection → loadFromLinkBag with target filter.
   @Test
   public void testIndexOrderedMatchSingleSourceLoadFromRidSetWithTargetFilter()
       throws Exception {
@@ -7248,7 +7250,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
           rid = ridResult.next().getProperty("r").toString();
         }
 
-        // {rid:} → single-source. MAX_SCAN=1 → loadFromRidSet.
+        // {rid:} → single-source. MAX_SCAN=1 → loadFromLinkBag.
         // Target WHERE (msgId > 190) → matchesTargetFilter exercised in stream.
         var query = "MATCH {class: TestPerson, as: p, rid: " + rid + "}"
             + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m,"
@@ -7271,7 +7273,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
-  // Single-source cost model rejection (small data) exercises loadFromRidSet with
+  // Single-source cost model rejection (small data) exercises loadFromLinkBag with
   // target WHERE filter. Covers the filter branches in the stream pipeline.
   @Test
   public void testIndexOrderedMatchSingleSourceLoadFromRidSetWithFilter() throws Exception {
@@ -7280,7 +7282,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     try (var cfg = setIndexOrderedTestConfig()) {
       session.begin();
       // person1 has 10 messages. With setIndexOrderedTestConfig the cost model
-      // approves, so force loadFromRidSet by lowering MAX_SCAN to make cost model
+      // approves, so force loadFromLinkBag by lowering MAX_SCAN to make cost model
       // prefer direct load over index scan at runtime.
       var oldMaxScan = GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.getValue();
       GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(1);
@@ -7292,7 +7294,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
                 + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 3";
         try (var result = session.query(query)) {
           // Plan may or may not use INDEX ORDERED MATCH depending on plan-time.
-          // If it does, runtime cost model rejects → loadFromRidSet path.
+          // If it does, runtime cost model rejects → loadFromLinkBag path.
           // Either way, results must be correct.
           var mids = new java.util.ArrayList<Long>();
           while (result.hasNext()) {
@@ -7707,9 +7709,9 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   }
 
   // =====================================================================
-  // loadSortFromRidSet coverage: single-source with downstream edges +
+  // loadSortFromLinkBag coverage: single-source with downstream edges +
   // LIMIT triggers local sort fallback when cost model rejects index scan.
-  // Exercises: loadSortFromRidSet, sortByOrderProperty (including null
+  // Exercises: loadSortFromLinkBag, sortByOrderProperty (including null
   // handling for both-null, va-null, vb-null branches).
   // =====================================================================
 
@@ -7773,14 +7775,14 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   /**
    * Single-source 3-hop pattern: the cost model rejects index scan (MAX_SCAN=1)
    * but downstream edges exist (msg→reply) and LIMIT is present, so the step
-   * falls into the loadSortFromRidSet path — loads all targets from LinkBag,
+   * falls into the loadSortFromLinkBag path — loads all targets from LinkBag,
    * sorts locally by creationDate, and emits as a pre-sorted stream.
    *
    * <p>Includes null creationDate values to exercise sortByOrderProperty null
    * handling: both-null, va-null, and vb-null branches in the comparator.
    *
-   * <p>Covers: processUpstreamRow lines 171-178 (downstreamEdges+LIMIT branch),
-   * loadSortFromRidSet lines 222-243, sortByOrderProperty lines 274-292.
+   * <p>Covers the downstream-edges-plus-LIMIT branch of processUpstreamRow,
+   * loadSortFromLinkBag, and sortByOrderProperty.
    */
   @Test
   public void testIndexOrderedMatchLoadSortFromRidSetWithDownstreamEdges()
@@ -7789,7 +7791,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
 
     // Use setIndexOrderedTestConfig to lower MIN_LINKBAG so the planner
     // approves, then set MAX_SCAN=1 so the runtime cost model rejects
-    // index scan — forcing the loadSortFromRidSet fallback.
+    // index scan — forcing the loadSortFromLinkBag fallback.
     try (var cfg = setIndexOrderedTestConfig()) {
       var oldMaxScan = GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.getValue();
       GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(1L);
@@ -7797,7 +7799,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         session.begin();
         // 3-hop: person → message → reply. ORDER BY on intermediate alias 'm'.
         // The edge p→m is the optimized edge; m→r is a downstream edge.
-        // downstreamEdgeCount=1, limit=4 → loadSortFromRidSet path.
+        // downstreamEdgeCount=1, limit=4 → loadSortFromLinkBag path.
         var query =
             "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
                 + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m}"

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -6393,17 +6393,14 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   // Additional branch-coverage tests for IndexOrderedEdgeStep
   // =====================================================================
 
-  // Class inheritance: targetClassName filtering skips records of wrong class
-  // when multiple classes share the same index via a common superclass.
-  // Covers matchesTargetFilter branches: targetClassName != null, class mismatch,
-  // isSubClassOf check.
+  // Class filtering: targetClassName skips unrelated classes in the same LinkBag.
+  // Covers matchesTargetFilter via hasPolymorphicCollectionId (reject path).
   @Test
   public void testIndexOrderedMatchTargetClassInheritance() throws Exception {
     // Person1 has in_TEST_HAS_CREATOR edges pointing to both TestMessage and
     // TestComment vertices. The index is on TestMessage.creationDate. The
     // MATCH query targets {class: TestMessage} — TestComment records in the
     // LinkBag are loaded but fail targetClassName check in matchesTargetFilter.
-    // This exercises the class mismatch branch (lines 873, 882-883).
     session.execute("CREATE CLASS TestPerson EXTENDS V").close();
     session.execute("CREATE CLASS TestMessage EXTENDS V").close();
     session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
@@ -6474,6 +6471,151 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         }
         // DESC order: 100, 99, 98, 97, 96
         Assert.assertEquals(100L, (long) mids.get(0));
+      }
+      session.commit();
+    }
+  }
+
+  /**
+   * Parent class constraint must accept subclass vertices: TestPost EXTENDS
+   * TestMessage linked on the same edge; {@code {class: TestMessage}} returns
+   * both base messages and posts (polymorphic include via
+   * {@code hasPolymorphicCollectionId}).
+   */
+  @Test
+  public void testIndexOrderedMatchTargetClassIncludesSubclass() throws Exception {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    // Enough base + subclass rows for the plan-time cost model to approve
+    // index-ordered MATCH (same scale as testIndexOrderedMatchTargetClassInheritance).
+    for (var i = 1; i <= 50; i++) {
+      session.execute(
+          "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 "
+              + String.format("%02d", i / 60) + ":"
+              + String.format("%02d", i % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    for (var i = 100; i <= 149; i++) {
+      session.execute(
+          "CREATE VERTEX TestPost SET creationDate = '2025-02-01 "
+              + String.format("%02d", (i - 100) / 60) + ":"
+              + String.format("%02d", (i - 100) % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    session.commit();
+
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      var query =
+          "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+              + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
+              + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 5";
+      try (var result = session.query(query)) {
+        var plan = getPlan(result);
+        Assert.assertTrue(
+            "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+
+        var mids = new java.util.ArrayList<Long>();
+        while (result.hasNext()) {
+          mids.add(((Number) result.next().getProperty("mid")).longValue());
+        }
+        // Posts are dated February (after January base messages) → top-5 are posts
+        Assert.assertEquals(
+            "Parent class constraint should include subclass posts first: " + mids,
+            java.util.List.of(149L, 148L, 147L, 146L, 145L),
+            mids);
+      }
+      session.commit();
+    }
+  }
+
+  /**
+   * Concrete subclass constraint must reject base-class siblings: {@code {class:
+   * TestPost}} returns only posts, not base TestMessage rows on the same LinkBag.
+   */
+  @Test
+  public void testIndexOrderedMatchTargetClassConcreteSubclassExcludesBase()
+      throws Exception {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    for (var i = 1; i <= 50; i++) {
+      session.execute(
+          "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 "
+              + String.format("%02d", i / 60) + ":"
+              + String.format("%02d", i % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    for (var i = 100; i <= 149; i++) {
+      session.execute(
+          "CREATE VERTEX TestPost SET creationDate = '2025-02-01 "
+              + String.format("%02d", (i - 100) / 60) + ":"
+              + String.format("%02d", (i - 100) % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    session.commit();
+
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      var query =
+          "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+              + ".in('TEST_HAS_CREATOR'){class: TestPost, as: m} "
+              + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 5";
+      try (var result = session.query(query)) {
+        var plan = getPlan(result);
+        Assert.assertTrue(
+            "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+
+        var mids = new java.util.ArrayList<Long>();
+        while (result.hasNext()) {
+          mids.add(((Number) result.next().getProperty("mid")).longValue());
+        }
+        Assert.assertEquals(
+            "Concrete subclass constraint should return only posts: " + mids,
+            java.util.List.of(149L, 148L, 147L, 146L, 145L),
+            mids);
+        for (var mid : mids) {
+          Assert.assertTrue(
+              "Base TestMessage rows (1..50) must be excluded, got: " + mid,
+              mid >= 100);
+        }
       }
       session.commit();
     }
@@ -7451,6 +7593,168 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
           Assert.assertNull("Second result should have NULL cd (nulls first in ASC)", cds.get(1));
           Assert.assertNotNull("Third result should have non-NULL cd", cds.get(2));
           Assert.assertNotNull("Fourth result should have non-NULL cd", cds.get(3));
+        }
+        session.commit();
+      } finally {
+        GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(oldMaxScan);
+      }
+    }
+  }
+
+  /**
+   * Schema for loadSort polymorphic target tests: base TestMessage, subclass
+   * TestPost, unrelated TestNote on the same LinkBag; each has a TestReply so
+   * MAX_SCAN=1 + LIMIT forces {@code loadSortFromLinkBag}.
+   */
+  private void initLoadSortPolymorphicTargetData() {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestPerson.name STRING").close();
+    session.execute("CREATE INDEX TestPerson.name ON TestPerson(name) UNIQUE").close();
+
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.execute("CREATE CLASS TestNote EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestNote.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestNote.noteId LONG").close();
+
+    session.execute("CREATE CLASS TestReply EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestReply.content STRING").close();
+    session.execute("CREATE CLASS TEST_REPLY_OF EXTENDS E").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+
+    // Base messages: msgId 1..2 (Jan 1..2)
+    for (var i = 1; i <= 2; i++) {
+      session.execute(
+          "CREATE VERTEX TestMessage SET msgId = " + i
+              + ", creationDate = '2025-01-" + String.format("%02d", i) + " 00:00:00'")
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = "
+              + i + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+      session.execute(
+          "CREATE VERTEX TestReply SET content = 'reply-msg-" + i + "'").close();
+      session.execute(
+          "CREATE EDGE TEST_REPLY_OF FROM (SELECT FROM TestReply WHERE content = 'reply-msg-"
+              + i + "') TO (SELECT FROM TestMessage WHERE msgId = " + i + ")")
+          .close();
+    }
+
+    // Subclass posts: msgId 10..11 (Jan 10..11) — must match {class: TestMessage}
+    for (var i = 10; i <= 11; i++) {
+      session.execute(
+          "CREATE VERTEX TestPost SET msgId = " + i
+              + ", creationDate = '2025-01-" + String.format("%02d", i) + " 00:00:00'")
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = "
+              + i + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+      session.execute(
+          "CREATE VERTEX TestReply SET content = 'reply-post-" + i + "'").close();
+      session.execute(
+          "CREATE EDGE TEST_REPLY_OF FROM (SELECT FROM TestReply WHERE content = 'reply-post-"
+              + i + "') TO (SELECT FROM TestPost WHERE msgId = " + i + ")")
+          .close();
+    }
+
+    // Unrelated notes on the same LinkBag — must never match Message/Post class filters
+    for (var i = 100; i <= 101; i++) {
+      session.execute(
+          "CREATE VERTEX TestNote SET noteId = " + i
+              + ", creationDate = '2025-02-01 00:00:00'")
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestNote WHERE noteId = "
+              + i + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    session.commit();
+  }
+
+  /**
+   * loadSortFromLinkBag: {@code {class: TestMessage}} includes TestPost subclass
+   * RIDs and excludes unrelated TestNote RIDs on the same LinkBag.
+   */
+  @Test
+  public void testIndexOrderedMatchLoadSortIncludesSubclassExcludesUnrelated()
+      throws Exception {
+    initLoadSortPolymorphicTargetData();
+
+    try (var cfg = setIndexOrderedTestConfig()) {
+      var oldMaxScan = GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.getValue();
+      GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(1L);
+      try {
+        session.begin();
+        var query =
+            "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+                + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m}"
+                + ".in('TEST_REPLY_OF'){class: TestReply, as: r} "
+                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 4";
+        try (var result = session.query(query)) {
+          var plan = getPlan(result);
+          Assert.assertTrue(
+              "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+              plan.contains("INDEX ORDERED MATCH"));
+
+          var mids = new java.util.ArrayList<Long>();
+          while (result.hasNext()) {
+            mids.add(((Number) result.next().getProperty("mid")).longValue());
+          }
+          Assert.assertEquals(
+              "loadSort parent filter should return base+subclass only: " + mids,
+              java.util.List.of(11L, 10L, 2L, 1L),
+              mids);
+        }
+        session.commit();
+      } finally {
+        GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(oldMaxScan);
+      }
+    }
+  }
+
+  /**
+   * loadSortFromLinkBag: {@code {class: TestPost}} returns only subclass rows,
+   * not base TestMessage or unrelated TestNote.
+   */
+  @Test
+  public void testIndexOrderedMatchLoadSortConcreteSubclassExcludesBase()
+      throws Exception {
+    initLoadSortPolymorphicTargetData();
+
+    try (var cfg = setIndexOrderedTestConfig()) {
+      var oldMaxScan = GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.getValue();
+      GlobalConfiguration.QUERY_INDEX_ORDERED_MAX_SCAN.setValue(1L);
+      try {
+        session.begin();
+        var query =
+            "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+                + ".in('TEST_HAS_CREATOR'){class: TestPost, as: m}"
+                + ".in('TEST_REPLY_OF'){class: TestReply, as: r} "
+                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 4";
+        try (var result = session.query(query)) {
+          var plan = getPlan(result);
+          Assert.assertTrue(
+              "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+              plan.contains("INDEX ORDERED MATCH"));
+
+          var mids = new java.util.ArrayList<Long>();
+          while (result.hasNext()) {
+            mids.add(((Number) result.next().getProperty("mid")).longValue());
+          }
+          Assert.assertEquals(
+              "loadSort concrete subclass filter should return only posts: " + mids,
+              java.util.List.of(11L, 10L),
+              mids);
         }
         session.commit();
       } finally {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -12,6 +12,7 @@ import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.match.IndexOrderedEdgeStep;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.junit.Assert;
@@ -7075,6 +7076,206 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
       mids.add(((Number) result.next().getProperty("mid")).longValue());
     }
     return mids;
+  }
+
+  /**
+   * The LDBC IS2 query, verbatim from {@code jmh-ldbc/.../ldbc-queries/IS2.sql}
+   * with the parameters inlined. Kept as a constant so a drift between this test
+   * and the benchmarked query is a visible edit rather than a silent divergence.
+   */
+  private static final String LDBC_IS2_QUERY =
+      "MATCH {class: LdbcPerson, as: p, where: (id = 1)}"
+          + "  .in('LDBC_HAS_CREATOR'){as: message}"
+          + "  .out('LDBC_REPLY_OF'){while: ($currentMatch.@class = 'LdbcComment'),"
+          + "                        where: (@class = 'LdbcPost'), as: originalPost}"
+          + "  .out('LDBC_HAS_CREATOR'){as: author}"
+          + " RETURN message.id as messageId,"
+          + "  coalesce(message.imageFile, message.content) as messageContent,"
+          + "  message.creationDate as messageCreationDate,"
+          + "  originalPost.id as originalPostId,"
+          + "  author.id as originalPostAuthorId,"
+          + "  author.firstName as originalPostAuthorFirstName,"
+          + "  author.lastName as originalPostAuthorLastName"
+          + " ORDER BY messageCreationDate DESC"
+          + " LIMIT 10";
+
+  /**
+   * End-to-end regression for the LDBC IS2 query shape — the benchmark this
+   * optimization was built for.
+   *
+   * <p>The JMH harness hands its rows to JMH and never inspects them, and the
+   * benchmark workflows run no correctness step, so a change that wrongly
+   * discarded matching rows would register there as a throughput improvement.
+   * This test pins the rows instead: it runs IS2 with the optimization enabled
+   * and again with it disabled, and requires both to return the same result.
+   *
+   * <p>The schema mirrors {@code ldbc-schema.sql}: LdbcPost and LdbcComment both
+   * extend LdbcMessage, the ORDER BY index sits on the parent
+   * LdbcMessage.creationDate, and LDBC_HAS_CREATOR declares its endpoints as
+   * LINK properties. Those endpoint declarations matter — the {@code {as:
+   * message}} pattern in IS2 carries no {@code class:} constraint, so the
+   * planner infers LdbcMessage for it from the edge definition. Reproducing that
+   * inference is the point: the target class filter then has to accept both
+   * subclasses, which is exactly the behaviour the optimization changed.
+   */
+  @Test
+  public void testIndexOrderedMatchLdbcIs2ShapeMatchesClassic() throws Exception {
+    initLdbcIs2ShapeData();
+
+    List<Map<String, Object>> optimized;
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      try (var result = session.query(LDBC_IS2_QUERY)) {
+        var plan = getPlan(result);
+        Assert.assertTrue(
+            "IS2 should use INDEX ORDERED MATCH, but plan was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+        optimized = collectRows(result);
+      }
+      session.commit();
+    }
+
+    // The reference run drops the ORDER BY index rather than tuning a threshold.
+    // QUERY_INDEX_ORDERED_MIN_LINKBAG only forces the step onto its load-sort
+    // path, so it cannot produce a plan free of IndexOrderedEdgeStep; without an
+    // index on the sort property the planner has nothing to match and falls back
+    // to classic MATCH plus a full sort. The data is untouched, so the two runs
+    // remain directly comparable.
+    session.execute("DROP INDEX LdbcMessage.creationDate").close();
+
+    session.begin();
+    List<Map<String, Object>> classic;
+    try (var result = session.query(LDBC_IS2_QUERY)) {
+      var plan = getPlan(result);
+      Assert.assertFalse(
+          "Reference run must not use the optimization, but plan was:\n" + plan,
+          plan.contains("INDEX ORDERED MATCH"));
+      classic = collectRows(result);
+    }
+    session.commit();
+    Assert.assertEquals(
+        "IS2 must return identical rows with and without the optimization",
+        classic, optimized);
+
+    // Comparing two runs proves agreement but not that either returned anything,
+    // so pin the expected content too. The newest ten messages are the level-2
+    // comments 60..51; each resolves through two REPLY_OF hops to post id-40.
+    Assert.assertEquals("IS2 must fill its LIMIT", 10, optimized.size());
+    var messageIds = new java.util.ArrayList<Long>();
+    var originalPostIds = new java.util.ArrayList<Long>();
+    for (var row : optimized) {
+      messageIds.add(((Number) row.get("messageId")).longValue());
+      originalPostIds.add(((Number) row.get("originalPostId")).longValue());
+      Assert.assertEquals("author must be the single curated person",
+          1L, ((Number) row.get("originalPostAuthorId")).longValue());
+      Assert.assertEquals("coalesce must fall through to content",
+          "msg-" + row.get("messageId"), row.get("messageContent"));
+    }
+    Assert.assertEquals(expectedDescending(60, 51), messageIds);
+    Assert.assertEquals(expectedDescending(20, 11), originalPostIds);
+  }
+
+  /**
+   * Collects every projected column of every row as a name-keyed map, preserving
+   * row order. Keyed by name rather than position because
+   * {@code getPropertyNames()} does not promise projection order, and sorted so
+   * a mismatch prints readably.
+   */
+  private static List<Map<String, Object>> collectRows(ResultSet result) {
+    var rows = new java.util.ArrayList<Map<String, Object>>();
+    while (result.hasNext()) {
+      var row = result.next();
+      var values = new java.util.TreeMap<String, Object>();
+      for (var name : row.getPropertyNames()) {
+        values.put(name, row.getProperty(name));
+      }
+      rows.add(values);
+    }
+    return rows;
+  }
+
+  /**
+   * Builds a miniature LDBC graph for the IS2 shape: one person owning 20 posts,
+   * 20 comments replying to those posts, and 20 further comments replying to
+   * those comments. The two comment levels give the recursive REPLY_OF hop
+   * something to walk — the newest messages resolve to their original post
+   * through two hops, not one.
+   *
+   * <p>creationDate increases with id, so ORDER BY creationDate DESC is a total
+   * order and the expected top-10 is unambiguous.
+   */
+  private void initLdbcIs2ShapeData() {
+    session.execute("CREATE CLASS LdbcPerson EXTENDS V").close();
+    session.execute("CREATE PROPERTY LdbcPerson.id LONG").close();
+    session.execute("CREATE PROPERTY LdbcPerson.firstName STRING").close();
+    session.execute("CREATE PROPERTY LdbcPerson.lastName STRING").close();
+
+    session.execute("CREATE CLASS LdbcMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY LdbcMessage.id LONG").close();
+    session.execute("CREATE PROPERTY LdbcMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY LdbcMessage.content STRING").close();
+    session.execute("CREATE CLASS LdbcPost EXTENDS LdbcMessage").close();
+    // Posts carry imageFile in LDBC; left unset so the query's coalesce falls
+    // through to content, as it does for most real rows.
+    session.execute("CREATE PROPERTY LdbcPost.imageFile STRING").close();
+    session.execute("CREATE CLASS LdbcComment EXTENDS LdbcMessage").close();
+
+    // The LINK endpoint declarations are what let the planner infer the class of
+    // the unconstrained {as: message} alias.
+    session.execute("CREATE CLASS LDBC_HAS_CREATOR EXTENDS E").close();
+    session.execute("CREATE PROPERTY LDBC_HAS_CREATOR.out LINK LdbcMessage").close();
+    session.execute("CREATE PROPERTY LDBC_HAS_CREATOR.in LINK LdbcPerson").close();
+    session.execute("CREATE CLASS LDBC_REPLY_OF EXTENDS E").close();
+    session.execute("CREATE PROPERTY LDBC_REPLY_OF.out LINK LdbcComment").close();
+    session.execute("CREATE PROPERTY LDBC_REPLY_OF.in LINK LdbcMessage").close();
+
+    session.execute("CREATE INDEX LdbcPerson.id ON LdbcPerson(id) UNIQUE").close();
+    session.execute(
+        "CREATE INDEX LdbcMessage.creationDate ON LdbcMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute(
+        "CREATE VERTEX LdbcPerson SET id = 1, firstName = 'Ada', lastName = 'Lovelace'")
+        .close();
+    for (var id = 1; id <= 20; id++) {
+      createIs2Message("LdbcPost", id);
+    }
+    // Level-1 comments reply to the post 20 ids below them.
+    for (var id = 21; id <= 40; id++) {
+      createIs2Message("LdbcComment", id);
+      createIs2Reply(id, id - 20);
+    }
+    // Level-2 comments reply to the level-1 comment 20 ids below them, so their
+    // original post is two hops away.
+    for (var id = 41; id <= 60; id++) {
+      createIs2Message("LdbcComment", id);
+      createIs2Reply(id, id - 20);
+    }
+    session.commit();
+  }
+
+  /** Creates one IS2 message of the given class and links it to the person. */
+  private void createIs2Message(String className, int id) {
+    session.execute(
+        "CREATE VERTEX " + className + " SET id = " + id
+            + ", content = 'msg-" + id + "'"
+            + ", creationDate = '2025-01-01 " + String.format("%02d", id / 60)
+            + ":" + String.format("%02d", id % 60) + ":00'")
+        .close();
+    session.execute(
+        "CREATE EDGE LDBC_HAS_CREATOR"
+            + " FROM (SELECT FROM LdbcMessage WHERE id = " + id + ")"
+            + " TO (SELECT FROM LdbcPerson WHERE id = 1)")
+        .close();
+  }
+
+  private void createIs2Reply(int fromId, int toId) {
+    session.execute(
+        "CREATE EDGE LDBC_REPLY_OF"
+            + " FROM (SELECT FROM LdbcMessage WHERE id = " + fromId + ")"
+            + " TO (SELECT FROM LdbcMessage WHERE id = " + toId + ")")
+        .close();
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -3523,6 +3523,110 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
+  /**
+   * Sparse multi-source setup: 5 persons with 20 messages each (100 edges into
+   * the optimized traversal) plus 300 orphan messages that sit in the same index
+   * without a creator edge. Connected messages take every fourth date slot, so
+   * the reachable fraction of the index is a uniform 1/4 — the density band
+   * where a union-RidSet index scan is cheaper than loading all 100 targets to
+   * sort them locally, and cheaper than a global scan that would load every
+   * fourth-of-a-match entry.
+   */
+  private void initIndexOrderedMatchSparseMultiSourceData() {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    // Connected messages: msgId 1..100 on date slots 4, 8, ... 400.
+    // person1 owns msgId 1..20, person5 owns msgId 81..100, so the newest
+    // connected messages all belong to person5.
+    var msgId = 0;
+    for (var p = 1; p <= 5; p++) {
+      session.execute("CREATE VERTEX TestPerson SET name = 'person" + p + "'").close();
+      for (var d = 1; d <= 20; d++) {
+        msgId++;
+        session.execute(
+            "CREATE VERTEX TestMessage SET creationDate = '"
+                + dateForSlot(msgId * 4) + "', msgId = " + msgId)
+            .close();
+        session.execute(
+            "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = "
+                + msgId + ") TO (SELECT FROM TestPerson WHERE name = 'person" + p + "')")
+            .close();
+      }
+    }
+    // Orphan messages fill the remaining three of every four date slots. They
+    // enlarge the index without being reachable through the edge, which is what
+    // pushes density down to 1/4.
+    var orphanId = 1000;
+    for (var slot = 1; slot <= 400; slot++) {
+      if (slot % 4 == 0) {
+        continue;
+      }
+      orphanId++;
+      session.execute(
+          "CREATE VERTEX TestMessage SET creationDate = '"
+              + dateForSlot(slot) + "', msgId = " + orphanId)
+          .close();
+    }
+    session.commit();
+  }
+
+  /** Maps a 1-based date slot to a distinct datetime that grows with the slot. */
+  private static String dateForSlot(int slot) {
+    return java.time.LocalDate.of(2025, 1, 1).plusDays(slot - 1L) + " 00:00:00";
+  }
+
+  /**
+   * Sparse FILTERED_BOUND traversal (WHERE on the source plus the source alias in
+   * RETURN) at 1/4 density: the cost model must pick the union-RidSet index scan
+   * rather than loading and sorting all 100 targets. Asserts the runtime path so
+   * a future cost-model change that silently stops scanning shows up here, and
+   * asserts the bound source alias so the reverse-edge lookup that this path
+   * relies on is checked at the same time.
+   */
+  @Test
+  public void testIndexOrderedMatchFilteredBoundUnionScan() throws Exception {
+    initIndexOrderedMatchSparseMultiSourceData();
+
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      var query =
+          "MATCH {class: TestPerson, as: p, where: (name LIKE 'person%')}"
+              + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
+              + "RETURN p.name as pname, m.msgId as mid"
+              + " ORDER BY m.creationDate DESC LIMIT 5";
+      try (var result = session.query(query)) {
+        var plan = getPlan(result);
+        Assert.assertTrue(
+            "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+        Assert.assertTrue(
+            "Plan should use FILTERED_BOUND mode, but was:\n" + plan,
+            plan.contains("FILTERED_BOUND"));
+
+        var mids = new java.util.ArrayList<Long>();
+        var names = new HashSet<String>();
+        while (result.hasNext()) {
+          var row = result.next();
+          mids.add(((Number) row.getProperty("mid")).longValue());
+          names.add(row.getProperty("pname"));
+        }
+        assertRuntimePath(result, IndexOrderedEdgeStep.RuntimePath.UNION_SCAN);
+        Assert.assertEquals(List.of(100L, 99L, 98L, 97L, 96L), mids);
+        Assert.assertEquals(
+            "Newest connected messages all belong to person5", Set.of("person5"), names);
+      }
+      session.commit();
+    }
+  }
+
   // Multi-source FILTERED_UNBOUND mode with WHERE filter and source alias NOT in RETURN uses union-RidSet-only mode.
   @Test
   public void testIndexOrderedMatchMultiSourceFilteredUnbound() throws Exception {
@@ -4876,46 +4980,49 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
-  // FILTERED_BOUND union overflow (RidSet exceeds MAX_RIDSET_SIZE during union build) falls back to loadFromSourcesUnsorted.
+  /**
+   * FILTERED_BOUND union overflow: the RidSet cap is set below the number of
+   * edges being unioned, so the bitmap is abandoned mid-build and the step
+   * streams the source LinkBags unsorted instead. The fallback clears
+   * PRE_SORTED, so OrderByStep does the sorting and the order must match the
+   * union-scan run in {@link #testIndexOrderedMatchFilteredBoundUnionScan}.
+   *
+   * <p>Uses the sparse (1/4 density) data on purpose: at density 1 the cost
+   * model picks a global scan and never builds a union RidSet, so the overflow
+   * branch would not be reached at all.
+   */
   @Test
-  public void testIndexOrderedMatchFilteredBoundUnionOverflow() {
-    initIndexOrderedMatchMultiSourceData();
+  public void testIndexOrderedMatchFilteredBoundUnionOverflow() throws Exception {
+    initIndexOrderedMatchSparseMultiSourceData();
 
-    var oldMaxRidSet = GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.getValue();
-    var oldMinLinkBag = GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.getValue();
-    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(3);
-    GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(1);
-    try {
-      session.begin();
-      // FILTERED_BOUND + cost model approves → tries UNION_RIDSET_SCAN →
-      // union exceeds maxRidSetSize(3) → overflow → loadFromSourcesUnsorted
-      var query =
-          "MATCH {class: TestPerson, as: p, where: (name LIKE 'person%')}"
-              + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
-              + "RETURN p.name as pname, m.creationDate as cd"
-              + " ORDER BY cd DESC LIMIT 5";
-      try (var result = session.query(query)) {
-        var plan = getPlan(result);
-        Assert.assertTrue(
-            "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
-            plan.contains("INDEX ORDERED MATCH"));
-
-        // Overflow → loadFromSourcesUnsorted → OrderByStep sorts
-        var days = new java.util.ArrayList<Integer>();
-        while (result.hasNext()) {
-          days.add(dayOfMonth(result.next().getProperty("cd")));
-        }
-        Assert.assertEquals("Should have 5 results: " + days, 5, days.size());
-        for (var i = 0; i < days.size() - 1; i++) {
+    try (var cfg = setIndexOrderedTestConfig()) {
+      var oldMaxRidSet = GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.getValue();
+      GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(10);
+      try {
+        session.begin();
+        var query =
+            "MATCH {class: TestPerson, as: p, where: (name LIKE 'person%')}"
+                + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
+                + "RETURN p.name as pname, m.msgId as mid"
+                + " ORDER BY m.creationDate DESC LIMIT 5";
+        try (var result = session.query(query)) {
+          var plan = getPlan(result);
           Assert.assertTrue(
-              "Results should be in DESC order after fallback: " + days,
-              days.get(i) >= days.get(i + 1));
+              "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
+              plan.contains("INDEX ORDERED MATCH"));
+
+          var mids = new java.util.ArrayList<Long>();
+          while (result.hasNext()) {
+            mids.add(((Number) result.next().getProperty("mid")).longValue());
+          }
+          assertRuntimePath(
+              result, IndexOrderedEdgeStep.RuntimePath.LOAD_UNSORTED_MULTI);
+          Assert.assertEquals(List.of(100L, 99L, 98L, 97L, 96L), mids);
         }
+        session.commit();
+      } finally {
+        GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(oldMaxRidSet);
       }
-      session.commit();
-    } finally {
-      GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(oldMaxRidSet);
-      GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(oldMinLinkBag);
     }
   }
 
@@ -6457,13 +6564,21 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
   // Additional branch-coverage tests for IndexOrderedEdgeStep
   // =====================================================================
 
-  // Class filter rejects unrelated types that share the source LinkBag.
+  /**
+   * A LinkBag mixing TestMessage and TestComment must yield only messages for
+   * {@code {class: TestMessage}}.
+   *
+   * <p>On this single-hop shape the cost model picks the index scan, and the
+   * index on TestMessage.creationDate holds no TestComment entries, so the scan
+   * itself is what keeps the comments out — the class filter never sees them.
+   * The test therefore asserts the scan path explicitly rather than claiming to
+   * exercise the filter. Rejection by the class filter is covered on the
+   * LinkBag-driven paths by
+   * {@link #testIndexOrderedMatchLoadSortIncludesSubclassExcludesUnrelated} and
+   * {@link #testIndexOrderedMatchLoadSortConcreteSubclassExcludesBase}.
+   */
   @Test
   public void testIndexOrderedMatchTargetClassInheritance() throws Exception {
-    // Person1 has in_TEST_HAS_CREATOR edges pointing to both TestMessage and
-    // TestComment vertices. The index is on TestMessage.creationDate. The
-    // MATCH query targets {class: TestMessage} — TestComment records in the
-    // LinkBag must be dropped by the target class filter.
     session.execute("CREATE CLASS TestPerson EXTENDS V").close();
     session.execute("CREATE CLASS TestMessage EXTENDS V").close();
     session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
@@ -6506,11 +6621,25 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
     session.commit();
 
+    // Control assertion on the data itself: without a class constraint the same
+    // traversal reaches all 150 linked vertices. Without this, an assertion that
+    // "only messages came back" could pass simply because the comments were
+    // never reachable through the edge.
+    session.begin();
+    try (var result = session.query(
+        "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+            + ".in('TEST_HAS_CREATOR'){as: m} RETURN m.msgId as mid")) {
+      Assert.assertEquals(
+          "Both messages and comments must share person1's LinkBag",
+          150, collectNullableMids(result).size());
+    }
+    session.commit();
+
     try (var cfg = setIndexOrderedTestConfig()) {
       session.begin();
-      // Target class = TestMessage → only TestMessage records should be returned.
-      // Person1's LinkBag has both TestMessage and TestComment RIDs; when loading,
-      // TestComment records fail the targetClassName check.
+      // The comments are dated February, newer than every message, so under a DESC
+      // sort any comment reaching the output would take a slot in this window and
+      // surface as a null msgId.
       var query =
           "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
               + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
@@ -6521,22 +6650,23 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
             plan.contains("INDEX ORDERED MATCH"));
 
-        var mids = new java.util.ArrayList<Long>();
-        while (result.hasNext()) {
-          mids.add(((Number) result.next().getProperty("mid")).longValue());
-        }
-        Assert.assertEquals("Should have 5 results (only TestMessage)", 5, mids.size());
-        // All returned records must be TestMessage (msgId 1..100)
-        for (var mid : mids) {
-          Assert.assertTrue(
-              "Only TestMessage (1..100) should be returned, got: " + mid,
-              mid >= 1 && mid <= 100);
-        }
-        // DESC order: 100, 99, 98, 97, 96
-        Assert.assertEquals(100L, (long) mids.get(0));
+        var mids = collectNullableMids(result);
+        assertIndexScanRuntimePath(result);
+        Assert.assertEquals(
+            "Only TestMessage rows may reach the output: " + mids,
+            expectedDescending(100, 96), mids);
       }
       session.commit();
     }
+  }
+
+  /** Builds the inclusive descending list {@code [from, from-1, ... to]}. */
+  private static java.util.List<Long> expectedDescending(long from, long to) {
+    var expected = new java.util.ArrayList<Long>();
+    for (var v = from; v >= to; v--) {
+      expected.add(v);
+    }
+    return expected;
   }
 
   /**
@@ -6595,15 +6725,12 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
             plan.contains("INDEX ORDERED MATCH"));
 
-        var mids = new java.util.ArrayList<Long>();
-        while (result.hasNext()) {
-          mids.add(((Number) result.next().getProperty("mid")).longValue());
-        }
-        // Posts are dated February (after January base messages) → top-5 are posts
+        var mids = collectNullableMids(result);
+        // Posts are the newest rows, so a parent-class filter that wrongly rejected
+        // the subclass would fill this window with January base messages instead.
         Assert.assertEquals(
-            "Parent class constraint should include subclass posts first: " + mids,
-            java.util.List.of(149L, 148L, 147L, 146L, 145L),
-            mids);
+            "Parent class constraint should include subclass posts: " + mids,
+            expectedDescending(149, 145), mids);
       }
       session.commit();
     }
@@ -6628,9 +6755,13 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
 
     session.begin();
     session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    // Base messages are dated March — deliberately NEWER than the posts. Under a
+    // DESC sort a filter that failed to reject them would put them at the head of
+    // the result, which the assertion below catches. Dating them older would let
+    // the sort hide the leak past the LIMIT.
     for (var i = 1; i <= 50; i++) {
       session.execute(
-          "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 "
+          "CREATE VERTEX TestMessage SET creationDate = '2025-03-01 "
               + String.format("%02d", i / 60) + ":"
               + String.format("%02d", i % 60) + ":00', msgId = " + i)
           .close();
@@ -6664,19 +6795,12 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
             plan.contains("INDEX ORDERED MATCH"));
 
-        var mids = new java.util.ArrayList<Long>();
-        while (result.hasNext()) {
-          mids.add(((Number) result.next().getProperty("mid")).longValue());
-        }
+        var mids = collectNullableMids(result);
+        // Base messages are the newest rows, so a filter that failed to reject
+        // them would fill this whole window with msgIds 50..46.
         Assert.assertEquals(
             "Concrete subclass constraint should return only posts: " + mids,
-            java.util.List.of(149L, 148L, 147L, 146L, 145L),
-            mids);
-        for (var mid : mids) {
-          Assert.assertTrue(
-              "Base TestMessage rows (1..50) must be excluded, got: " + mid,
-              mid >= 100);
-        }
+            expectedDescending(149, 145), mids);
       }
       session.commit();
     }
@@ -6951,6 +7075,38 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
       mids.add(((Number) result.next().getProperty("mid")).longValue());
     }
     return mids;
+  }
+
+  /**
+   * Collects {@code mid} for every row, mapping a missing property to null
+   * instead of throwing. Class-filter tests use this so a row that leaked past
+   * the filter (an unrelated type that has no {@code msgId}) is reported as a
+   * null in the assertion message rather than crashing the collection loop.
+   */
+  private static java.util.List<Long> collectNullableMids(ResultSet result) {
+    var mids = new java.util.ArrayList<Long>();
+    while (result.hasNext()) {
+      Object mid = result.next().getProperty("mid");
+      mids.add(mid == null ? null : ((Number) mid).longValue());
+    }
+    return mids;
+  }
+
+  /**
+   * Asserts the step drove the traversal from the source LinkBag rather than
+   * from an index scan. Class-filter tests need this: on a scan path the index
+   * itself only holds entries of the indexed class, so unrelated types are
+   * excluded before the class filter ever sees them, and the test would pass
+   * with the filter removed.
+   */
+  private static void assertLinkBagRuntimePath(ResultSet result) {
+    var path = findIndexOrderedStep(result).getChosenRuntimePath();
+    Assert.assertTrue(
+        "Class filtering must be exercised on a LinkBag-driven path, got " + path
+            + ". Plan:\n" + result.getExecutionPlan().prettyPrint(0, 2),
+        path == IndexOrderedEdgeStep.RuntimePath.LOAD_SORT
+            || path == IndexOrderedEdgeStep.RuntimePath.LOAD_UNSORTED
+            || path == IndexOrderedEdgeStep.RuntimePath.LOAD_UNSORTED_MULTI);
   }
 
   // UNFILTERED_BOUND with class inheritance: reverse edge class check filters
@@ -8005,7 +8161,11 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
           .close();
     }
 
-    // Unrelated notes on the same LinkBag — must never match Message/Post class filters
+    // Unrelated notes on the same LinkBag — must never match Message/Post class
+    // filters. They are dated February, newer than every message and post, so a
+    // leak surfaces at the head of a DESC result. Each note also gets a reply, so
+    // the downstream TEST_REPLY_OF hop cannot quietly drop a leaked note and make
+    // the class filter look like it worked.
     for (var i = 100; i <= 101; i++) {
       session.execute(
           "CREATE VERTEX TestNote SET noteId = " + i
@@ -8014,6 +8174,13 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
       session.execute(
           "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestNote WHERE noteId = "
               + i + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+      session.execute(
+          "CREATE VERTEX TestReply SET content = 'reply-note-" + i + "'").close();
+      session.execute(
+          "CREATE EDGE TEST_REPLY_OF FROM (SELECT FROM TestReply WHERE content ="
+              + " 'reply-note-" + i + "') TO (SELECT FROM TestNote WHERE noteId = "
+              + i + ")")
           .close();
     }
     session.commit();
@@ -8037,17 +8204,17 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
                 + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m}"
                 + ".in('TEST_REPLY_OF'){class: TestReply, as: r} "
-                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 4";
+                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 10";
         try (var result = session.query(query)) {
           var plan = getPlan(result);
           Assert.assertTrue(
               "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
               plan.contains("INDEX ORDERED MATCH"));
 
-          var mids = new java.util.ArrayList<Long>();
-          while (result.hasNext()) {
-            mids.add(((Number) result.next().getProperty("mid")).longValue());
-          }
+          var mids = collectNullableMids(result);
+          assertLinkBagRuntimePath(result);
+          // The LIMIT exceeds the candidate count, so a leaked note would appear
+          // as a null at the head instead of being pushed out of the window.
           Assert.assertEquals(
               "Parent class filter should return base+subclass only: " + mids,
               java.util.List.of(11L, 10L, 2L, 1L),
@@ -8078,17 +8245,17 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
                 + ".in('TEST_HAS_CREATOR'){class: TestPost, as: m}"
                 + ".in('TEST_REPLY_OF'){class: TestReply, as: r} "
-                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 4";
+                + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 10";
         try (var result = session.query(query)) {
           var plan = getPlan(result);
           Assert.assertTrue(
               "Plan should use INDEX ORDERED MATCH, but was:\n" + plan,
               plan.contains("INDEX ORDERED MATCH"));
 
-          var mids = new java.util.ArrayList<Long>();
-          while (result.hasNext()) {
-            mids.add(((Number) result.next().getProperty("mid")).longValue());
-          }
+          var mids = collectNullableMids(result);
+          assertLinkBagRuntimePath(result);
+          // Notes (newest, now with replies of their own) and base messages must
+          // both be rejected, leaving exactly the two posts.
           Assert.assertEquals(
               "Concrete subclass filter should return only posts: " + mids,
               java.util.List.of(11L, 10L),

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -6,11 +6,14 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.query.BasicResult;
 import com.jetbrains.youtrackdb.internal.core.query.BasicResultSet;
+import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.match.IndexOrderedEdgeStep;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -3133,6 +3136,58 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     return plan.prettyPrint(0, 2);
   }
 
+  /**
+   * Finds the {@link IndexOrderedEdgeStep} in the plan after the query has
+   * started (so {@link IndexOrderedEdgeStep#getChosenRuntimePath()} is set).
+   */
+  private static IndexOrderedEdgeStep findIndexOrderedStep(ResultSet result) {
+    var plan = result.getExecutionPlan();
+    Assert.assertNotNull("Execution plan should be present", plan);
+    var found = findIndexOrderedStep(plan.getSteps());
+    Assert.assertNotNull(
+        "Expected an IndexOrderedEdgeStep in the plan:\n" + plan.prettyPrint(0, 2),
+        found);
+    return found;
+  }
+
+  @Nullable private static IndexOrderedEdgeStep findIndexOrderedStep(
+      List<ExecutionStep> steps) {
+    for (var step : steps) {
+      if (step instanceof IndexOrderedEdgeStep indexOrdered) {
+        return indexOrdered;
+      }
+      var nested = findIndexOrderedStep(step.getSubSteps());
+      if (nested != null) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  private static void assertRuntimePath(
+      ResultSet result, IndexOrderedEdgeStep.RuntimePath expected) {
+    var step = findIndexOrderedStep(result);
+    Assert.assertEquals(
+        "Unexpected index-ordered runtime path. Plan:\n"
+            + result.getExecutionPlan().prettyPrint(0, 2),
+        expected,
+        step.getChosenRuntimePath());
+  }
+
+  /**
+   * Asserts a real B-tree index scan ran (single-source RidSet scan, multi-source
+   * union scan, or unfiltered global scan) — not local load/sort.
+   */
+  private static void assertIndexScanRuntimePath(ResultSet result) {
+    var path = findIndexOrderedStep(result).getChosenRuntimePath();
+    Assert.assertTrue(
+        "Expected a real index-scan path, got " + path + ". Plan:\n"
+            + result.getExecutionPlan().prettyPrint(0, 2),
+        path == IndexOrderedEdgeStep.RuntimePath.INDEX_SCAN
+            || path == IndexOrderedEdgeStep.RuntimePath.UNION_SCAN
+            || path == IndexOrderedEdgeStep.RuntimePath.GLOBAL_SCAN);
+  }
+
   /** Sets index-ordered config to known test-safe values. Call restore in finally. */
   private AutoCloseable setIndexOrderedTestConfig() {
     var oldMinLinkBag = GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.getValue();
@@ -3633,6 +3688,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         while (result.hasNext()) {
           mids.add(((Number) result.next().getProperty("mid")).longValue());
         }
+        assertIndexScanRuntimePath(result);
         Assert.assertEquals("Should have 3 results", 3, mids.size());
         // The msgIds with latest timestamps should come first
         // All 3 should be from the highest msgId range (close to 200)
@@ -5248,6 +5304,12 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         while (result.hasNext()) {
           mids.add(((Number) result.next().getProperty("mid")).longValue());
         }
+        // Dense 200-edge LinkBag vs same-size index → true RidSet index scan.
+        assertRuntimePath(result, IndexOrderedEdgeStep.RuntimePath.INDEX_SCAN);
+        Assert.assertTrue(
+            "Plan should label the index-scan path, but was:\n"
+                + result.getExecutionPlan().prettyPrint(0, 2),
+            result.getExecutionPlan().prettyPrint(0, 2).contains("[index-scan]"));
         Assert.assertEquals("Should have 5 results: " + mids, 5, mids.size());
         Assert.assertEquals(200L, (long) mids.get(0));
         Assert.assertEquals(199L, (long) mids.get(1));
@@ -6618,6 +6680,277 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
     }
   }
 
+  /**
+   * Direct proof that the lock-friendly class check agrees with the old
+   * {@code getSchemaClass}/{@code isSubClassOf} predicate on every vertex in a
+   * mixed LinkBag (base, subclass, unrelated).
+   */
+  @Test
+  public void testIndexOrderedTargetClassCheckMatchesLegacyPredicate() {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TestNote EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestNote.noteId LONG").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    session.execute(
+        "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 00:00:00', msgId = 1")
+        .close();
+    session.execute(
+        "CREATE VERTEX TestPost SET creationDate = '2025-01-02 00:00:00', msgId = 2")
+        .close();
+    session.execute("CREATE VERTEX TestNote SET noteId = 3").close();
+    session.execute(
+        "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = 1)"
+            + " TO (SELECT FROM TestPerson WHERE name = 'person1')")
+        .close();
+    session.execute(
+        "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = 2)"
+            + " TO (SELECT FROM TestPerson WHERE name = 'person1')")
+        .close();
+    session.execute(
+        "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestNote WHERE noteId = 3)"
+            + " TO (SELECT FROM TestPerson WHERE name = 'person1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var schema = session.getMetadata().getImmutableSchemaSnapshot();
+    Assert.assertNotNull(schema);
+    var messageClass = schema.getClassInternal("TestMessage");
+    var postClass = schema.getClassInternal("TestPost");
+    Assert.assertNotNull(messageClass);
+    Assert.assertNotNull(postClass);
+
+    var checked = 0;
+    try (var rs = session.query(
+        "SELECT FROM (SELECT expand(in('TEST_HAS_CREATOR')) FROM TestPerson"
+            + " WHERE name = 'person1')")) {
+      while (rs.hasNext()) {
+        var entity = rs.next().asEntity();
+        var legacyMessage = legacyTargetClassMatches(entity, "TestMessage");
+        var legacyPost = legacyTargetClassMatches(entity, "TestPost");
+        var snapshotMessage =
+            messageClass.hasPolymorphicCollectionId(entity.getIdentity().getCollectionId());
+        var snapshotPost =
+            postClass.hasPolymorphicCollectionId(entity.getIdentity().getCollectionId());
+        Assert.assertEquals(
+            "TestMessage filter must match legacy predicate for " + entity.getIdentity(),
+            legacyMessage, snapshotMessage);
+        Assert.assertEquals(
+            "TestPost filter must match legacy predicate for " + entity.getIdentity(),
+            legacyPost, snapshotPost);
+        checked++;
+      }
+    }
+    Assert.assertEquals("Expected base + subclass + unrelated vertices", 3, checked);
+    session.commit();
+  }
+
+  /** Legacy class check used before the immutable-snapshot collection-id path. */
+  private static boolean legacyTargetClassMatches(Entity entity, String targetClassName) {
+    var schemaClass = entity.getSchemaClass();
+    if (schemaClass == null) {
+      return false;
+    }
+    return schemaClass.getName().equals(targetClassName)
+        || schemaClass.isSubClassOf(targetClassName);
+  }
+
+  /**
+   * High-density single-source path (true index scan, not local sort): parent
+   * class filter includes subclass rows; results match classic MATCH with the
+   * optimization disabled.
+   */
+  @Test
+  public void testIndexOrderedMatchIndexScanClassFilterMatchesClassic()
+      throws Exception {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TestNote EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestNote.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestNote.noteId LONG").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    // Dense LinkBag vs index so the cost model picks indexScanFiltered.
+    for (var i = 1; i <= 150; i++) {
+      session.execute(
+          "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 "
+              + String.format("%02d", i / 60) + ":"
+              + String.format("%02d", i % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    for (var i = 200; i <= 249; i++) {
+      session.execute(
+          "CREATE VERTEX TestPost SET creationDate = '2025-02-01 "
+              + String.format("%02d", (i - 200) / 60) + ":"
+              + String.format("%02d", (i - 200) % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    // Unrelated type on the same LinkBag — must not appear for {class: TestMessage}.
+    for (var i = 1; i <= 20; i++) {
+      session.execute(
+          "CREATE VERTEX TestNote SET creationDate = '2025-03-01 00:00:00', noteId = "
+              + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestNote WHERE noteId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    session.commit();
+
+    var query =
+        "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+            + ".in('TEST_HAS_CREATOR'){class: TestMessage, as: m} "
+            + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 10";
+
+    java.util.List<Long> indexOrderedMids;
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      try (var result = session.query(query)) {
+        var plan = getPlan(result);
+        Assert.assertTrue(
+            "Plan should use INDEX ORDERED MATCH (index-scan density), but was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+        indexOrderedMids = collectMids(result);
+        assertIndexScanRuntimePath(result);
+      }
+      session.commit();
+    }
+
+    // Disable the optimization: classic MATCH with the same class filter.
+    var oldMin = GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.getValue();
+    GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(Integer.MAX_VALUE);
+    try {
+      session.begin();
+      java.util.List<Long> classicMids;
+      try (var result = session.query(query)) {
+        var plan = getPlan(result);
+        Assert.assertFalse(
+            "Optimization should be off, but plan was:\n" + plan,
+            plan.contains("INDEX ORDERED MATCH"));
+        classicMids = collectMids(result);
+      }
+      Assert.assertEquals(
+          "Index-scan class filter must match classic MATCH results",
+          classicMids, indexOrderedMids);
+      // Top rows are February posts (subclass), proving polymorphic include on scan path.
+      Assert.assertEquals(
+          java.util.List.of(249L, 248L, 247L, 246L, 245L, 244L, 243L, 242L, 241L, 240L),
+          indexOrderedMids);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(oldMin);
+    }
+  }
+
+  /**
+   * High-density index scan with a concrete subclass filter: only posts, and
+   * the ordered ids match classic MATCH with the optimization disabled.
+   */
+  @Test
+  public void testIndexOrderedMatchIndexScanConcreteSubclassMatchesClassic()
+      throws Exception {
+    session.execute("CREATE CLASS TestPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TestMessage EXTENDS V").close();
+    session.execute("CREATE PROPERTY TestMessage.creationDate DATETIME").close();
+    session.execute("CREATE PROPERTY TestMessage.msgId LONG").close();
+    session.execute("CREATE CLASS TestPost EXTENDS TestMessage").close();
+    session.execute("CREATE CLASS TEST_HAS_CREATOR EXTENDS E").close();
+    session.execute(
+        "CREATE INDEX TestMessage.creationDate ON TestMessage(creationDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX TestPerson SET name = 'person1'").close();
+    for (var i = 1; i <= 150; i++) {
+      session.execute(
+          "CREATE VERTEX TestMessage SET creationDate = '2025-01-01 "
+              + String.format("%02d", i / 60) + ":"
+              + String.format("%02d", i % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestMessage WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    for (var i = 200; i <= 249; i++) {
+      session.execute(
+          "CREATE VERTEX TestPost SET creationDate = '2025-02-01 "
+              + String.format("%02d", (i - 200) / 60) + ":"
+              + String.format("%02d", (i - 200) % 60) + ":00', msgId = " + i)
+          .close();
+      session.execute(
+          "CREATE EDGE TEST_HAS_CREATOR FROM (SELECT FROM TestPost WHERE msgId = " + i
+              + ") TO (SELECT FROM TestPerson WHERE name = 'person1')")
+          .close();
+    }
+    session.commit();
+
+    var query =
+        "MATCH {class: TestPerson, as: p, where: (name = 'person1')}"
+            + ".in('TEST_HAS_CREATOR'){class: TestPost, as: m} "
+            + "RETURN m.msgId as mid ORDER BY m.creationDate DESC LIMIT 5";
+
+    java.util.List<Long> indexOrderedMids;
+    try (var cfg = setIndexOrderedTestConfig()) {
+      session.begin();
+      try (var result = session.query(query)) {
+        Assert.assertTrue(getPlan(result).contains("INDEX ORDERED MATCH"));
+        indexOrderedMids = collectMids(result);
+        assertIndexScanRuntimePath(result);
+      }
+      session.commit();
+    }
+
+    var oldMin = GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.getValue();
+    GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(Integer.MAX_VALUE);
+    try {
+      session.begin();
+      java.util.List<Long> classicMids;
+      try (var result = session.query(query)) {
+        Assert.assertFalse(getPlan(result).contains("INDEX ORDERED MATCH"));
+        classicMids = collectMids(result);
+      }
+      Assert.assertEquals(classicMids, indexOrderedMids);
+      Assert.assertEquals(
+          java.util.List.of(249L, 248L, 247L, 246L, 245L), indexOrderedMids);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_INDEX_ORDERED_MIN_LINKBAG.setValue(oldMin);
+    }
+  }
+
+  private static java.util.List<Long> collectMids(ResultSet result) {
+    var mids = new java.util.ArrayList<Long>();
+    while (result.hasNext()) {
+      mids.add(((Number) result.next().getProperty("mid")).longValue());
+    }
+    return mids;
+  }
+
   // UNFILTERED_BOUND with class inheritance: reverse edge class check filters
   // out sources of wrong class. Covers hasPolymorphicCollectionId branches.
   @Test
@@ -6852,6 +7185,7 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         while (result.hasNext()) {
           mids.add(((Number) result.next().getProperty("mid")).longValue());
         }
+        assertRuntimePath(result, IndexOrderedEdgeStep.RuntimePath.INDEX_SCAN);
         // Only msgIds > 190 pass filter: 191..200 → 10 available, LIMIT 5
         Assert.assertEquals("Should have 5 results", 5, mids.size());
         for (var mid : mids) {
@@ -7487,6 +7821,11 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
             cds.add(row.getProperty("cd"));
             contents.add(row.getProperty("rc"));
           }
+          assertRuntimePath(result, IndexOrderedEdgeStep.RuntimePath.LOAD_SORT);
+          Assert.assertTrue(
+              "Plan should label load-sort, but was:\n"
+                  + result.getExecutionPlan().prettyPrint(0, 2),
+              result.getExecutionPlan().prettyPrint(0, 2).contains("[load-sort]"));
           Assert.assertEquals("Should have 4 results: " + cds, 4, cds.size());
 
           // Reply content should be bound for every row

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStepCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/IndexOrderedEdgeStepCostTest.java
@@ -448,4 +448,46 @@ public class IndexOrderedEdgeStepCostTest {
     assertEquals("Negative frequencies clamped to 0: 0+10+0+20=30", 30L, sum);
   }
 
+  /**
+   * LDBC SF1 IS2 shape: small person LinkBag vs huge Message.creationDate
+   * index, LIMIT 10, downstream REPLY_OF. Index scan must lose to loadSort —
+   * choosing scan would walk O(indexSize × LIMIT / N) entries. Not a model
+   * bug that benches stay on loadSort.
+   */
+  @Test
+  public void testSf1Is2LikeShapePrefersLoadSortOverIndexScan() {
+    // SF1: ~2.4M messages; curated persons often have ~50–200 posts/comments.
+    int linkBag = 100;
+    long indexSize = 2_400_000L;
+    long limit = 10;
+    int downstreamEdges = 2; // REPLY_OF (+ HAS_CREATOR on original)
+
+    var costs = IndexOrderedCostModel.computeCosts(
+        linkBag, indexSize, limit, null, false, downstreamEdges);
+    assertNotNull(
+        "Costs should be defined (expectedScanLength under MAX_SCAN)", costs);
+    // expectedScanLength = 10 / (100/2.4e6) = 240_000
+    assertEquals(240_000.0, costs.expectedScanLength(), 1.0);
+    assertTrue(
+        "IS2-like sparse LinkBag must prefer loadSort; unionScan="
+            + costs.costUnionScan() + " loadSort=" + costs.costLoadSort(),
+        costs.costUnionScan() > costs.costLoadSort());
+  }
+
+  /**
+   * Opposite of IS2: person owns most of the indexed rows. Index scan must
+   * win — this is the regime integration tests force with large single-source
+   * data and no artificial MAX_SCAN=1.
+   */
+  @Test
+  public void testHighDensityWithLimitPrefersIndexScan() {
+    var costs = IndexOrderedCostModel.computeCosts(
+        200, 200, 5, null, false, 0);
+    assertNotNull(costs);
+    assertTrue(
+        "Dense LinkBag + small LIMIT must prefer index scan; unionScan="
+            + costs.costUnionScan() + " loadSort=" + costs.costLoadSort(),
+        costs.costUnionScan() < costs.costLoadSort());
+  }
+
 }


### PR DESCRIPTION
#### PR Title:

YTDB-1280: Fix index-ordered IS2 multi-thread regression

#### Motivation:

Index-ordered MATCH regressed LDBC IS2 on 32 threads: loadSort filtered each LinkBag target via `Entity.getSchemaClass()` / `isSubClassOf`, which took the shared schema RW lock and contended under concurrency. Classic MATCH did not hit that path the same way, so IS2 MT looked worse after the optimization landed.

This change decides target class membership from the immutable schema snapshot and the record’s collection id (class + subclasses)—same idea as the unfiltered modes—so the hot path no longer takes that lock per record.

Measured on the same CCX53 / SF1 campaign (classic fork-point, index-ordered before this fix, then with the fix): classic ~8.5k ops/s, pre-fix index-ordered ~5.1–5.6k (−36% to −42%), with fix ~22.3k (+162% vs classic). The pre-fix regression was reproduced in that campaign before applying the change. Details in the PR comment.

#### Planned changes:

##### Current state
Index-ordered target class filtering used per-record schema class resolution under a shared RW lock.

##### What changes
Class filter is lock-friendly on the immutable snapshot; polymorphic include/exclude behavior unchanged.

##### How
Resolve the target class once from the snapshot where the scan loops; check collection id membership per record.

##### Suggestions:
None.

#### Tracks:
N/A (single-track)