### PR TITLE
YTDB-1284: Translate values(k).limit(n) via IS DEFINED

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinProjectionAssembler.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinProjectionAssembler.java
@@ -77,7 +77,10 @@ final class GremlinProjectionAssembler {
    *
    * <p>Keeping the conjunct off the main-line arm matters: {@code IS DEFINED} has no estimator in the
    * MATCH root-selection cost model (see {@link ByModulatorPresence}'s {@code @implNote}), and the
-   * main line already expresses the same drop through {@code dropOnAbsent}.
+   * main line already expresses the same drop through {@code dropOnAbsent}. A following slice
+   * promotes the conjunct on demand through {@link
+   * RecognitionContext#promotePresenceDropToPatternFilter}, so the estimator caveat applies only to
+   * that sliced surface rather than to every {@code values(k)}.
    *
    * @param contributePresenceConjunct whether the captured child still emits nothing for an element
    *     without the property once its remaining steps have run. Read only on the captured-child path;
@@ -108,6 +111,9 @@ final class GremlinProjectionAssembler {
       // dropOnAbsent + presence key so the plan step drops rows where the entity lacks the property.
       ctx.setResultShaping(
           ResultShaping.NONE.withDropOnAbsent(true).withPresencePropertyKeys(List.of(propertyKey)));
+      // After setResultShaping, which clears any previous alias. The slice recogniser promotes
+      // this alias into a pattern conjunct when a real SKIP / LIMIT arrives.
+      ctx.setPresenceDropAlias(boundary);
     } else if (contributePresenceConjunct) {
       // A captured child's shaping is swallowed, so the same drop travels as a pattern conjunct.
       ByModulatorPresence.requireProjectedProperty(ctx, boundary, propertyKey);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinStepWalker.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinStepWalker.java
@@ -682,7 +682,7 @@ final class GremlinStepWalker {
    * presence conjunct into the pattern, so its row-dropping happens before the clause exactly as
    * native does it. The unguarded projection path is the wrong one, because its drop rides
    * post-plan shaping instead; {@link RangeGlobalStepRecogniser} carries the other half of that
-   * story and the decline that closes it.
+   * story and promotes the drop into a pattern conjunct when a slice arrives.
    */
   private static boolean capturedCardinalityClause(RecognitionContext ctx) {
     return ctx.skip() != null || ctx.limit() != null || ctx.returnDistinct();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/RangeGlobalStepRecogniser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/RangeGlobalStepRecogniser.java
@@ -34,36 +34,30 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.map.CountGlobalStep;
  *
  * <h2>A slice behind a drop-on-absent projection</h2>
  *
- * The gate above closes the ordering where the slice comes first. This one closes the other, and
- * the two are the same collision seen from opposite ends: {@code g.V().limit(2).values(age)} and
- * {@code g.V().values(age).limit(2)} also compile to one statement, and it means the first.
- *
- * <p>{@code values(key)} drops rows whose entity lacks the property, and on the main line that drop
- * rides {@code dropOnAbsent} result shaping, which the plan step applies to the plan's <em>output</em>.
+ * {@code values(key)} drops rows whose entity lacks the property. On the main line that drop rides
+ * {@code dropOnAbsent} result shaping, which the plan step applies to the plan's <em>output</em>.
  * A statement-level {@code LIMIT} therefore counts rows the drop has not removed yet, where Gremlin
  * counts only survivors. Measured on five vertices with {@code age} on the one that scans last, both
  * arms enumerating identically: {@code g.V().values(age).limit(1)} returned {@code []} translated
  * against {@code [44]} native, and {@code g.V().values(age).skip(1)} returned {@code [44]} against
- * {@code []}. So this recogniser declines once {@link RecognitionContext#dropsRowsOnAbsentProperty()}
- * holds.
+ * {@code []}.
  *
- * <p>The guard reads one boolean, {@link RecognitionContext#dropsRowsOnAbsentProperty()}, which the
- * projection recogniser writes. So the decline covers exactly the orderings where the projection was
- * recognised first, and the reverse spelling {@code g.V().limit(n).values(k)} is accepted because
- * the slice reached this recogniser before any shaping existed — taking {@code n} rows and then
- * dropping is what native does in that spelling too. The boolean says nothing about the pattern's
- * conjuncts. A preceding {@code order().by(k)} writes {@code k IS DEFINED}, which would make the
- * shaping drop a no-op and the slice safe, and the guard neither reads that nor needs to: it is
- * strictly more conservative than the rule that conjunct would license, so it costs coverage and
- * never correctness. The aggregate path needs no guard at all, writing its presence conjunct into
- * the pattern rather than relying on shaping.
+ * <p>The captured-child path already has the matching alternative: a {@code key IS DEFINED} conjunct
+ * in the alias filters, evaluated inside the plan and therefore before {@code SKIP} / {@code LIMIT}.
+ * When a real slice arrives behind a main-line drop, this recogniser promotes the same conjunct
+ * through {@link RecognitionContext#promotePresenceDropToPatternFilter} rather than declining. The
+ * promotion is lazy: a {@code values(k)} with no slice keeps today's shaping-only plan, so the
+ * {@code IS DEFINED} estimator gap ({@code SQLWhereClause.estimate} falls back to
+ * {@code classCount / 2} and can pick a presence-only alias as root) applies only to sliced
+ * shapes. A no-op slice ({@code skip(0)}, {@code range(0, -1)}) never promotes.
  *
- * <p>The price is the {@code values(k).limit(n)} surface, which is a common spelling — a top-N over
- * a projected property gives up its plan and runs on the native traverser pipeline. Nothing narrower
- * was available: the drop is a post-plan operation by construction, so no ordering of the existing
- * clauses expresses it, and making the projection contribute a pattern conjunct instead would change
- * every {@code values(k)} plan's root-selection estimate. Spelling the slice before the projection
- * ({@code g.V().limit(n).values(k)}) still translates, and means something different.
+ * <p>The reverse spelling {@code g.V().limit(n).values(k)} still translates without promotion,
+ * because the slice reached this recogniser before any shaping existed — taking {@code n} rows and
+ * then dropping is what native does in that spelling too. The two spellings compile to different
+ * statements and mean different things.
+ *
+ * <p>A combinator child cannot promote: {@code SubTraversalPredicateAdapter} answers {@code false},
+ * so {@code and(values(k).limit(n))} still declines.
  *
  * <h2>A slice behind a captured {@code ORDER BY}</h2>
  *
@@ -204,15 +198,9 @@ final class RangeGlobalStepRecogniser implements StepRecogniser {
     if (normalized.noop()) {
       return Outcome.ACCEPTED;
     }
-    // A real slice behind a row-dropping projection counts the wrong rows — see the class Javadoc's
-    // "A slice behind a drop-on-absent projection". Checked after the no-op test so skip(0) and
-    // range(0, -1), which select no position, still ride through.
-    if (ctx.dropsRowsOnAbsentProperty()) {
-      return Outcome.DECLINE;
-    }
     // A real slice behind a captured ORDER BY cuts into a tie group the sort does not resolve, and
     // the two pipelines resolve it differently — see the class Javadoc's "A slice behind a captured
-    // ORDER BY". Same placement rationale as the guard above: a slice that selects no position
+    // ORDER BY". Same placement rationale as the no-op test: a slice that selects no position
     // cannot cut into anything. The decline is not free on memory either: it trades the plan's
     // bounded top-N heap for the native barrier step's full materialisation, which the same Javadoc
     // section prices along with what a narrower rule would need.
@@ -223,6 +211,12 @@ final class RangeGlobalStepRecogniser implements StepRecogniser {
     // map the terminator emits — see the class Javadoc's "A slice behind a grouping terminator".
     // Same placement rationale as the two guards above.
     if (ctx.groupBy() != null) {
+      return Outcome.DECLINE;
+    }
+    // Promotion mutates the context (writes alias filters), so it sits after every remaining
+    // decline. A no-op slice never reaches here. See the class Javadoc's "A slice behind a
+    // drop-on-absent projection".
+    if (ctx.dropsRowsOnAbsentProperty() && !ctx.promotePresenceDropToPatternFilter()) {
       return Outcome.DECLINE;
     }
     if (normalized.skip() > 0) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/RecognitionContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/RecognitionContext.java
@@ -373,12 +373,30 @@ interface RecognitionContext extends ParamSink {
 
   /**
    * Whether the shaping pinned so far drops rows whose entity lacks a projected property — the
-   * {@code dropOnAbsent} half of {@code values(key)}. {@link RangeGlobalStepRecogniser} reads it to
-   * refuse a slice behind such a projection: the plan step applies the drop to the plan's output,
-   * so a statement-level {@code SKIP} / {@code LIMIT} would count rows the drop has not removed yet
-   * while Gremlin counts only the survivors. See that recogniser for the measured divergence.
+   * {@code dropOnAbsent} half of {@code values(key)}. {@link RangeGlobalStepRecogniser} reads it
+   * when a slice arrives: a statement-level {@code SKIP} / {@code LIMIT} would count rows the
+   * post-plan drop has not removed yet, so the recogniser promotes the drop into a pattern conjunct
+   * through {@link #promotePresenceDropToPatternFilter()} rather than declining. See that
+   * recogniser for the measured divergence that made the promotion necessary.
    */
   boolean dropsRowsOnAbsentProperty();
+
+  /**
+   * Records the alias whose entity {@link #dropsRowsOnAbsentProperty()} checks. The projection that
+   * turns {@code dropOnAbsent} on writes it alongside the shaping; a later {@link #setResultShaping}
+   * clears it. {@link #promotePresenceDropToPatternFilter()} reads it.
+   */
+  void setPresenceDropAlias(@Nullable String alias);
+
+  /**
+   * Promotes a pinned {@code dropOnAbsent} into {@code key IS DEFINED} alias conjuncts so a
+   * following slice counts survivors rather than pre-drop rows. Returns {@code true} when there is
+   * nothing to promote, or when the conjuncts were written. Returns {@code false} when this context
+   * cannot express the promotion — a combinator child whose shaping is swallowed, or a drop whose
+   * alias was never recorded — in which case the caller declines. See {@link
+   * #dropsRowsOnAbsentProperty()} for why the slice needs the conjunct at all.
+   */
+  boolean promotePresenceDropToPatternFilter();
 
   /**
    * Appends one ordered list-shaping stage to the shaping pinned so far, keeping the flags and the

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/SubTraversalPredicateAdapter.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/SubTraversalPredicateAdapter.java
@@ -463,6 +463,11 @@ final class SubTraversalPredicateAdapter implements RecognitionContext {
     // context only; a combinator filter sub-walk never shapes the parent's rows.
   }
 
+  @Override
+  public void setPresenceDropAlias(@Nullable String alias) {
+    // Swallowed — see setResultShaping.
+  }
+
   /**
    * Always false, and not delegated to the parent. Since {@link #setResultShaping} is swallowed
    * this context never holds a shaping of its own, and the parent's is not the sub-walk's business:
@@ -471,6 +476,16 @@ final class SubTraversalPredicateAdapter implements RecognitionContext {
    */
   @Override
   public boolean dropsRowsOnAbsentProperty() {
+    return false;
+  }
+
+  /**
+   * Always false. See {@link RecognitionContext#promotePresenceDropToPatternFilter()} — a combinator
+   * child's shaping is swallowed, so there is nothing to promote and a slice inside the child
+   * declines.
+   */
+  @Override
+  public boolean promotePresenceDropToPatternFilter() {
     return false;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/TailGlobalStepRecogniser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/TailGlobalStepRecogniser.java
@@ -23,11 +23,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TailGlobalStep
  * so it covers the recognisers written after this one too.
  *
  * <p>The window itself does sit behind a row-dropping projection safely, which is worth naming because
- * the neighbouring {@code LIMIT} does not. {@code values(key)} drops absent-property rows in the
- * boundary's own payload projection, and the window runs after that projection, so
- * {@code values(k).tail(2)} takes the last two <em>survivors</em> — which is what Gremlin does with that
- * spelling. A statement-level {@code LIMIT} counts rows the drop has not removed yet, which is the
- * divergence {@code RangeGlobalStepRecogniser} declines on {@code dropsRowsOnAbsentProperty}.
+ * the neighbouring {@code LIMIT} needed a promotion to do the same. {@code values(key)} drops
+ * absent-property rows in the boundary's own payload projection, and the window runs after that
+ * projection, so {@code values(k).tail(2)} takes the last two <em>survivors</em> — which is what
+ * Gremlin does with that spelling. A statement-level {@code LIMIT} would count rows the drop has not
+ * removed yet; {@code RangeGlobalStepRecogniser} therefore promotes the drop into a pattern conjunct
+ * before capturing the slice.
  *
  * <h2>Post-union, the window is refused because it reads positions</h2>
  *

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/WalkerContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/WalkerContext.java
@@ -141,6 +141,14 @@ final class WalkerContext implements RecognitionContext {
   ResultShaping shaping = ResultShaping.NONE;
 
   /**
+   * Alias whose entity a pinned {@code dropOnAbsent} checks. Set beside the shaping write that
+   * turns the flag on; cleared by every {@link #setResultShaping} so a later replace cannot promote
+   * against a stale alias. {@link UnionStepRecogniser} copies agreed child shaping without
+   * re-declaring the alias, so a post-union slice cannot promote and stays declined.
+   */
+  @Nullable String presenceDropAlias;
+
+  /**
    * Field-access expression from the immediately preceding single-key property extraction, consumed
    * by aggregate recognisers ({@code values("age").mean()}).
    */
@@ -638,11 +646,36 @@ final class WalkerContext implements RecognitionContext {
   @Override
   public void setResultShaping(@Nonnull ResultShaping shaping) {
     this.shaping = shaping;
+    // A wholesale replace drops any alias a previous drop-on-absent write recorded. The writer that
+    // turns dropOnAbsent back on has to re-declare it; UnionStepRecogniser's agreed-shaping path
+    // does not, so a post-union slice cannot promote and stays declined.
+    this.presenceDropAlias = null;
+  }
+
+  @Override
+  public void setPresenceDropAlias(@Nullable String alias) {
+    this.presenceDropAlias = alias;
   }
 
   @Override
   public boolean dropsRowsOnAbsentProperty() {
     return shaping.dropOnAbsent();
+  }
+
+  @Override
+  public boolean promotePresenceDropToPatternFilter() {
+    if (!shaping.dropOnAbsent()) {
+      return true;
+    }
+    if (presenceDropAlias == null) {
+      return false;
+    }
+    for (var key : shaping.presencePropertyKeys()) {
+      ByModulatorPresence.requireProjectedProperty(this, presenceDropAlias, key);
+    }
+    // dropOnAbsent stays on: after the conjunct no row lacking the key survives, so the shaping
+    // drop is redundant, but it cannot remove a row the conjunct left.
+    return true;
   }
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinStepWalkerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinStepWalkerTest.java
@@ -1326,17 +1326,18 @@ public class GremlinStepWalkerTest extends GraphBaseTest {
   // ---------------------------------------------------------------------------
 
   /**
-   * The mirror of the slice gate: a slice behind a {@code values(k)} declines, because the
-   * projection's row-dropping rides post-plan shaping and a statement-level {@code LIMIT} would
-   * count rows the drop has not removed yet.
+   * A slice behind {@code values(k)} promotes the absence drop into a pattern conjunct, so the
+   * walk survives and the statement-level {@code LIMIT} counts survivors.
    */
   @Test
-  public void walk_valuesThenSlice_declines() {
+  public void walk_valuesThenSlice_translates() {
     var admin = graph.traversal().V().values("age").limit(1).asAdmin();
 
     var result = GremlinStepWalker.production().walk(admin);
 
-    assertThat(result).isNull();
+    assertThat(result).isNotNull();
+    assertThat(result.inputs().limit()).isNotNull();
+    assertThat(result.outputType()).isEqualTo(BoundaryOutputType.SINGLE_VALUE);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/OrderRangeStepRecogniserTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/OrderRangeStepRecogniserTest.java
@@ -589,30 +589,42 @@ public class OrderRangeStepRecogniserTest extends GraphBaseTest {
   }
 
   /**
-   * The mirror ordering: a slice <em>behind</em> a row-dropping projection. {@code values(age)}
-   * drops property-less rows through post-plan shaping, so a statement-level {@code LIMIT 1} counted
-   * a row the drop then removed and returned nothing, where native drops first and returns the one
-   * age. Both arms enumerate rows in the same order, so this is not order luck — with {@code age}
-   * on the vertex that scans last, the translated arm's {@code LIMIT 1} always lands on a
-   * property-less row.
+   * A slice behind {@code values(age)} promotes the absence drop into a pattern conjunct, so
+   * {@code LIMIT} counts survivors. On this fixture only the last-scanned vertex carries {@code age},
+   * so both arms return that one value. The reverse spelling {@code limit(1).values(age)} still
+   * translates and still means something else: it takes one row then drops, and on this fixture
+   * that row has no {@code age}.
    */
   @Test
-  public void valuesThenLimit_declinesAndReturnsNativeRows() {
+  public void valuesThenLimit_translatesAndCountsSurvivors() {
     seedAgeOnLastScannedVertex();
-    assertClauseThenStepDeclines(
+    assertTranslatesAndMatchesNativeValues(
         "g.V().values(age).limit(1)",
-        () -> graph.traversal().V().values("age").limit(1),
+        () -> graph.traversal().V().values("age").limit(1));
+    support.assertEquivalent(
+        "g.V().limit(1).values(age) — reverse spelling, drop after the slice",
+        Recognition.RECOGNIZED,
+        Cardinality.MAY_BE_EMPTY,
+        TranslatorEquivalenceSupport::sortedStrings,
         () -> graph.traversal().V().limit(1).values("age"));
   }
 
-  /** The skip half of the same defect, and it errs in the opposite direction: the translated arm
-   *  kept the one age where native, having dropped first, has nothing left to skip past. */
+  /**
+   * The skip half of the same promotion. Native drops first and has nothing left to skip, so both
+   * arms return empty. The reverse spelling {@code skip(1).values(age)} keeps the aged vertex (it
+   * scans last) and is the non-empty control that the two spellings still differ.
+   */
   @Test
-  public void valuesThenSkip_declinesAndReturnsNativeRows() {
+  public void valuesThenSkip_translatesAndCountsSurvivors() {
     seedAgeOnLastScannedVertex();
-    assertClauseThenStepDeclines(
+    support.assertEquivalent(
         "g.V().values(age).skip(1)",
-        () -> graph.traversal().V().values("age").skip(1),
+        Recognition.RECOGNIZED,
+        Cardinality.MAY_BE_EMPTY,
+        TranslatorEquivalenceSupport::sortedStrings,
+        () -> graph.traversal().V().values("age").skip(1));
+    assertTranslatesAndMatchesNativeValues(
+        "g.V().skip(1).values(age) — reverse spelling, drop after the skip",
         () -> graph.traversal().V().skip(1).values("age"));
   }
 
@@ -670,11 +682,9 @@ public class OrderRangeStepRecogniserTest extends GraphBaseTest {
    * not the other way round — a change that re-admitted any of these three shapes would fail on the
    * boundary count first, which is the signal a row comparison cannot give.
    *
-   * <p>The decline of the first two is over-determined: the slice sits behind a captured
-   * {@code ORDER BY} and behind a row-dropping projection, and either gate alone refuses it. So the
-   * control removes the slice rather than the sort — {@code values(name).order()} translates on this
-   * same fixture, which is what proves the fixture can engage a boundary step at all and keeps the
-   * three declines attributable to the slice.
+   * <p>The decline of the first two is keyed on the captured {@code ORDER BY}: after the drop-on-absent
+   * promotion a slice behind {@code values(k)} would otherwise translate, so stripping the slice
+   * (rather than the sort) is still the control that proves the fixture can engage a boundary step.
    */
   @Test
   public void sortedSliceOverAProjection_declines_withATranslatingControl() {
@@ -850,9 +860,9 @@ public class OrderRangeStepRecogniserTest extends GraphBaseTest {
   /**
    * Five vertices, then {@code age} put on whichever one scans <em>last</em>, read back at seed time
    * rather than assumed. Scan order is not stable across JVM forks, so the fixture discovers it
-   * instead of predicting it; what the cases need is only that the aged vertex is not among the
-   * first rows a slice would take. Native drops the four property-less rows before slicing and so
-   * always sees exactly one value; the translated arm slices first and lands on a property-less row.
+   * instead of predicting it. Native drops the four property-less rows before slicing and so
+   * always sees exactly one value; a translation that sliced first would land on a property-less
+   * row. The promotion this suite now pins keeps the two arms in agreement.
    */
   private void seedAgeOnLastScannedVertex() {
     for (var i = 0; i < 5; i++) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/ProjectionEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/ProjectionEquivalenceTest.java
@@ -76,6 +76,62 @@ public class ProjectionEquivalenceTest extends GraphBaseTest {
         () -> graph.traversal().V().values("foo"));
   }
 
+  /**
+   * A slice behind {@code values(age)} promotes the absence drop into a pattern conjunct, so
+   * {@code LIMIT} / {@code SKIP} / {@code range} count survivors. Only the last-scanned vertex
+   * carries {@code age=44}: {@code limit(1)} keeps it, {@code skip(1)} and {@code range(1, 3)}
+   * skip it and return empty. A leading {@code has(name, …)} still translates. {@code skip(0)}
+   * is the no-op control that never promotes.
+   */
+  @Test
+  public void valuesThenSlice_translatesAndCountsSurvivors() {
+    seedAgeOnLastScannedVertex();
+
+    assertEquivalent(
+        "g.V().values(age).limit(1)",
+        Recognition.RECOGNIZED,
+        () -> graph.traversal().V().values("age").limit(1));
+    assertEquivalent(
+        "g.V().values(age).skip(1)",
+        Recognition.RECOGNIZED,
+        Cardinality.MAY_BE_EMPTY,
+        () -> graph.traversal().V().values("age").skip(1));
+    assertEquivalent(
+        "g.V().values(age).range(1, 3)",
+        Recognition.RECOGNIZED,
+        Cardinality.MAY_BE_EMPTY,
+        () -> graph.traversal().V().values("age").range(1, 3));
+    assertEquivalent(
+        "g.V().values(age).skip(0)",
+        Recognition.RECOGNIZED,
+        () -> graph.traversal().V().values("age").skip(0));
+
+    withTranslatorOff(
+        () -> {
+          assertThat(graph.traversal().V().values("age").limit(1).toList())
+              .as("native drops the four ageless rows first, so limit(1) keeps the one age")
+              .containsExactly(44);
+          assertThat(graph.traversal().V().values("age").skip(1).toList())
+              .as("native has nothing left to skip past")
+              .isEmpty();
+        });
+  }
+
+  /**
+   * A leading filter does not block the promotion: {@code has(name, Person4)} narrows the scan to
+   * one vertex, and if that vertex is the aged one the slice still translates over the survivor.
+   */
+  @Test
+  public void hasThenValuesThenLimit_translates() {
+    seedAgeOnLastScannedVertex();
+    var lastName = lastScannedVertexName();
+
+    assertEquivalent(
+        "g.V().has(name, " + lastName + ").values(age).limit(1)",
+        Recognition.RECOGNIZED,
+        () -> graph.traversal().V().has("name", lastName).values("age").limit(1));
+  }
+
   // ---------------------------------------------------------------------------
   // properties(key): the element form declines where the value would be read.
   // AdjacentToIncidentStrategy rewrites a written values(key) into the element
@@ -1747,6 +1803,39 @@ public class ProjectionEquivalenceTest extends GraphBaseTest {
     graph.addVertex(T.label, "Person", "name", "Bob");
     graph.addVertex(T.label, "Person", "age", 44, "nick", "c");
     graph.tx().commit();
+  }
+
+  /**
+   * Five vertices, then {@code age=44} put on whichever one scans last, read back at seed time
+   * rather than assumed. Scan order is not stable across JVM forks, so the fixture discovers it;
+   * what the slice cases need is only that the aged vertex is not among the first rows a slice
+   * would take.
+   */
+  private void seedAgeOnLastScannedVertex() {
+    for (var i = 0; i < 5; i++) {
+      graph.addVertex(T.label, "Person", "name", "Person" + i);
+    }
+    graph.tx().commit();
+
+    withTranslatorOff(
+        () -> {
+          var scanned = graph.traversal().V().toList();
+          assertThat(scanned).as("fixture must seed five vertices").hasSize(5);
+          ((Vertex) scanned.get(scanned.size() - 1)).property("age", 44);
+          graph.tx().commit();
+        });
+  }
+
+  /** The {@code name} of the vertex that currently scans last — the one {@link
+   *  #seedAgeOnLastScannedVertex} ages. */
+  private String lastScannedVertexName() {
+    var holder = new String[1];
+    withTranslatorOff(
+        () -> {
+          var scanned = graph.traversal().V().toList();
+          holder[0] = ((Vertex) scanned.get(scanned.size() - 1)).value("name");
+        });
+    return holder[0];
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/SubTraversalPredicateAdapterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/SubTraversalPredicateAdapterTest.java
@@ -516,6 +516,24 @@ public class SubTraversalPredicateAdapterTest {
   }
 
   /**
+   * A combinator child cannot promote a drop-on-absent into a pattern conjunct. The parent's
+   * {@code true} (nothing to promote, no drop pinned) is the discriminating half: Mockito would
+   * answer {@code false} for an unstubbed parent and make both arms agree for the wrong reason.
+   */
+  @Test
+  public void promotePresenceDrop_falseOnSubWalk_trueOnAParentWithNothingToPromote() {
+    var parent = new WalkerContext(true, false);
+    var adapter = new SubTraversalPredicateAdapter(parent, Map.of());
+
+    assertThat(parent.promotePresenceDropToPatternFilter())
+        .as("a top-level context with no drop has nothing to promote")
+        .isTrue();
+    assertThat(adapter.promotePresenceDropToPatternFilter())
+        .as("a sub-walk declines instead of promoting, and never delegates the parent's true")
+        .isFalse();
+  }
+
+  /**
    * The gate-side query answers empty on a sub-walk without delegating a parent that does carry a
    * stage — the discriminating half being the parent's non-empty answer, which a bare
    * {@code isEmpty()} on a fresh parent could not tell from a delegated one. The walker reads this

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/WalkerContextResultShapingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/WalkerContextResultShapingTest.java
@@ -174,6 +174,56 @@ public class WalkerContextResultShapingTest {
   }
 
   /**
+   * Promoting a pinned drop writes {@code key IS DEFINED} on the recorded alias and leaves
+   * {@code dropOnAbsent} on as a fail-safe. Without an alias the same drop cannot promote — the
+   * union path copies shaping without re-declaring the alias.
+   */
+  @Test
+  public void promotePresenceDrop_writesConjunctOrDeclinesWithoutAlias() {
+    var withAlias = new WalkerContext(true, false);
+    withAlias.setResultShaping(
+        ResultShaping.NONE.withDropOnAbsent(true).withPresencePropertyKeys(List.of("age")));
+    withAlias.setPresenceDropAlias("v");
+
+    assertThat(withAlias.promotePresenceDropToPatternFilter()).isTrue();
+    assertThat(withAlias.aliasFilters)
+        .as("the conjunct lands on the recorded alias")
+        .containsKey("v");
+    assertThat(withAlias.aliasFilters.get("v").toString())
+        .as("the conjunct is key IS DEFINED, evaluated inside the plan")
+        .contains("age")
+        .containsIgnoringCase("defined");
+    assertThat(withAlias.shaping().dropOnAbsent())
+        .as("the shaping drop stays on as a fail-safe")
+        .isTrue();
+
+    var withoutAlias = new WalkerContext(true, false);
+    withoutAlias.setResultShaping(
+        ResultShaping.NONE.withDropOnAbsent(true).withPresencePropertyKeys(List.of("age")));
+    assertThat(withoutAlias.promotePresenceDropToPatternFilter())
+        .as("a drop whose alias was never recorded cannot promote")
+        .isFalse();
+  }
+
+  /**
+   * {@code setResultShaping} clears the recorded alias, so a later copy of a drop-on-absent
+   * shaping (the union agreed-shaping write) cannot promote against a stale alias.
+   */
+  @Test
+  public void setResultShaping_clearsPresenceDropAlias() {
+    var ctx = new WalkerContext(true, false);
+    ctx.setResultShaping(
+        ResultShaping.NONE.withDropOnAbsent(true).withPresencePropertyKeys(List.of("age")));
+    ctx.setPresenceDropAlias("v");
+    ctx.setResultShaping(
+        ResultShaping.NONE.withDropOnAbsent(true).withPresencePropertyKeys(List.of("age")));
+
+    assertThat(ctx.promotePresenceDropToPatternFilter())
+        .as("a replace drops the alias, so a copied drop cannot promote")
+        .isFalse();
+  }
+
+  /**
    * A pass-through stage that carries a readable identity. Two ops written as identical lambdas would
    * still be distinct instances, so the order assertion would hold, but neither the source nor an
    * {@code AssertionError} would show a reader which op is which — a failure would name two synthetic


### PR DESCRIPTION
#### PR Title:

YTDB-1284: Translate values(k).limit(n) via IS DEFINED

#### Motivation:

`values(k)` drops entities that lack the property. On the main line that drop rides `dropOnAbsent` result shaping, applied to the plan's output. A statement-level `LIMIT` / `SKIP` therefore counted rows the drop had not removed yet, where Gremlin counts only survivors. On five vertices with `age` on the one that scans last, `g.V().values(age).limit(1)` returned `[]` translated against `[44]` native, so `RangeGlobalStepRecogniser` declined the whole shape.

The captured-child path already had the matching alternative: a `k IS DEFINED` conjunct in the alias filters, evaluated inside the plan and therefore before `SKIP` / `LIMIT`. When a real slice arrives behind a main-line drop, the recogniser now promotes that same conjunct instead of declining. Unsliced `values(k)` keeps today's shaping-only plan, so the `IS DEFINED` estimator gap (`SQLWhereClause.estimate` falls back to `classCount / 2` and can pick a presence-only alias as root) applies only to sliced shapes.

#### Planned changes:

##### Current state
`g.V().values(age).limit(1)` declined. `g.V().limit(n).values(k)` already translated: the slice runs first and then the drop, which is also what native does in that spelling. Combinator children (`and(values(k).limit(n))`) cannot promote.

##### What changes
`g.V().values(k).limit(n)` / `skip(n)` / `range(low, high)` translate. `LIMIT` counts survivors. A no-op slice (`skip(0)`, `range(0, -1)`) never promotes. `g.V().limit(n).values(k)` is unchanged. `and(values(k).limit(n))` still declines.

##### How
`RecognitionContext.promotePresenceDropToPatternFilter` writes the pending presence conjunct into the alias filters when the range recogniser sees a real slice. `SubTraversalPredicateAdapter` answers false, so a combinator child cannot promote. `TailGlobalStepRecogniser` follows the same promotion path as `RangeGlobalStepRecogniser`.

##### Key decisions
- Promote lazily on slice arrival rather than putting `IS DEFINED` on every `values(k)` plan. The estimator gap would otherwise change root selection for unsliced walks.
- Do not promote combinator children. The sub-walk has no alias to attach the conjunct to.

##### Out of scope
Slices behind a captured `ORDER BY` (`gremlin-ordered-limit-translation`). Changing `SQLWhereClause.estimate` for `IS DEFINED`. Making `and(values(k).limit(n))` translate.

##### Risks & accepted trade-offs
Overlaps `gremlin-ordered-limit-translation` on `RangeGlobalStepRecogniser` / `WalkerContext` / `RecognitionContext`. Merge one, then rebase the other. Sliced `values(k)` plans now pay the `IS DEFINED` estimator; that is the cost of counting survivors correctly.

##### Suggestions:
None.

##### Verification approach
`ProjectionEquivalenceTest`: `values` then `limit` / `skip` / `range` match native survivor counts; `has` then `values` then `limit` translates. `WalkerContextResultShapingTest` and `SubTraversalPredicateAdapterTest` pin promotion (parent writes a conjunct; sub-walk refuses). `OrderRangeStepRecogniserTest` / `GremlinStepWalkerTest` updated for the shapes that now translate.

#### Tracks:

N/A (single-track)