### PR TITLE
Fix gremlin_arms default in LDBC JMH compare dispatch [no-it-tests]

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -30,10 +30,13 @@ on:
           Gremlin wall time; not the default PR comment framing).
         required: false
         type: choice
+        # Both values must stay quoted: YAML coerces a bare `on` to the boolean
+        # true, which the dispatch form then offers as "true" and passes on to
+        # `--gremlin-arms`, where it is not a valid choice.
         options:
-          - on
-          - both
-        default: on
+          - 'on'
+          - 'both'
+        default: 'on'
       base_branch:
         description: >
           Base branch to compare against (fork-point is computed with
@@ -241,6 +244,16 @@ jobs:
           # Default production arm only. JMH -p applies to benches that declare
           # the @Param; SQL LDBC classes without translatorEnabled are unchanged.
           ARMS="${GREMLIN_ARMS:-on}"
+          # `true` reaches here from any dispatch whose workflow file still has
+          # the unquoted `on` option. Reject anything else now rather than at
+          # the compare step, which runs after hours of benchmarking.
+          if [ "$ARMS" = "true" ]; then
+            ARMS=on
+          fi
+          if [ "$ARMS" != "on" ] && [ "$ARMS" != "both" ]; then
+            echo "::error::Unsupported gremlin_arms='$ARMS' (expected on|both)."
+            exit 1
+          fi
           echo "gremlin_arms=$ARMS" >> "$GITHUB_OUTPUT"
           if [ "$ARMS" = "on" ]; then
             echo "jmh_param_arg=-p translatorEnabled=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
#### Motivation:

The `gremlin_arms` choice input listed its values unquoted, and YAML reads a
bare `on` as the boolean true. The workflow_dispatch form therefore offered
`true` as the default instead of `on`. Run
[32741314582](https://github.com/JetBrains/youtrackdb/actions/runs/32741314582)
was dispatched with that default and paid for it twice: the filter step took the
`else` branch and ran the Gremlin benchmarks in `both` mode, and the final
compare step died on `--gremlin-arms true` (`invalid choice`) after an hour and
a half of benchmarking. The results survived only because they were uploaded as
an artifact.

#### Planned changes:

**Current state** — `options: [on, both]` with `default: on`, all unquoted. The
dispatch form shows `true` / `both`, and no step rejects an out-of-range value
until `jmh-compare.py` parses its arguments at the very end of the job.

**What changes** — the dispatch form offers `on` and `both` again, and an
invalid `gremlin_arms` value fails the job in its first minutes rather than
after the benchmark runs.

**How** — quote both option values and the default so YAML keeps them as
strings. In the `Build JMH filter from query list` step, map the coerced `true`
back to `on` for runs dispatched from refs that still carry the unquoted file,
and fail with an explicit error on anything outside `on|both`.

**Out of scope** — the Gremlin arm semantics, the comparison script's own
`choices` tuple, and the CCX53 runner change (already on `develop` via #1280).

**Risks & accepted trade-offs** — the `true` → `on` mapping is dead weight once
every active branch carries this file; it stays because the alternative is
another multi-hour run lost to a value that was never valid.

**Verification approach** — parsed the workflow with PyYAML to confirm both
options and the default now come back as strings rather than a boolean. The real
proof is the next dispatch: the form must show `on` as the default.

##### Suggestions:

None.

#### Tracks:

N/A (single-track)