### PR TITLE
[no-it-tests] YTDB-1285: Gremlin benchmarks shapes improved

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -9,15 +9,18 @@ on:
     inputs:
       queries:
         description: >
-          Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
-          Leave empty to run the full jmh-ldbc suite: SQL LDBC
-          (LdbcSingleThread / LdbcMultiThread) plus
-          LdbcGremlinTranslatorBenchmark. Gremlin rows compare head against
-          the fork-point with translator on both sides (gremlin_arms default
-          on). Pass gremlin_arms=both only for an optional on/off A/B on one
-          commit (~doubles Gremlin wall). Full empty-filter with both arms
-          was ~21h on CCX33; run on CCX53 (32 vCPU) to match nightly
-          multi-thread core count. Job timeout is 30h.
+          Comma-separated query IDs (e.g. IS1,IC2,IC13), or gremlin for
+          LdbcGremlinTranslatorBenchmark only (methods are named gremlin_*).
+          A query ID matches SQL (.*is1_.*) and any Gremlin shape that
+          echoes it (gremlin_is1_*). The one complete SQL twin is
+          gremlin_is5_messageCreator. Leave empty for the full suite: SQL
+          LDBC (LdbcSingleThread / LdbcMultiThread) plus Gremlin. Gremlin
+          rows compare head against the fork-point with translator on both
+          sides (gremlin_arms default on). Pass gremlin_arms=both only for
+          an optional on/off A/B on one commit (~doubles Gremlin wall).
+          Full empty-filter with both arms was ~21h on CCX33; run on CCX53
+          (32 vCPU) to match nightly multi-thread core count. Job timeout
+          is 30h.
         required: false
         type: string
         default: ''

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -65,7 +65,7 @@ def parse_jmh_results(data):
     """Parse JMH JSON into dict keyed by (query, suite).
 
     ``query`` is the benchmark method name, plus a param suffix when JMH
-    ``params`` are present (e.g. ``gremlinKnowsFirstNames [on]``).
+    ``params`` are present (e.g. ``gremlin_knowsFirstNames [on]``).
     """
     results = {}
     for entry in data:

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
@@ -4,8 +4,10 @@ import com.jetbrains.youtrackdb.api.gremlin.YTDBGraphTraversal;
 import com.jetbrains.youtrackdb.api.gremlin.YTDBGraphTraversalSource;
 import com.jetbrains.youtrackdb.api.gremlin.__;
 import com.jetbrains.youtrackdb.internal.core.gremlin.translator.step.AbstractMatchPlanStep;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -50,9 +52,10 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  *
  * <h2>Relation to the SQL IC / IS benchmarks</h2>
  *
- * <p><b>Throughput is not comparable across SQL and Gremlin rows</b> — different entry points. The
- * LDBC-derived shapes below are named after the query they echo; per-method Javadoc carries the SQL
- * for auditable correspondence, not a claim that timings can be divided.
+ * <p><b>Throughput is not comparable across SQL and Gremlin rows</b> — different entry points.
+ * Every builder's Javadoc starts with {@code LDBC:}: {@code complete} for a full IC/IS twin,
+ * {@code <query> reduced} plus the clauses the reduction drops, or {@code none} for a translator
+ * primitive that does not echo a workload query.
  *
  * <p>Three of the twenty-one queries in {@code ldbc-queries/} use {@code LET}; most of the rest are
  * plain MATCH patterns. What blocks them is the recogniser set rather than Gremlin's expressiveness,
@@ -91,6 +94,33 @@ public final class GremlinTraversalShapes {
   /** Vertex class the LDBC schema gives the {@code name} property the anti-join shape filters on. */
   public static final String PLACE_LABEL = "Place";
 
+  /** Vertex class that contains posts; IS6 walks from a Post to its Forum. */
+  public static final String FORUM_LABEL = "Forum";
+
+  /** Vertex class of a reply; IC8 filters the inbound {@code REPLY_OF} hop to it. */
+  public static final String COMMENT_LABEL = "Comment";
+
+  /**
+   * Vertex class of an employer. The LDBC loader inserts organisations into this class (with {@code
+   * type = 'company'}), not into the empty {@code Company} subclass.
+   */
+  public static final String ORGANISATION_LABEL = "Organisation";
+
+  /** Edge label from a {@code Comment} to the {@code Message} it replies to. */
+  public static final String REPLY_OF_LABEL = "REPLY_OF";
+
+  /** Edge label from a {@code Forum} to a {@code Message} it contains. */
+  public static final String CONTAINER_OF_LABEL = "CONTAINER_OF";
+
+  /** Edge label from a {@code Forum} to its moderating {@code Person}. */
+  public static final String HAS_MODERATOR_LABEL = "HAS_MODERATOR";
+
+  /** Edge label from a {@code Person} to a {@code Message} they liked. */
+  public static final String LIKES_LABEL = "LIKES";
+
+  /** Edge label from a {@code Person} to an {@code Organisation} they work at. */
+  public static final String WORK_AT_LABEL = "WORK_AT";
+
   private GremlinTraversalShapes() {
   }
 
@@ -100,7 +130,8 @@ public final class GremlinTraversalShapes {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * A bare {@code g.V(rid)} by-id lookup with nothing after it — a DECLINING shape.
+   * LDBC: none. Bare {@code g.V(rid)} point-lookup — a DECLINING translator primitive, not an
+   * IC/IS query.
    *
    * <p>Held apart from the other walk shapes because it is the only one where the native path issues
    * no query: TinkerPop resolves the id straight to a record. Translating it would compile an
@@ -115,7 +146,7 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 2 — the {@code KNOWS} walk under {@code values}: one property value per friend.
+   * LDBC: none. Translator primitive: one-hop {@code KNOWS} under {@code values}.
    *
    * <p>This is the witness shape for the kill-switch installation check, because every step in it
    * ({@code V}, {@code hasLabel}, {@code has}, {@code out}, {@code values}) has been in the
@@ -131,14 +162,14 @@ public final class GremlinTraversalShapes {
         .values("firstName");
   }
 
-  /** Shape 3 — the same walk under {@code count()}: one scalar per traversal. */
+  /** LDBC: none. Translator primitive: the {@link #knowsFirstNames} walk under {@code count()}. */
   public static YTDBGraphTraversal<Vertex, Long> knowsFirstNameCount(
       YTDBGraphTraversalSource g, long personId) {
     return knowsFirstNames(g, personId).count();
   }
 
   /**
-   * Shape 4 — the same walk under {@code fold()}: one list per traversal.
+   * LDBC: none. Translator primitive: the {@link #knowsFirstNames} walk under {@code fold()}.
    *
    * <p>The list-shaping terminator the boundary step drains through a {@code ListShapingOp}, and
    * the newest recogniser this harness covers. Its assertion doubles as a classpath check: a
@@ -151,7 +182,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 5 — IS1 reduced to its city-side columns.
+   * LDBC: IS1 reduced. City-side columns of the person–city join; drops the other seven person
+   * fields SQL returns.
    *
    * <p>IS1 is {@code MATCH {class: Person, as: p, where: (id = :personId)}.out('IS_LOCATED_IN'){as:
    * city} RETURN p.firstName, p.lastName, p.birthday, p.locationIP, p.browserUsed, city.id,
@@ -170,7 +202,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 6 — IS3 reduced to its friend-side columns.
+   * LDBC: IS3 reduced. Friend columns plus one {@code ORDER BY}; drops {@code k.creationDate} and
+   * the second sort key.
    *
    * <p>IS3 is {@code MATCH {class: Person, as: p, where: (id = :personId)}.outE('KNOWS'){as: k}
    * .inV(){as: friend} RETURN friend.id, friend.firstName, friend.lastName, k.creationDate ORDER BY
@@ -194,7 +227,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 7 — IS5 whole, the one IS query that translates without losing a column.
+   * LDBC: IS5 complete. Message author {@code id}/{@code firstName}/{@code lastName}; every SQL
+   * column, no dropped clause.
    *
    * <p>IS5 is {@code MATCH {class: Message, as: m, where: (id = :messageId)}.out('HAS_CREATOR'){as:
    * author} RETURN author.id, author.firstName, author.lastName}. Every RETURN column comes from the
@@ -210,7 +244,159 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 8 — two chained {@code KNOWS} hops.
+   * LDBC: IS2 reduced. Person {@code in(HAS_CREATOR)} messages, newest first.
+   *
+   * <p>IS2 is {@code MATCH {class: Person, as: p, where: (id = :personId)}.in('HAS_CREATOR'){as:
+   * message}.out('REPLY_OF'){while: Comment, where: Post, as: originalPost}.out('HAS_CREATOR'){as:
+   * author} RETURN message.*, originalPost.id, author.* ORDER BY date DESC LIMIT n}. Kept: the
+   * inbound creator hop, {@code ORDER BY creationDate DESC}, and three message columns. Dropped:
+   * the {@code REPLY_OF} climb ({@code RepeatDeclineStrategy}), {@code coalesce(imageFile,
+   * content)}, original-post and original-author columns, and {@code LIMIT}.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<Object, Object>> is2PersonMessages(
+      YTDBGraphTraversalSource g, long personId) {
+    return g.V()
+        .hasLabel(PERSON_LABEL)
+        .has("id", personId)
+        .in(HAS_CREATOR_LABEL)
+        .hasLabel(MESSAGE_LABEL)
+        .order().by("creationDate", Order.desc)
+        .valueMap("id", "content", "creationDate");
+  }
+
+  /**
+   * LDBC: IS6 reduced. Post {@code in(CONTAINER_OF)} Forum plus its moderator.
+   *
+   * <p>IS6 is {@code MATCH {class: Message}.out('REPLY_OF'){while: Comment, where: Post}
+   * .in('CONTAINER_OF'){as: forum}.out('HAS_MODERATOR'){as: moderator} RETURN forum.id/title,
+   * moderator.id/firstName/lastName}. Kept: the Forum hop and the moderator hop, projected through
+   * {@code select("forum", "moderator")}. Dropped: the {@code REPLY_OF} climb, so the shape starts
+   * at a {@code Post} rather than an arbitrary Message. {@code CONTAINER_OF} is Forum→Message; the
+   * Gremlin hop is {@code in}, matching SQL {@code .in('CONTAINER_OF')}. Labels bind on valued
+   * {@code has("id", P.neq(-1L))} like IS1's {@code has("id", personId)}; a bare {@code has(key)}
+   * rewrites to {@code TraversalFilterStep} and the walker declines.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<String, Object>> is6ForumOfPost(
+      YTDBGraphTraversalSource g, long messageId) {
+    return g.V()
+        .hasLabel("Post")
+        .has("id", messageId)
+        .in(CONTAINER_OF_LABEL)
+        .hasLabel(FORUM_LABEL)
+        .has("id", P.neq(-1L)).as("forum")
+        .out(HAS_MODERATOR_LABEL)
+        .has("id", P.neq(-1L)).as("moderator")
+        .select("forum", "moderator").by("title").by("firstName");
+  }
+
+  /**
+   * LDBC: IS7 reduced. Direct replies of a message and their authors.
+   *
+   * <p>IS7 is {@code MATCH {class: Message, as: msg}.out('HAS_CREATOR'){as: author}, {as: msg}
+   * .in('REPLY_OF'){as: reply}.out('HAS_CREATOR'){as: replyAuthor}
+   * .out('KNOWS'){as: knowsCheck, optional: true} RETURN reply.*, replyAuthor.*, ifnull(knowsCheck)}.
+   * Kept: {@code in(REPLY_OF).out(HAS_CREATOR)} and three author columns. Dropped: {@code optional()}
+   * KNOWS check, {@code coalesce} on the reply, {@code ORDER BY} + {@code LIMIT}.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<Object, Object>> is7RepliesWithAuthors(
+      YTDBGraphTraversalSource g, long messageId) {
+    return g.V()
+        .hasLabel(MESSAGE_LABEL)
+        .has("id", messageId)
+        .in(REPLY_OF_LABEL)
+        .out(HAS_CREATOR_LABEL)
+        .valueMap("id", "firstName", "lastName");
+  }
+
+  /**
+   * LDBC: IC2 reduced. Friends' messages before {@code maxDate}, newest first.
+   *
+   * <p>IC2 is {@code MATCH {class: Person}.out('KNOWS'){as: friend}.in('HAS_CREATOR'){as: msg,
+   * where: (creationDate < :maxDate)} RETURN friend.*, msg.* ORDER BY date DESC, id ASC LIMIT n}.
+   * Kept: the two hops, the date predicate, {@code ORDER BY creationDate DESC}, and three message
+   * columns. Dropped: friend columns, {@code coalesce}, the second sort key, and {@code LIMIT}.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<Object, Object>> ic2FriendsMessagesOrdered(
+      YTDBGraphTraversalSource g, long personId, Date maxDate) {
+    return g.V()
+        .hasLabel(PERSON_LABEL)
+        .has("id", personId)
+        .out(KNOWS_LABEL)
+        .in(HAS_CREATOR_LABEL)
+        .hasLabel(MESSAGE_LABEL)
+        .has("creationDate", P.lt(maxDate))
+        .order().by("creationDate", Order.desc)
+        .valueMap("id", "content", "creationDate");
+  }
+
+  /**
+   * LDBC: IC7 reduced. First names of people who liked a person's messages.
+   *
+   * <p>IC7 walks {@code in('HAS_CREATOR').inE('LIKES')} then optional KNOWS, groups by liker, and
+   * takes {@code first()} of the like date. Kept: {@code in(HAS_CREATOR).in(LIKES).values(firstName)}.
+   * Dropped: like-edge {@code creationDate}, {@code optional()} KNOWS / {@code isNew}, {@code GROUP
+   * BY} + {@code first()}, {@code coalesce}, and {@code LIMIT}.
+   */
+  public static YTDBGraphTraversal<Vertex, String> ic7Likers(
+      YTDBGraphTraversalSource g, long personId) {
+    return g.V()
+        .hasLabel(PERSON_LABEL)
+        .has("id", personId)
+        .in(HAS_CREATOR_LABEL)
+        .in(LIKES_LABEL)
+        .values("firstName");
+  }
+
+  /**
+   * LDBC: IC8 reduced. Comments that reply to a person's messages, newest first.
+   *
+   * <p>IC8 is {@code MATCH {class: Person}.in('HAS_CREATOR'){as: message}.in('REPLY_OF'){as: comment}
+   * .out('HAS_CREATOR'){as: creator} RETURN creator.*, comment.* ORDER BY date DESC LIMIT n}. Kept:
+   * the two inbound hops, {@code hasLabel(Comment)}, {@code ORDER BY creationDate DESC}, and three
+   * comment columns. Dropped: creator columns, {@code coalesce}, and {@code LIMIT}.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<Object, Object>> ic8RecentRepliesOrdered(
+      YTDBGraphTraversalSource g, long personId) {
+    return g.V()
+        .hasLabel(PERSON_LABEL)
+        .has("id", personId)
+        .in(HAS_CREATOR_LABEL)
+        .in(REPLY_OF_LABEL)
+        .hasLabel(COMMENT_LABEL)
+        .order().by("creationDate", Order.desc)
+        .valueMap("id", "content", "creationDate");
+  }
+
+  /**
+   * LDBC: IC11 reduced. Direct friends' companies in a named country.
+   *
+   * <p>IC11 is {@code MATCH {class: Person}.out('KNOWS'){while: ($depth < 2)}.outE('WORK_AT'){where:
+   * (workFrom < :year)}.inV(){as: company}.out('IS_LOCATED_IN'){where: (name = :country)} RETURN
+   * person.*, company.name, workFrom ORDER BY workFrom, personId LIMIT n}. Kept: one {@code KNOWS}
+   * hop (not FoF), {@code out(WORK_AT)} onto {@code Organisation}, country filter, and
+   * {@code select("company", "country")}. Dropped: depth-2 {@code repeat}, person columns, {@code
+   * workFrom} predicate and column, {@code ORDER BY} + {@code LIMIT}. The company alias binds on
+   * valued {@code has("id", P.neq(-1L))}, the same pattern as IS1: a bare {@code has("name")}
+   * rewrites to {@code TraversalFilterStep} and declines. The LDBC loader inserts companies as
+   * {@code Organisation} vertices, so the filter is that class, not the empty {@code Company}
+   * subclass.
+   */
+  public static YTDBGraphTraversal<Vertex, Map<String, Object>> ic11FriendsCompaniesInCountry(
+      YTDBGraphTraversalSource g, long personId, String countryName) {
+    return g.V()
+        .hasLabel(PERSON_LABEL)
+        .has("id", personId)
+        .out(KNOWS_LABEL)
+        .out(WORK_AT_LABEL)
+        .hasLabel(ORGANISATION_LABEL)
+        .has("id", P.neq(-1L)).as("company")
+        .out(IS_LOCATED_IN_LABEL)
+        .has("name", countryName).as("country")
+        .select("company", "country").by("name").by("name");
+  }
+
+  /**
+   * LDBC: none. Translator primitive: two chained {@code KNOWS} hops.
    *
    * <p>The first shape where the two engines can disagree on plan shape rather than on overhead: the
    * native pipeline walks adjacency twice with a barrier between the hops, while MATCH enumerates
@@ -228,7 +414,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 9 — a two-hop walk with a property filter on the intermediate hop.
+   * LDBC: none. Translator primitive: two-hop {@code KNOWS} with an indexed filter on the
+   * intermediate hop.
    *
    * <p>Where index selection should tell: {@code Person.firstName} carries a {@code NOTUNIQUE}
    * index, so a MATCH planner is free to enter the pattern from the filtered alias and intersect
@@ -246,7 +433,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 10 — three hops with a {@code where()} back-reference to the first hop's alias.
+   * LDBC: none. Translator primitive: three-hop {@code KNOWS} with {@code where(neq)} against a
+   * mid-walk alias.
    *
    * <p>{@code where(P.neq("f"))} drops the paths whose third hop returns to the friend the second
    * hop came from — a back-reference to a mid-walk alias. An earlier note here explained that
@@ -267,7 +455,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 11 — IS1's full projection through {@code select("p", "city")}.
+   * LDBC: IS1 reduced. {@code select("p", "city")} of {@code firstName} and city {@code id}; SQL
+   * returns eight person fields plus {@code city.id}.
    *
    * <p>Same SQL as {@link #is1PersonCityProfile}, with the person-side columns added.
    * {@code select("p", "city")} needs both user {@code as(...)} labels to resolve to pattern
@@ -290,7 +479,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 12 — {@code groupCount().by(key)}: {@code GROUP BY lastName} with {@code count(*)}.
+   * LDBC: none. Translator primitive: {@code groupCount().by(lastName)}, the IC-style
+   * {@code GROUP BY} + {@code count(*)} shape without a workload query behind it.
    *
    * <p>The aggregate pushes into the MATCH plan, so the on-arm returns a grouped result set while
    * the off-arm builds the map in the traverser pipeline.
@@ -305,7 +495,9 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 13 — a person's friends who are <em>not</em> located in a given place: a hash anti-join.
+   * LDBC: none. Translator primitive: hash anti-join of friends not located in a place. Echoes
+   * IC-style {@code NOT} without IC4's {@code GROUP BY} / {@code LIMIT} or IS4/IS2's declined
+   * projections.
    *
    * <p>Echoes the shape of LDBC IC-style negation and IS4/IS2's {@code NOT} projections without
    * their declined steps: {@code MATCH {class: Person, where: (id = :personId)}.out('KNOWS'){as:
@@ -333,7 +525,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Shape 14 — a mutual-friend triangle closed by a {@code where()} back-reference to the start.
+   * LDBC: none. Translator primitive: three-hop {@code KNOWS} triangle closed by
+   * {@code where(eq(start))}. Cyclic social-graph shape; not a named IC/IS query.
    *
    * <p>Echoes the cyclic patterns the LDBC social queries lean on: three {@code KNOWS} hops that
    * must return to the person they started from, i.e. {@code MATCH {class: Person, as: start,
@@ -369,7 +562,9 @@ public final class GremlinTraversalShapes {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * Declining shape 0 — IS3 whole: edge and friend columns through {@code select("k", "friend")}.
+   * LDBC: IS3 full attempt. Edge {@code creationDate} plus friend {@code firstName} through
+   * {@code select("k", "friend")}; declines because {@code as("k")} on {@code outE} would bind the
+   * edge-as-node vertex.
    *
    * <p>Same SQL as {@link #is3FriendsWithNames}, but projects the friendship edge's {@code
    * creationDate} via a user {@code as("k")} label on {@code outE(KNOWS)}. That edge {@code as(k)}
@@ -389,7 +584,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Declining shape 1 — {@code order().by(key)} with {@code range} as paging.
+   * LDBC: none. Declining translator primitive: {@code order().by(firstName).range(1, 3)}. LDBC
+   * pages look like this; the walker refuses a slice behind a captured {@code ORDER BY}.
    *
    * <p>{@code ORDER BY firstName SKIP 1 LIMIT 2} is what MATCH would compile this to, and the
    * walker refuses it: a slice sitting behind a captured {@code ORDER BY} declines, so the whole
@@ -413,7 +609,10 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Declining shape 2 — IC1's variable-depth {@code KNOWS} walk, declined by design.
+   * LDBC: IC1 fragment. Variable-depth {@code KNOWS} via {@code repeat().times(3).emit()};
+   * {@code RepeatDeclineStrategy} vetoes it before the walker runs. The same veto covers IS2 and
+   * IS6's {@code while:} recursion over {@code REPLY_OF}. Drops IC1's {@code LET} universities /
+   * companies, {@code GROUP BY} min(distance), and {@code LIMIT}.
    *
    * <p>IC1 walks {@code KNOWS} to depth three. {@code RepeatDeclineStrategy} vetoes any traversal
    * whose subtree carries a {@code RepeatStep}, because {@code RepeatUnrollStrategy} rewrites the
@@ -442,7 +641,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Declining shape 4 — IS4's {@code coalesce(imageFile, content)} projection.
+   * LDBC: IS4 fragment. {@code coalesce(imageFile, content)} on a message; declines on
+   * {@code CoalesceStep}. IS2 projects the same expression.
    *
    * <p>IS4 is {@code SELECT coalesce(imageFile, content) as messageContent, creationDate FROM
    * Message WHERE id = :messageId}; IS2 projects the same expression. Gremlin spells it {@code
@@ -459,7 +659,8 @@ public final class GremlinTraversalShapes {
   }
 
   /**
-   * Declining shape 5 — IS7's optional hop.
+   * LDBC: IS7 fragment. {@code optional(out(KNOWS))} after the message's author; declines on
+   * {@code optional()}. SQL also has {@code coalesce} and {@code ifnull(knowsCheck)}.
    *
    * <p>IS7 ends with {@code .out('KNOWS'){as: knowsCheck, where: (@rid = $matched.author.@rid),
    * optional: true}}. MATCH's {@code optional: true} is a Phase 2 capability, and Gremlin's

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/GremlinTraversalShapes.java
@@ -33,7 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  *
  * <p>{@link LdbcGremlinTranslatorBenchmark} still exposes {@code translatorEnabled} as a JMH
  * {@code @Param} for a secondary A/B: MATCH against the native pipeline on one tree. Run both arms
- * with {@code -Djmh.args=".*LdbcGremlinTranslator.*"} and no {@code -p} filter, or pass {@code
+ * with {@code -Djmh.args=".*gremlin_.*"} and no {@code -p} filter, or pass {@code
  * --gremlin-arms both} to {@code jmh-compare.py}. That axis is for recogniser and kill-switch work,
  * not for the default PR regression comment.
  *

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
@@ -40,9 +40,15 @@ import org.openjdk.jmh.annotations.Warmup;
  * (taking {@code -ea}, the heap sizing and every {@code --add-opens} with it) and on others plugin
  * configuration wins and the CLI value is inert. Neither failure is visible in the numbers.
  *
- * <p>Run both arms locally with {@code -Djmh.args=".*LdbcGremlinTranslator.*"} (no {@code -p}
- * filter). For {@code jmh-compare.py}, pass {@code --gremlin-arms both} to include off-arm rows in
- * the markdown comment.
+ * <p>Every {@code @Benchmark} method starts with {@code gremlin_}, so the compare workflow's
+ * {@code queries=gremlin} filter ({@code .*gremlin_.*}) selects this class without a special case.
+ * Shapes that echo an IC/IS query keep the SQL id ({@code gremlin_is1_...}). The one complete twin
+ * reuses the SQL method suffix: {@code gremlin_is5_messageCreator} next to {@code
+ * is5_messageCreator}. Translator primitives have no query id ({@code gremlin_knowsFirstNames}).
+ *
+ * <p>Run both arms locally with {@code -Djmh.args=".*gremlin_.*"} (no {@code -p} filter). For
+ * {@code jmh-compare.py}, pass {@code --gremlin-arms both} to include off-arm rows in the markdown
+ * comment.
  *
  * <h2>Two benchmark groups, read differently</h2>
  *
@@ -63,8 +69,7 @@ import org.openjdk.jmh.annotations.Warmup;
  * applies strategies, and throws unless the boundary step matches the arm — see {@link
  * GremlinTraversalShapes#requireTranslated}.
  *
- * <p>Reproduce the CI arm only: {@code -Djmh.args=".*LdbcGremlinTranslator.* -p
- * translatorEnabled=true"}.
+ * <p>Reproduce the CI arm only: {@code -Djmh.args=".*gremlin_.* -p translatorEnabled=true"}.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -265,7 +270,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. One-hop {@code KNOWS} under {@code values}. */
   @Benchmark
-  public List<String> gremlinKnowsFirstNames(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<String> gremlin_knowsFirstNames(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.knowsFirstNames(t, arm.personId(i)).toList());
@@ -273,7 +278,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. {@link GremlinTraversalShapes#knowsFirstNames} under {@code count()}. */
   @Benchmark
-  public Long gremlinKnowsFirstNameCount(LdbcBenchmarkState state, TranslatorArm arm) {
+  public Long gremlin_knowsFirstNameCount(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.knowsFirstNameCount(t, arm.personId(i)).next());
@@ -284,7 +289,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * predates {@code FoldStep} declines the shape and both arms run natively.
    */
   @Benchmark
-  public List<String> gremlinKnowsFirstNamesFolded(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<String> gremlin_knowsFirstNamesFolded(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.knowsFirstNamesFolded(t, arm.personId(i)).next());
@@ -292,7 +297,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: IS1 reduced. City-side columns of the person–city join. */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIs1PersonCityProfile(
+  public List<Map<Object, Object>> gremlin_is1_personCityProfile(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -301,16 +306,19 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: IS3 reduced. Friend columns under {@code ORDER BY firstName}; no edge date. */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIs3FriendsWithNames(
+  public List<Map<Object, Object>> gremlin_is3_friendsWithNames(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.is3FriendsWithNames(t, arm.personId(i)).toList());
   }
 
-  /** LDBC: IS5 complete. Message author; every SQL column. */
+  /**
+   * LDBC: IS5 complete. Message author; every SQL column. JMH name matches
+   * {@code is5_messageCreator}.
+   */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIs5MessageCreator(
+  public List<Map<Object, Object>> gremlin_is5_messageCreator(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -321,7 +329,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: IS2 reduced. Person messages newest first; no original-post climb, coalesce, or LIMIT.
    */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIs2PersonMessages(
+  public List<Map<Object, Object>> gremlin_is2_personMessages(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -332,7 +340,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: IS6 reduced. Post's Forum and moderator; no {@code REPLY_OF} climb from a Comment.
    */
   @Benchmark
-  public List<Map<String, Object>> gremlinIs6ForumOfPost(
+  public List<Map<String, Object>> gremlin_is6_forumOfPost(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -343,7 +351,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: IS7 reduced. Reply authors; no optional KNOWS, coalesce, or LIMIT.
    */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIs7RepliesWithAuthors(
+  public List<Map<Object, Object>> gremlin_is7_repliesWithAuthors(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -355,7 +363,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * or LIMIT. Uses {@code ic2PersonId}/{@code ic2MaxDate}, not the IS person pool.
    */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIc2FriendsMessagesOrdered(
+  public List<Map<Object, Object>> gremlin_ic2_friendsMessagesOrdered(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -369,7 +377,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * Uses {@code ic7PersonId}.
    */
   @Benchmark
-  public List<String> gremlinIc7Likers(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<String> gremlin_ic7_likers(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.ic7Likers(t, state.ic7PersonId(i)).toList());
@@ -380,7 +388,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * columns, coalesce, or LIMIT. Uses {@code ic8PersonId}.
    */
   @Benchmark
-  public List<Map<Object, Object>> gremlinIc8RecentRepliesOrdered(
+  public List<Map<Object, Object>> gremlin_ic8_recentRepliesOrdered(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -392,7 +400,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LIMIT. Uses {@code ic11PersonId}/{@code ic11CountryName}.
    */
   @Benchmark
-  public List<Map<String, Object>> gremlinIc11FriendsCompaniesInCountry(
+  public List<Map<String, Object>> gremlin_ic11_friendsCompaniesInCountry(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -403,7 +411,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. Two chained {@code KNOWS} hops. */
   @Benchmark
-  public List<String> gremlinTwoHopKnows(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<String> gremlin_twoHopKnows(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.twoHopKnows(t, arm.personId(i)).toList());
@@ -413,7 +421,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: none. Two-hop {@code KNOWS} with an indexed filter on the intermediate hop.
    */
   @Benchmark
-  public List<String> gremlinKnowsFilteredByFriendFirstName(
+  public List<String> gremlin_knowsFilteredByFriendFirstName(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -424,7 +432,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. Three-hop {@code KNOWS} with {@code where(neq)} against a mid-walk alias. */
   @Benchmark
-  public List<String> gremlinThreeHopKnowsExcludingIntermediate(
+  public List<String> gremlin_threeHopKnowsExcludingIntermediate(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -434,7 +442,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: IS1 reduced. {@code select("p", "city")} of firstName and city id. */
   @Benchmark
-  public List<Map<String, Object>> gremlinIs1FullProfile(
+  public List<Map<String, Object>> gremlin_is1_fullProfile(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -443,7 +451,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. {@code groupCount().by(lastName)}. */
   @Benchmark
-  public Map<Object, Long> gremlinKnowsGroupCountByLastName(
+  public Map<Object, Long> gremlin_knowsGroupCountByLastName(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -454,7 +462,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: none. Hash anti-join of friends not located in a place.
    */
   @Benchmark
-  public List<String> gremlinFriendsNotLocatedInPlace(
+  public List<String> gremlin_friendsNotLocatedInPlace(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -467,7 +475,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: none. Three-hop {@code KNOWS} triangle closed by {@code where(eq(start))}.
    */
   @Benchmark
-  public List<String> gremlinMutualFriendTriangle(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<String> gremlin_mutualFriendTriangle(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.mutualFriendTriangle(t, arm.personId(i)).toList());
@@ -482,7 +490,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: none. Bare {@code g.V(rid)} point-lookup; translator declines, both CI arms native.
    */
   @Benchmark
-  public List<Vertex> gremlinVertexByRidDeclines(LdbcBenchmarkState state, TranslatorArm arm) {
+  public List<Vertex> gremlin_vertexByRidDeclines(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
         t -> GremlinTraversalShapes.personByRid(t, arm.personRid(i)).toList());
@@ -490,7 +498,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: none. {@code order().by(firstName).range(1, 3)}; slice-after-sort declines. */
   @Benchmark
-  public List<String> gremlinKnowsOrderedPageDeclines(
+  public List<String> gremlin_knowsOrderedPageDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -501,7 +509,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * LDBC: IC1 fragment. {@code repeat(out(KNOWS)).times(3)}; {@code RepeatDeclineStrategy} veto.
    */
   @Benchmark
-  public List<String> gremlinRepeatKnowsToThreeHopsDeclines(
+  public List<String> gremlin_ic1_repeatKnowsToThreeHopsDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -510,7 +518,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: IS4 fragment. {@code coalesce(imageFile, content)}; declines on {@code CoalesceStep}. */
   @Benchmark
-  public List<String> gremlinCoalesceMessageContentDeclines(
+  public List<String> gremlin_is4_coalesceMessageContentDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -519,7 +527,7 @@ public class LdbcGremlinTranslatorBenchmark {
 
   /** LDBC: IS7 fragment. {@code optional(out(KNOWS))} after the author; declines on {@code optional()}. */
   @Benchmark
-  public List<String> gremlinOptionalFriendOfCreatorDeclines(
+  public List<String> gremlin_is7_optionalFriendOfCreatorDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(
@@ -531,7 +539,7 @@ public class LdbcGremlinTranslatorBenchmark {
    * {@code as("k")}. See {@link GremlinTraversalShapes#is3FriendsWithDates}.
    */
   @Benchmark
-  public List<Map<String, Object>> gremlinIs3FriendsWithDatesDeclines(
+  public List<Map<String, Object>> gremlin_is3_friendsWithDatesDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
     return state.traversal.computeInTx(

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinTranslatorBenchmark.java
@@ -263,7 +263,7 @@ public class LdbcGremlinTranslatorBenchmark {
   // Translating shapes. CI: head vs base with translator on. Optional A/B: MATCH vs native.
   // ---------------------------------------------------------------------------------------------
 
-  /** Shape 2 — the {@code KNOWS} walk under {@code values}: one row per friend. */
+  /** LDBC: none. One-hop {@code KNOWS} under {@code values}. */
   @Benchmark
   public List<String> gremlinKnowsFirstNames(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
@@ -271,7 +271,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.knowsFirstNames(t, arm.personId(i)).toList());
   }
 
-  /** Shape 3 — the same walk under {@code count()}: the aggregate pushes into the MATCH plan. */
+  /** LDBC: none. {@link GremlinTraversalShapes#knowsFirstNames} under {@code count()}. */
   @Benchmark
   public Long gremlinKnowsFirstNameCount(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
@@ -280,9 +280,8 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * Shape 4 — the same walk under {@code fold()}: the drain the boundary step applies after
-   * projection. A run whose {@code youtrackdb-core} predates the {@code FoldStep} registry entry
-   * declines the shape, so both arms run natively and the two numbers coincide.
+   * LDBC: none. {@link GremlinTraversalShapes#knowsFirstNames} under {@code fold()}. A core that
+   * predates {@code FoldStep} declines the shape and both arms run natively.
    */
   @Benchmark
   public List<String> gremlinKnowsFirstNamesFolded(LdbcBenchmarkState state, TranslatorArm arm) {
@@ -291,7 +290,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.knowsFirstNamesFolded(t, arm.personId(i)).next());
   }
 
-  /** Shape 5 — IS1's {@code IS_LOCATED_IN} join with the city columns. */
+  /** LDBC: IS1 reduced. City-side columns of the person–city join. */
   @Benchmark
   public List<Map<Object, Object>> gremlinIs1PersonCityProfile(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -300,7 +299,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.is1PersonCityProfile(t, arm.personId(i)).toList());
   }
 
-  /** Shape 6 — IS3's friend columns under an {@code ORDER BY}. */
+  /** LDBC: IS3 reduced. Friend columns under {@code ORDER BY firstName}; no edge date. */
   @Benchmark
   public List<Map<Object, Object>> gremlinIs3FriendsWithNames(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -309,7 +308,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.is3FriendsWithNames(t, arm.personId(i)).toList());
   }
 
-  /** Shape 7 — IS5 whole: the message's author, every column projected. */
+  /** LDBC: IS5 complete. Message author; every SQL column. */
   @Benchmark
   public List<Map<Object, Object>> gremlinIs5MessageCreator(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -318,7 +317,91 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.is5MessageCreator(t, arm.messageId(i)).toList());
   }
 
-  /** Shape 8 — two chained {@code KNOWS} hops: MATCH path enumeration against two native passes. */
+  /**
+   * LDBC: IS2 reduced. Person messages newest first; no original-post climb, coalesce, or LIMIT.
+   */
+  @Benchmark
+  public List<Map<Object, Object>> gremlinIs2PersonMessages(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.is2PersonMessages(t, arm.personId(i)).toList());
+  }
+
+  /**
+   * LDBC: IS6 reduced. Post's Forum and moderator; no {@code REPLY_OF} climb from a Comment.
+   */
+  @Benchmark
+  public List<Map<String, Object>> gremlinIs6ForumOfPost(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.is6ForumOfPost(t, arm.messageId(i)).toList());
+  }
+
+  /**
+   * LDBC: IS7 reduced. Reply authors; no optional KNOWS, coalesce, or LIMIT.
+   */
+  @Benchmark
+  public List<Map<Object, Object>> gremlinIs7RepliesWithAuthors(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.is7RepliesWithAuthors(t, arm.messageId(i)).toList());
+  }
+
+  /**
+   * LDBC: IC2 reduced. Friends' messages before the curated max date, newest first; no coalesce
+   * or LIMIT. Uses {@code ic2PersonId}/{@code ic2MaxDate}, not the IS person pool.
+   */
+  @Benchmark
+  public List<Map<Object, Object>> gremlinIc2FriendsMessagesOrdered(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes
+            .ic2FriendsMessagesOrdered(t, state.ic2PersonId(i), state.ic2MaxDate(i))
+            .toList());
+  }
+
+  /**
+   * LDBC: IC7 reduced. Likers' first names; no like-edge date, optional KNOWS, or GROUP BY.
+   * Uses {@code ic7PersonId}.
+   */
+  @Benchmark
+  public List<String> gremlinIc7Likers(LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.ic7Likers(t, state.ic7PersonId(i)).toList());
+  }
+
+  /**
+   * LDBC: IC8 reduced. Comments replying to a person's messages, newest first; no creator
+   * columns, coalesce, or LIMIT. Uses {@code ic8PersonId}.
+   */
+  @Benchmark
+  public List<Map<Object, Object>> gremlinIc8RecentRepliesOrdered(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.ic8RecentRepliesOrdered(t, state.ic8PersonId(i)).toList());
+  }
+
+  /**
+   * LDBC: IC11 reduced. Direct friends' companies in the curated country; no FoF, workFrom, or
+   * LIMIT. Uses {@code ic11PersonId}/{@code ic11CountryName}.
+   */
+  @Benchmark
+  public List<Map<String, Object>> gremlinIc11FriendsCompaniesInCountry(
+      LdbcBenchmarkState state, TranslatorArm arm) {
+    var i = state.nextIndex();
+    return state.traversal.computeInTx(
+        t -> GremlinTraversalShapes.ic11FriendsCompaniesInCountry(
+            t, state.ic11PersonId(i), state.ic11CountryName(i))
+            .toList());
+  }
+
+  /** LDBC: none. Two chained {@code KNOWS} hops. */
   @Benchmark
   public List<String> gremlinTwoHopKnows(LdbcBenchmarkState state, TranslatorArm arm) {
     var i = state.nextIndex();
@@ -327,8 +410,7 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * Shape 9 — two hops with an indexed filter on the intermediate one, where MATCH can enter the
-   * pattern from the filtered alias and native cannot.
+   * LDBC: none. Two-hop {@code KNOWS} with an indexed filter on the intermediate hop.
    */
   @Benchmark
   public List<String> gremlinKnowsFilteredByFriendFirstName(
@@ -340,7 +422,7 @@ public class LdbcGremlinTranslatorBenchmark {
             .toList());
   }
 
-  /** Shape 10 — three hops with a {@code where()} back-reference to the first hop's alias. */
+  /** LDBC: none. Three-hop {@code KNOWS} with {@code where(neq)} against a mid-walk alias. */
   @Benchmark
   public List<String> gremlinThreeHopKnowsExcludingIntermediate(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -350,7 +432,7 @@ public class LdbcGremlinTranslatorBenchmark {
             .toList());
   }
 
-  /** Shape 11 — IS1's full projection: both aliases reached through {@code select}. */
+  /** LDBC: IS1 reduced. {@code select("p", "city")} of firstName and city id. */
   @Benchmark
   public List<Map<String, Object>> gremlinIs1FullProfile(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -359,7 +441,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.is1FullProfile(t, arm.personId(i)).toList());
   }
 
-  /** Shape 12 — {@code GROUP BY} with {@code count(*)} pushed into the plan. */
+  /** LDBC: none. {@code groupCount().by(lastName)}. */
   @Benchmark
   public Map<Object, Long> gremlinKnowsGroupCountByLastName(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -369,8 +451,7 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * Shape 13 — a person's friends not located in a given place: MATCH's hash anti-join against the
-   * native pipeline's per-candidate re-walk of {@code IS_LOCATED_IN}.
+   * LDBC: none. Hash anti-join of friends not located in a place.
    */
   @Benchmark
   public List<String> gremlinFriendsNotLocatedInPlace(
@@ -383,8 +464,7 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * Shape 14 — a mutual-friend triangle closed by a {@code where()} back-reference to the start:
-   * MATCH's topological self-join against the native pipeline's full three-hop expansion.
+   * LDBC: none. Three-hop {@code KNOWS} triangle closed by {@code where(eq(start))}.
    */
   @Benchmark
   public List<String> gremlinMutualFriendTriangle(LdbcBenchmarkState state, TranslatorArm arm) {
@@ -399,10 +479,7 @@ public class LdbcGremlinTranslatorBenchmark {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * A bare {@code g.V(rid)} point-lookup. Native resolves the id without a query; the translator
-   * declines a bare RID walk ({@code cacheEligible=false}, no join to optimise), so both CI arms
-   * run native. Optional on/off A/B prices decline overhead; a RID start followed by a hop still
-   * translates.
+   * LDBC: none. Bare {@code g.V(rid)} point-lookup; translator declines, both CI arms native.
    */
   @Benchmark
   public List<Vertex> gremlinVertexByRidDeclines(LdbcBenchmarkState state, TranslatorArm arm) {
@@ -411,7 +488,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.personByRid(t, arm.personRid(i)).toList());
   }
 
-  /** {@code ORDER BY} with {@code SKIP} / {@code LIMIT} paging: a slice behind a captured sort. */
+  /** LDBC: none. {@code order().by(firstName).range(1, 3)}; slice-after-sort declines. */
   @Benchmark
   public List<String> gremlinKnowsOrderedPageDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -421,8 +498,7 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * IC1's variable-depth walk: vetoed by {@code RepeatDeclineStrategy} before the walker runs, so
-   * this is the cheapest decline route in the group and the floor the other two are read against.
+   * LDBC: IC1 fragment. {@code repeat(out(KNOWS)).times(3)}; {@code RepeatDeclineStrategy} veto.
    */
   @Benchmark
   public List<String> gremlinRepeatKnowsToThreeHopsDeclines(
@@ -432,7 +508,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.repeatKnowsToThreeHops(t, arm.personId(i)).toList());
   }
 
-  /** IS4's {@code coalesce} projection: declines part-way through the walk on {@code CoalesceStep}. */
+  /** LDBC: IS4 fragment. {@code coalesce(imageFile, content)}; declines on {@code CoalesceStep}. */
   @Benchmark
   public List<String> gremlinCoalesceMessageContentDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -441,7 +517,7 @@ public class LdbcGremlinTranslatorBenchmark {
         t -> GremlinTraversalShapes.coalesceMessageContent(t, arm.messageId(i)).toList());
   }
 
-  /** IS7's optional hop: declines part-way through the walk, and reserves the Phase 2 baseline. */
+  /** LDBC: IS7 fragment. {@code optional(out(KNOWS))} after the author; declines on {@code optional()}. */
   @Benchmark
   public List<String> gremlinOptionalFriendOfCreatorDeclines(
       LdbcBenchmarkState state, TranslatorArm arm) {
@@ -451,10 +527,8 @@ public class LdbcGremlinTranslatorBenchmark {
   }
 
   /**
-   * IS3 whole: edge {@code creationDate} and friend {@code firstName} via {@code select}. Declines
-   * because the {@code as("k")} label on {@code outE(KNOWS)} would bind to the edge-as-node vertex
-   * alias, so {@code select("k")} would read the target vertex rather than the friendship edge —
-   * see {@link GremlinTraversalShapes#is3FriendsWithDates}. Both arms run natively.
+   * LDBC: IS3 full attempt. Edge date plus friend name via {@code select}; declines on edge
+   * {@code as("k")}. See {@link GremlinTraversalShapes#is3FriendsWithDates}.
    */
   @Benchmark
   public List<Map<String, Object>> gremlinIs3FriendsWithDatesDeclines(

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinShapeTranslationTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcGremlinShapeTranslationTest.java
@@ -66,7 +66,8 @@ import org.junit.Test;
  *
  * <h2>Fixture</h2>
  *
- * <p>Five people, two places and two messages — the smallest graph that distinguishes the shapes:
+ * <p>Five people, two places, two messages, one forum and one organisation — the smallest graph
+ * that distinguishes the shapes:
  *
  * <ul>
  *   <li>{@code KNOWS}: Alice→Bob, Alice→Carol, Bob→Dave, Bob→Alice, Carol→Erin, and Erin→everyone
@@ -77,7 +78,8 @@ import org.junit.Test;
  *   <li>{@code IS_LOCATED_IN}: Alice→Zurich, Bob→Berlin — two cities, so an IS1 plan that ignores
  *       the join returns both.
  *   <li>A {@code Post} authored by Bob and a {@code Comment} authored by Carol replying to it, for
- *       the IS4 / IS5 / IS7 shapes.
+ *       the IS4 / IS5 / IS7 shapes. Alice likes the post (IC7). Forum {@code Wall} contains the
+ *       post and Alice moderates it (IS6). Bob works at organisation Acme in China (IC11).
  * </ul>
  *
  * <p>The flag is flipped through {@link GlobalConfiguration}, not through a session-local
@@ -102,6 +104,15 @@ public class LdbcGremlinShapeTranslationTest {
 
   /** A {@code Comment} authored by Carol, replying to {@link #POST}. */
   private static final long COMMENT = 1001;
+
+  private static final long POST_AT = 1_600_000_100_000L;
+  private static final long COMMENT_AT = 1_600_000_200_000L;
+  /** Exclusive upper bound for IC2's {@code creationDate < maxDate} filter. */
+  private static final long IC2_MAX_DATE = 1_600_000_300_000L;
+
+  private static final long FORUM = 10;
+  private static final long COMPANY = 50;
+  private static final long CHINA = 300;
 
   /**
    * {@code KNOWS.creationDate} values. Distinct and ordered so a projection of the edge property is
@@ -155,11 +166,20 @@ public class LdbcGremlinShapeTranslationTest {
       createKnows(t, ERIN, CAROL, 1_600_000_013_000L);
       createKnows(t, ERIN, DAVE, 1_600_000_014_000L);
 
-      insertMessage(t, "Post", POST, "post-1000", 1_600_000_100_000L);
-      insertMessage(t, "Comment", COMMENT, "c-1001", 1_600_000_200_000L);
+      insertMessage(t, "Post", POST, "post-1000", POST_AT);
+      insertMessage(t, "Comment", COMMENT, "c-1001", COMMENT_AT);
       createHasCreator(t, POST, BOB);
       createHasCreator(t, COMMENT, CAROL);
       createReplyOf(t, COMMENT, POST);
+
+      insertForum(t, FORUM, "Wall");
+      createContainerOf(t, FORUM, POST);
+      createHasModerator(t, FORUM, ALICE);
+      createLikes(t, ALICE, POST);
+      insertOrganisation(t, COMPANY, "Acme");
+      insertPlace(t, CHINA, "China");
+      createWorkAt(t, BOB, COMPANY);
+      createOrgLocatedIn(t, COMPANY, CHINA);
     });
 
     aliceRid = g.computeInTx(
@@ -297,6 +317,106 @@ public class LdbcGremlinShapeTranslationTest {
         "IS5: …hasLabel(Message).has(id).out(HAS_CREATOR).valueMap(id, firstName, lastName)",
         t -> GremlinTraversalShapes.is5MessageCreator(t, POST),
         List.of("{firstName=[Bob], id=[" + BOB + "], lastName=[Bobson]}"));
+  }
+
+  /**
+   * IS2 reduced — Bob's messages newest first. Only the post is his; Carol's comment must not
+   * appear. Compared in stream order because the shape keeps {@code ORDER BY creationDate DESC}.
+   */
+  @Test
+  public void is2PersonMessagesTranslatesOnAndRunsNativeOffInDateOrder() {
+    assertTranslatesInOrder(
+        "IS2 reduced: …in(HAS_CREATOR).hasLabel(Message).order().by(creationDate, desc)"
+            + ".valueMap(id, content, creationDate)",
+        t -> GremlinTraversalShapes.is2PersonMessages(t, BOB),
+        List.of(
+            "{content=[post-1000], creationDate=[date:" + POST_AT + "], id=[" + POST + "]}"));
+  }
+
+  /**
+   * IS6 reduced — the post's forum title and moderator first name. SQL climbs {@code REPLY_OF}
+   * from any Message; this shape starts at the Post and walks {@code in(CONTAINER_OF)}. Labels
+   * bind on {@code has()} like IS1, not on {@code hasLabel}.
+   */
+  @Test
+  public void is6ForumOfPostTranslatesOnAndRunsNativeOff() {
+    assertTranslates(
+        "IS6 reduced: …in(CONTAINER_OF).hasLabel(Forum).has(id, neq(-1)).as(forum)"
+            + ".out(HAS_MODERATOR).has(id, neq(-1)).as(moderator).select(forum, moderator)"
+            + ".by(title).by(firstName)",
+        t -> GremlinTraversalShapes.is6ForumOfPost(t, POST),
+        List.of("{forum=Wall, moderator=Alice}"));
+  }
+
+  /**
+   * IS7 reduced — authors of direct replies to the post. Carol replied; Alice did not, so a plan
+   * that walked {@code KNOWS} instead of {@code REPLY_OF} would return her.
+   */
+  @Test
+  public void is7RepliesWithAuthorsTranslatesOnAndRunsNativeOff() {
+    assertTranslates(
+        "IS7 reduced: …in(REPLY_OF).out(HAS_CREATOR).valueMap(id, firstName, lastName)",
+        t -> GremlinTraversalShapes.is7RepliesWithAuthors(t, POST),
+        List.of("{firstName=[Carol], id=[" + CAROL + "], lastName=[Carolson]}"));
+  }
+
+  /**
+   * IC2 reduced — Alice's friends' messages before {@link #IC2_MAX_DATE}, newest first. Carol's
+   * comment then Bob's post. Dave has no messages, so a plan that ignored {@code KNOWS} and
+   * scanned {@code Message} would still pass if it also ignored the date filter; the two-row
+   * ordered list is the discriminant.
+   */
+  @Test
+  public void ic2FriendsMessagesOrderedTranslatesOnAndRunsNativeOffInDateOrder() {
+    assertTranslatesInOrder(
+        "IC2 reduced: …out(KNOWS).in(HAS_CREATOR).has(creationDate, lt).order()"
+            + ".by(creationDate, desc).valueMap(id, content, creationDate)",
+        t -> GremlinTraversalShapes.ic2FriendsMessagesOrdered(t, ALICE, new Date(IC2_MAX_DATE)),
+        List.of(
+            "{content=[c-1001], creationDate=[date:" + COMMENT_AT + "], id=[" + COMMENT + "]}",
+            "{content=[post-1000], creationDate=[date:" + POST_AT + "], id=[" + POST + "]}"));
+  }
+
+  /**
+   * IC7 reduced — first names of people who liked Bob's messages. Alice liked the post; a plan
+   * that walked {@code KNOWS} instead of {@code LIKES} would also return Carol and Dave.
+   */
+  @Test
+  public void ic7LikersTranslatesOnAndRunsNativeOff() {
+    assertTranslates(
+        "IC7 reduced: …in(HAS_CREATOR).in(LIKES).values(firstName)",
+        t -> GremlinTraversalShapes.ic7Likers(t, BOB),
+        List.of("Alice"));
+  }
+
+  /**
+   * IC8 reduced — comments that reply to Bob's messages, newest first. Carol's comment replies to
+   * Bob's post; a plan that returned the post itself would fail the {@code hasLabel(Comment)}
+   * filter.
+   */
+  @Test
+  public void ic8RecentRepliesOrderedTranslatesOnAndRunsNativeOffInDateOrder() {
+    assertTranslatesInOrder(
+        "IC8 reduced: …in(HAS_CREATOR).in(REPLY_OF).hasLabel(Comment).order()"
+            + ".by(creationDate, desc).valueMap(id, content, creationDate)",
+        t -> GremlinTraversalShapes.ic8RecentRepliesOrdered(t, BOB),
+        List.of(
+            "{content=[c-1001], creationDate=[date:" + COMMENT_AT + "], id=[" + COMMENT + "]}"));
+  }
+
+  /**
+   * IC11 reduced — companies of Alice's friends located in China. Bob works at Acme in China;
+   * Carol does not work anywhere, so a plan that skipped {@code WORK_AT} returns nothing and a
+   * plan that skipped the country filter still has only Acme in this fixture.
+   */
+  @Test
+  public void ic11FriendsCompaniesInCountryTranslatesOnAndRunsNativeOff() {
+    assertTranslates(
+        "IC11 reduced: …out(WORK_AT).hasLabel(Organisation).has(id, neq(-1)).as(company)"
+            + ".out(IS_LOCATED_IN).has(name, China).as(country).select(company, country)"
+            + ".by(name).by(name)",
+        t -> GremlinTraversalShapes.ic11FriendsCompaniesInCountry(t, ALICE, "China"),
+        List.of("{company=Acme, country=China}"));
   }
 
   /**
@@ -736,5 +856,71 @@ public class LdbcGremlinShapeTranslationTest {
         "CREATE EDGE REPLY_OF FROM (SELECT FROM Message WHERE id = :comment)"
             + " TO (SELECT FROM Message WHERE id = :message)",
         "comment", commentId, "message", messageId).iterate();
+  }
+
+  private static void insertForum(YTDBGraphTraversalSource t, long id, String title) {
+    requireCreated(
+        "INSERT INTO Forum",
+        t.yql(
+            "INSERT INTO Forum SET id = :id, title = :title, creationDate = :cd",
+            "id", id, "title", title, "cd", POST_AT).toList());
+  }
+
+  private static void insertOrganisation(YTDBGraphTraversalSource t, long id, String name) {
+    requireCreated(
+        "INSERT INTO Organisation",
+        t.yql(
+            "INSERT INTO Organisation SET id = :id, type = :type, name = :name",
+            "id", id, "type", "company", "name", name).toList());
+  }
+
+  private static void createContainerOf(
+      YTDBGraphTraversalSource t, long forumId, long messageId) {
+    createEdge(t, "CONTAINER_OF", "Forum", forumId, "Post", messageId);
+  }
+
+  private static void createHasModerator(
+      YTDBGraphTraversalSource t, long forumId, long personId) {
+    createEdge(t, "HAS_MODERATOR", "Forum", forumId, "Person", personId);
+  }
+
+  private static void createLikes(YTDBGraphTraversalSource t, long personId, long messageId) {
+    createEdge(t, "LIKES", "Person", personId, "Message", messageId);
+  }
+
+  private static void createWorkAt(YTDBGraphTraversalSource t, long personId, long orgId) {
+    requireCreated(
+        "CREATE EDGE WORK_AT",
+        t.yql(
+            "CREATE EDGE WORK_AT FROM (SELECT FROM Person WHERE id = :from)"
+                + " TO (SELECT FROM Organisation WHERE id = :to) SET workFrom = :wf",
+            "from", personId, "to", orgId, "wf", 2008).toList());
+  }
+
+  private static void createOrgLocatedIn(
+      YTDBGraphTraversalSource t, long orgId, long placeId) {
+    createEdge(t, "IS_LOCATED_IN", "Organisation", orgId, "Place", placeId);
+  }
+
+  private static void createEdge(
+      YTDBGraphTraversalSource t,
+      String edgeLabel,
+      String fromClass,
+      long fromId,
+      String toClass,
+      long toId) {
+    requireCreated(
+        "CREATE EDGE " + edgeLabel,
+        t.yql(
+            "CREATE EDGE " + edgeLabel
+                + " FROM (SELECT FROM " + fromClass + " WHERE id = :from)"
+                + " TO (SELECT FROM " + toClass + " WHERE id = :to)",
+            "from", fromId, "to", toId).toList());
+  }
+
+  private static void requireCreated(String what, List<?> created) {
+    if (created.isEmpty()) {
+      throw new IllegalStateException(what + " produced no rows");
+    }
   }
 }

--- a/jmh-ldbc/tests/test_jmh_compare.py
+++ b/jmh-ldbc/tests/test_jmh_compare.py
@@ -40,13 +40,13 @@ def _gremlin_on_off_fixture():
     """Minimal base/head JSON with Gremlin on+off and one SQL ST row."""
     base = [
         _entry(
-            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
             100.0,
             score_error=1.0,
             params={"translatorEnabled": "true"},
         ),
         _entry(
-            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
             200.0,
             score_error=2.0,
             params={"translatorEnabled": "false"},
@@ -55,13 +55,13 @@ def _gremlin_on_off_fixture():
     ]
     head = [
         _entry(
-            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
             110.0,
             score_error=1.0,
             params={"translatorEnabled": "true"},
         ),
         _entry(
-            f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+            f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
             190.0,
             score_error=2.0,
             params={"translatorEnabled": "false"},
@@ -111,14 +111,14 @@ class TestSuiteDetection(unittest.TestCase):
         """Gremlin translator benches land in the Gremlin suite, not the raw class."""
         out = cmp.parse_jmh_results([
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 100.0,
                 params={"translatorEnabled": "true"},
             ),
         ])
-        self.assertIn(("gremlinKnowsFirstNames [on]", "Gremlin"), out)
+        self.assertIn(("gremlin_knowsFirstNames [on]", "Gremlin"), out)
         self.assertNotIn(
-            ("gremlinKnowsFirstNames [on]", "LdbcGremlinTranslatorBenchmark"),
+            ("gremlin_knowsFirstNames [on]", "LdbcGremlinTranslatorBenchmark"),
             out,
         )
 
@@ -128,51 +128,51 @@ class TestGremlinParamArms(unittest.TestCase):
         """Both translator arms must survive parse — previously the second overwrote."""
         out = cmp.parse_jmh_results([
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 100.0,
                 params={"translatorEnabled": "true"},
             ),
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 200.0,
                 params={"translatorEnabled": "false"},
             ),
         ])
         self.assertEqual(len(out), 2)
-        self.assertEqual(out[("gremlinKnowsFirstNames [on]", "Gremlin")]["score"], 100.0)
-        self.assertEqual(out[("gremlinKnowsFirstNames [off]", "Gremlin")]["score"], 200.0)
+        self.assertEqual(out[("gremlin_knowsFirstNames [on]", "Gremlin")]["score"], 100.0)
+        self.assertEqual(out[("gremlin_knowsFirstNames [off]", "Gremlin")]["score"], 200.0)
 
     def test_filter_default_keeps_on_only_and_strips_suffix(self):
         """Default arms=on drops off and strips [on] so each shape is one bare row."""
         parsed = cmp.parse_jmh_results([
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 100.0,
                 params={"translatorEnabled": "true"},
             ),
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 200.0,
                 params={"translatorEnabled": "false"},
             ),
             _entry(f"{ST_CLS}.is1_personProfile", 10.0),
         ])
         filtered = cmp.filter_gremlin_arms(parsed, "on")
-        self.assertIn(("gremlinKnowsFirstNames", "Gremlin"), filtered)
-        self.assertNotIn(("gremlinKnowsFirstNames [on]", "Gremlin"), filtered)
-        self.assertNotIn(("gremlinKnowsFirstNames [off]", "Gremlin"), filtered)
+        self.assertIn(("gremlin_knowsFirstNames", "Gremlin"), filtered)
+        self.assertNotIn(("gremlin_knowsFirstNames [on]", "Gremlin"), filtered)
+        self.assertNotIn(("gremlin_knowsFirstNames [off]", "Gremlin"), filtered)
         self.assertIn(("is1_personProfile", "SingleThread"), filtered)
 
     def test_filter_both_keeps_arm_labels(self):
         """arms=both leaves the [on]/[off] labels untouched."""
         parsed = cmp.parse_jmh_results([
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 100.0,
                 params={"translatorEnabled": "true"},
             ),
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 200.0,
                 params={"translatorEnabled": "false"},
             ),
@@ -184,12 +184,12 @@ class TestGremlinParamArms(unittest.TestCase):
         """Non-translator params stay readable as key=value in the label."""
         out = cmp.parse_jmh_results([
             _entry(
-                f"{GREMLIN_CLS}.gremlinKnowsFirstNames",
+                f"{GREMLIN_CLS}.gremlin_knowsFirstNames",
                 1.0,
                 params={"threads": "8", "mode": "thrpt"},
             ),
         ])
-        self.assertIn(("gremlinKnowsFirstNames [mode=thrpt, threads=8]", "Gremlin"), out)
+        self.assertIn(("gremlin_knowsFirstNames [mode=thrpt, threads=8]", "Gremlin"), out)
 
     def test_no_params_keeps_bare_method_name(self):
         """SQL LDBC entries without JMH params keep the plain method label."""
@@ -205,7 +205,7 @@ class TestGremlinTableInMarkdown(unittest.TestCase):
         base, head = _gremlin_on_off_fixture()
         md = _run_compare(base, head)
         self.assertIn("### Gremlin Translator Results", md)
-        self.assertIn("gremlinKnowsFirstNames", md)
+        self.assertIn("gremlin_knowsFirstNames", md)
         self.assertNotIn("[off]", md)
         self.assertNotIn("[on]", md)
         self.assertIn("production default", md)
@@ -216,8 +216,8 @@ class TestGremlinTableInMarkdown(unittest.TestCase):
         """--gremlin-arms both keeps the full A/B labels in the table."""
         base, head = _gremlin_on_off_fixture()
         md = _run_compare(base, head, extra_argv=["--gremlin-arms", "both"])
-        self.assertIn("gremlinKnowsFirstNames [on]", md)
-        self.assertIn("gremlinKnowsFirstNames [off]", md)
+        self.assertIn("gremlin_knowsFirstNames [on]", md)
+        self.assertIn("gremlin_knowsFirstNames [off]", md)
         self.assertIn("`[on]` / `[off]`", md)
 
 


### PR DESCRIPTION
#### PR title:

[no-it-tests] YTDB-1285: Gremlin benchmarks shapes improved

#### Motivation:

The Gremlin JMH class sat next to the SQL IC/IS suite without saying which shapes are complete twins, reductions, translator primitives, or declining fragments. Method names were camelCase (`gremlinKnowsFirstNames`), so `ldbc-jmh-compare`'s `queries` filter (`.*<id>_.*`) could not select Gremlin at all: `queries=gremlin` became `.*gremlin_.*` and matched nothing, and `queries=IS5` ran SQL only. A PR comment then mixed MATCH-plan rows with native-pipeline primitives under one heading.

Each shape now starts its Javadoc with `LDBC: complete | <query> reduced | none | fragment`. JMH methods are `gremlin_*`. `queries=gremlin` runs that class alone. A query id (`IS5`) still runs SQL and also any Gremlin shape that echoes it. The one complete twin reuses the SQL suffix: `gremlin_is5_messageCreator` next to `is5_messageCreator`.

#### Planned changes:

##### Current state
`LdbcGremlinTranslatorBenchmark` measured Gremlin-to-MATCH shapes on the LDBC schema. Correspondence to the twenty IC/IS SQL benches was informal. The compare workflow always wrapped `queries` as SQL method globs.

##### What changes
Seven new translating reductions (IS2, IS6, IS7, IC2, IC7, IC8, IC11) run on the same curated SQL parameters as their SQL counterparts. Existing shapes keep their behaviour; they gain an `LDBC:` label and a `gremlin_` method name. IS5 is the only complete twin. Reduced and fragment shapes keep a distinct name plus the query id (`gremlin_is1_fullProfile`), so a filtered compare of `IS1` includes those Gremlin rows. Translator primitives have no query id (`gremlin_knowsFirstNames`).

Throughput is still not comparable across SQL and Gremlin rows — different entry points. The labels are for selection and reading, not for dividing scores.

##### How
The compare workflow is unchanged: `IS1,IC2` still becomes `.*is1_.*|.*ic2_.*`. The method names now match that glob. `queries=gremlin` is the same wrapping, not a special-case token.

IC2/IC7/IC8/IC11 Gremlin benches use the curated SQL person/date/country pools, not the IS person pool.

##### Key decisions
- Prefix `gremlin_` instead of a `queries=gremlin` special case in the workflow. Same wrapping, one naming convention.
- Put the IC/IS id on reduced and fragment shapes as well as the complete twin, so a per-query compare includes the Gremlin echo. The extra Gremlin wall on `queries=IS1` is accepted.
- Add translating reductions rather than wait for full IC2/IC7/etc. (coalesce, LIMIT, optional KNOWS, FoF). Each reduction's Javadoc names the dropped clauses.

##### Out of scope
Translating the remaining LET / `repeat` / `coalesce` / `optional` queries. A Gremlin multi-thread suite. Changing `gremlin_arms`.

##### Risks & accepted trade-offs
`queries=IS1` (and any other id that has a Gremlin echo) now also runs those Gremlin methods. Empty `queries` is unchanged: SQL ST + MT + Gremlin.

##### Suggestions:
None.

##### Verification approach
`LdbcGremlinShapeTranslationTest` (26 tests) with `./mvnw -pl core,jmh-ldbc test -Dtest=LdbcGremlinShapeTranslationTest -Dsurefire.failIfNoSpecifiedTests=false` so `jmh-ldbc` uses this branch's `core`, not a stale `~/.m2` jar. `jmh-ldbc/tests/test_jmh_compare.py` covers the renamed method in the compare tables.

#### Tracks:

N/A (single-track)