### PR TITLE
YTDB-1288: Plan Gremlin MATCH with bound input parameters

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategy.java
@@ -529,8 +529,10 @@ public final class GremlinToMatchStrategy
   /**
    * Production plan builder: routes the translated {@link MatchPlanInputs} through the additive
    * {@link MatchExecutionPlanner#MatchExecutionPlanner(MatchPlanInputs) constructor} and builds
-   * the plan eagerly. Cache-eligible shapes get/put through {@link GremlinPlanCache}; RID-bearing
-   * shapes always build uncached.
+   * the plan eagerly, with the walk's positional parameters installed on the planning context so
+   * root selection and IndexOrdered cost estimates see bound {@code ?} values (mirrors
+   * {@code SQLMatchStatement}). Cache-eligible shapes get/put through {@link GremlinPlanCache};
+   * RID-bearing shapes always build uncached.
    *
    * <p>Package-private rather than private so a test can wrap it in a fixture {@link
    * MatchPlanBuilder} that parks between union children: the concurrent-invalidation guard below is
@@ -544,7 +546,8 @@ public final class GremlinToMatchStrategy
     assert !translation.isMultiPlan()
         : "single-plan buildPlan helper cannot build a multi-plan translation";
     if (!translation.cacheEligible()) {
-      return buildPlanUncached(session, requireInputs(translation));
+      return buildPlanUncached(
+          session, requireInputs(translation), translation.inputParameters());
     }
     var inputs = requireInputs(translation);
     var fingerprint = GremlinPlanFingerprint.fingerprint(inputs);
@@ -552,7 +555,7 @@ public final class GremlinToMatchStrategy
     if (cached != null) {
       return cached;
     }
-    var plan = buildPlanUncached(session, inputs);
+    var plan = buildPlanUncached(session, inputs, translation.inputParameters());
     // Cache only if no metadata invalidation landed after planningStart (captured before the walk).
     // A concurrent DDL that fires between the schema read and this put would otherwise leave a plan
     // built against the pre-change schema in the shared per-database cache, served to every later
@@ -620,9 +623,23 @@ public final class GremlinToMatchStrategy
     }
   }
 
+  /**
+   * Builds a MATCH plan with the walk's positional parameters installed on the planning context —
+   * the same order {@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement}
+   * uses. Root selection and IndexOrdered cost estimates call {@code WHERE.estimate} during
+   * planning; without bound {@code ?} values a UNIQUE {@code id = ?} collapses to
+   * {@code classCount / 2} and a smaller mid-walk alias (e.g. Forum behind {@code IS DEFINED})
+   * can win the root and full-scan. Parameters are also re-installed at execute time on the
+   * boundary step; planning needs them first so the cached plan shape is the selective one.
+   */
   private static InternalExecutionPlan buildPlanUncached(
-      DatabaseSessionEmbedded session, MatchPlanInputs inputs) {
+      DatabaseSessionEmbedded session,
+      MatchPlanInputs inputs,
+      Map<Object, Object> inputParameters) {
     var ctx = new BasicCommandContext(session);
+    if (!inputParameters.isEmpty()) {
+      ctx.setInputParameters(inputParameters);
+    }
     return new MatchExecutionPlanner(inputs)
         .createExecutionPlan(ctx, /* enableProfiling */ false, /* useCache */ false);
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/translator/strategy/GremlinToMatchStrategyTest.java
@@ -19,6 +19,8 @@ import com.jetbrains.youtrackdb.internal.core.gremlin.translator.step.PostConcat
 import com.jetbrains.youtrackdb.internal.core.gremlin.translator.step.ResultShaping;
 import com.jetbrains.youtrackdb.internal.core.gremlin.translator.step.YTDBMatchPlanStep;
 import com.jetbrains.youtrackdb.internal.core.gremlin.traversal.step.sideeffect.YTDBGraphStep;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass.INDEX_TYPE;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.match.MatchPlanInputs;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.match.builder.MatchPatternBuilder;
@@ -1164,6 +1166,72 @@ public class GremlinToMatchStrategyTest extends GraphBaseTest {
         .as("a duplicate-id g.V(ids) must decline to native, leaving the step list verbatim")
         .isEqualTo(stepsBefore);
     assertThat(admin.getSteps()).noneMatch(GremlinToMatchStrategyTest::isBoundary);
+  }
+
+  /**
+   * Planning must see bound {@code ?} values (like SQLMatchStatement). Without them a UNIQUE
+   * {@code id = ?} estimates {@code classCount / 2}; a smaller mid-walk class carrying
+   * {@code IS DEFINED} from {@code select().by()} can win the root and full-scan — the IS6/IC11
+   * catastrophe. Fixture: many Forums, one Post with UNIQUE id; assert the plan roots at the
+   * Post origin, not at Forum.
+   */
+  @Test
+  public void uniqueIdParamAtPlanTime_rootsAtStartNotSmallerMidWalkAlias() {
+    var post = session.createVertexClass("Post");
+    post.createProperty("id", PropertyType.LONG).createIndex(INDEX_TYPE.UNIQUE);
+    session.createVertexClass("Forum");
+    session.createEdgeClass("CONTAINER_OF");
+
+    session.begin();
+    for (var i = 0; i < 40; i++) {
+      session.execute("CREATE VERTEX Forum SET title = 'f" + i + "'").close();
+    }
+    session.execute("CREATE VERTEX Post SET id = 1").close();
+    session.execute(
+        "CREATE EDGE CONTAINER_OF FROM (SELECT FROM Forum WHERE title = 'f0') "
+            + "TO (SELECT FROM Post WHERE id = 1)")
+        .close();
+    session.commit();
+
+    var admin =
+        graph.traversal()
+            .V()
+            .hasLabel("Post")
+            .has("id", 1L)
+            .in("CONTAINER_OF")
+            .hasLabel("Forum")
+            .as("forum")
+            .select("forum")
+            .by("title")
+            .asAdmin();
+    admin.applyStrategies();
+    assertThat(admin.getSteps())
+        .as("shape must translate")
+        .anyMatch(GremlinToMatchStrategyTest::isBoundary);
+
+    var boundary =
+        admin.getSteps().stream()
+            .filter(YTDBMatchPlanStep.class::isInstance)
+            .map(s -> (YTDBMatchPlanStep<?, ?>) s)
+            .findFirst()
+            .orElseThrow();
+    var planText = boundary.getPlan().prettyPrint(0, 2);
+    var rootAlias = planRootAliasFromPretty(planText);
+    assertThat(rootAlias)
+        .as(
+            "UNIQUE id=? must win root over a smaller Forum class; plan was:\n" + planText)
+        .isEqualTo("$g2m_v0");
+  }
+
+  /** Alias after the first {@code + SET} line in a MATCH plan pretty-print. */
+  private static String planRootAliasFromPretty(String planText) {
+    var lines = planText.lines().toList();
+    for (var i = 0; i < lines.size() - 1; i++) {
+      if ("+ SET".equals(lines.get(i).strip())) {
+        return lines.get(i + 1).strip();
+      }
+    }
+    throw new AssertionError("plan names no root alias on a SET line:\n" + planText);
   }
 
   /**


### PR DESCRIPTION
##### PR Title:

YTDB-1288: Plan Gremlin MATCH with bound input parameters

#### Motivation:

Gremlin MATCH plans for shapes like LDBC IS6/IC11 choose the wrong root today: walk parameters are installed only at execute time, so plan-time cost estimates treat UNIQUE `id = ?` as `classCount / 2`. A smaller mid-walk alias (Forum/Organisation behind `IS DEFINED` from `select().by()`) wins root selection and the plan full-scans that class instead of starting at the selective id lookup. SQL already binds parameters before `MatchExecutionPlanner.createExecutionPlan`; Gremlin did not.

#### Planned changes:

##### Current state
Gremlin-to-MATCH builds the execution plan with an empty input-parameter map. Root selection and IndexOrdered estimates therefore understate UNIQUE start filters on already-translating queries (IS6, IC11, and any similar `has(id, ?)` + mid-walk projection).

##### What changes
Planning installs the walk's positional parameters on the command context before creating the plan (same order as SQL MATCH). Cached plan fingerprints stay structural; the first fill then stores a plan rooted at the selective start.

##### How
Single- and multi-plan build paths pass the translation's input parameters into the uncached plan builder and call `setInputParameters` before `createExecutionPlan`. Execute-time re-bind on the boundary step is unchanged.

##### Out of scope
IndexOrdered `FILTERED_BOUND` for multi-hop ORDER BY+LIMIT (IC2 after LIMIT restore), and LDBC shape `neq(-1)` cleanup — those stay on the ordered-limit branch.

##### Suggestions:
None.

#### Tracks:
N/A (single-track)

#### Test plan
- [x] Unit: `uniqueIdParamAtPlanTime_rootsAtStartNotSmallerMidWalkAlias` (many Forums, UNIQUE Post id → plan roots at Post origin)
- [x] CI unit / IT on this PR